### PR TITLE
add workaround to fix webcal creation under Nextcloud9

### DIFF
--- a/controller/viewcontroller.php
+++ b/controller/viewcontroller.php
@@ -65,10 +65,10 @@ class ViewController extends Controller {
 	 */
 	public function index() {
 		$runningOn = $this->config->getSystemValue('version');
-		$runningOnServer91OrLater = version_compare($runningOn, '9.1', '>=');
+		$runningOnNextcloud10OrLater = version_compare($runningOn, '9.1', '>=');
 
-		$supportsClass = $runningOnServer91OrLater;
-		$assetPipelineBroken = !$runningOnServer91OrLater;
+		$supportsClass = $runningOnNextcloud10OrLater;
+		$assetPipelineBroken = !$runningOnNextcloud10OrLater;
 
 		$isAssetPipelineEnabled = $this->config->getSystemValue('asset-pipeline.enabled', false);
 		if ($isAssetPipelineEnabled && $assetPipelineBroken) {
@@ -84,6 +84,8 @@ class ViewController extends Controller {
 		$skipPopover = $this->config->getUserValue($userId, $this->appName, 'skipPopover', 'no');
 		$weekNumbers = $this->config->getUserValue($userId, $this->appName, 'showWeekNr', 'no');
 		$defaultColor = $this->config->getAppValue('theming', 'color', '#0082C9');
+
+		$webCalWorkaround = $runningOnNextcloud10OrLater ? 'no' : 'yes';
 		
 		return new TemplateResponse('calendar', 'main', [
 			'appVersion' => $appVersion,
@@ -93,6 +95,7 @@ class ViewController extends Controller {
 			'weekNumbers' => $weekNumbers,
 			'supportsClass' => $supportsClass,
 			'defaultColor' => $defaultColor,
+			'webCalWorkaround' => $webCalWorkaround,
 		]);
 	}
 

--- a/templates/part.fullcalendar.php
+++ b/templates/part.fullcalendar.php
@@ -30,6 +30,7 @@
 	data-emailAddress="<?php p($_['emailAddress']); ?>"
 	data-skipPopover="<?php p($_['skipPopover']); ?>"
 	data-weekNumbers="<?php p($_['weekNumbers']); ?>"
+	data-webCalWorkaround="<?php p($_['webCalWorkaround']); ?>"
 	fc
 	id="fullcalendar">
 </div>

--- a/tests/unit/controller/viewcontrollerTest.php
+++ b/tests/unit/controller/viewcontrollerTest.php
@@ -86,7 +86,7 @@ class ViewControllerTest extends \PHPUnit_Framework_TestCase {
 	/**
 	 * @dataProvider indexDataProvider
 	 */
-	public function testIndex($isAssetPipelineEnabled, $showAssetPipelineError, $serverVersion, $expectsSupportsClass) {
+	public function testIndex($isAssetPipelineEnabled, $showAssetPipelineError, $serverVersion, $expectsSupportsClass, $expectsWebcalWorkaround) {
 		$this->config->expects($this->at(0))
 			->method('getSystemValue')
 			->with('version')
@@ -152,6 +152,7 @@ class ViewControllerTest extends \PHPUnit_Framework_TestCase {
 				'weekNumbers' => 'someShowWeekNrValue',
 				'supportsClass' => $expectsSupportsClass,
 				'defaultColor' => '#ff00ff',
+				'webCalWorkaround' => $expectsWebcalWorkaround
 			], $actual->getParams());
 			$this->assertEquals('main', $actual->getTemplateName());
 		}
@@ -160,10 +161,10 @@ class ViewControllerTest extends \PHPUnit_Framework_TestCase {
 
 	public function indexDataProvider() {
 		return [
-			[true, true, '9.0.5.2', false],
-			[true, false, '9.1.0.0', true],
-			[false, false, '9.0.5.2', false],
-			[false, false, '9.1.0.0', true]
+			[true, true, '9.0.5.2', false, 'yes'],
+			[true, false, '9.1.0.0', true, 'no'],
+			[false, false, '9.0.5.2', false, 'yes'],
+			[false, false, '9.1.0.0', true, 'no']
 		];
 	}
 


### PR DESCRIPTION
Nextcloud9 has a bug, that it doesn't save color, enabled and displayname when sending a MKCOL for a subscription.
This patch mitigates the issue by sending an additional update request when running on Nextcloud 9.