### PR TITLE
Fix global tz

### DIFF
--- a/js/app/models/simpleeventmodel.js
+++ b/js/app/models/simpleeventmodel.js
@@ -495,10 +495,33 @@ app.factory('SimpleEvent', function() {
 				};
 			}
 
-			var start = ICAL.Time.fromJSDate(newSimpleData.dtstart.value.toDate(), false);
-			start.isDate = newSimpleData.allDay;
-			var end = ICAL.Time.fromJSDate(newSimpleData.dtend.value.toDate(), false);
-			end.isDate = newSimpleData.allDay;
+			var startTz = newSimpleData.dtstart.parameters.zone === "floating" ? ICAL.Timezone.localTimezone : ICAL.TimezoneService.get(newSimpleData.dtstart.parameters.zone);
+ 			var start = ICAL.Time.fromData(
+ 				{
+						year: newSimpleData.dtstart.value.year(), 
+						month: newSimpleData.dtstart.value.month() + 1, 
+						day: newSimpleData.dtstart.value.date(), 
+						hour: newSimpleData.dtstart.value.hour(), 
+						minute: newSimpleData.dtstart.value.minute(), 
+						second: newSimpleData.dtstart.value.second(),
+ 					isDate: newSimpleData.allDay
+ 				},
+ 				startTz
+ 			);
+ 
+ 			var endTz = newSimpleData.dtend.parameters.zone === "floating" ? ICAL.Timezone.localTimezone : ICAL.TimezoneService.get(newSimpleData.dtend.parameters.zone);
+ 			var end = ICAL.Time.fromData(
+ 				{
+						year: newSimpleData.dtend.value.year(), 
+						month: newSimpleData.dtend.value.month() + 1, 
+						day: newSimpleData.dtend.value.date(), 
+						hour: newSimpleData.dtend.value.hour(), 
+						minute: newSimpleData.dtend.value.minute(), 
+						second: newSimpleData.dtend.value.second(),
+ 					isDate: newSimpleData.allDay
+ 				},
+ 				endTz
+ 			);
 
 			var availableTimezones = [];
 			var vtimezones = vevent.parent.getAllSubcomponents('vtimezone');
@@ -508,10 +531,9 @@ app.factory('SimpleEvent', function() {
 
 			var dtstart = new ICAL.Property('dtstart', vevent);
 			dtstart.setValue(start);
-			if (newSimpleData.dtstart.parameters.zone !== 'floating') {
+			if (start.zone.tzid !== 'UTC' && start.zone.tzid !== 'floating') {
 				dtstart.setParameter('tzid', newSimpleData.dtstart.parameters.zone);
-				var startTz = ICAL.TimezoneService.get(newSimpleData.dtstart.parameters.zone);
-				start.zone = startTz;
+			
 				if (availableTimezones.indexOf(newSimpleData.dtstart.parameters.zone) === -1) {
 					vevent.parent.addSubcomponent(startTz.component);
 					availableTimezones.push(newSimpleData.dtstart.parameters.zone);
@@ -520,10 +542,9 @@ app.factory('SimpleEvent', function() {
 
 			var dtend = new ICAL.Property('dtend', vevent);
 			dtend.setValue(end);
-			if (newSimpleData.dtend.parameters.zone !== 'floating') {
+			if (end.zone.tzid !== 'UTC' && end.zone.tzid !== 'floating') {
 				dtend.setParameter('tzid', newSimpleData.dtend.parameters.zone);
-				var endTz = ICAL.TimezoneService.get(newSimpleData.dtend.parameters.zone);
-				end.zone = endTz;
+				
 				if (availableTimezones.indexOf(newSimpleData.dtend.parameters.zone) === -1) {
 					vevent.parent.addSubcomponent(endTz.component);
 				}

--- a/js/app/models/simpleeventmodel.js
+++ b/js/app/models/simpleeventmodel.js
@@ -496,6 +496,13 @@ app.factory('SimpleEvent', function() {
 			}
 
 			var startTz = newSimpleData.dtstart.parameters.zone === "floating" ? ICAL.Timezone.localTimezone : ICAL.TimezoneService.get(newSimpleData.dtstart.parameters.zone);
+
+			//make sure _isUTC flag is turned off for the Moments
+			var isUTC =
+			  [newSimpleData.dtstart.value._isUTC, newSimpleData.dtend.value._isUTC];
+			newSimpleData.dtstart.value._isUTC = false;
+			newSimpleData.dtend.value._isUTC = false;
+
  			var start = ICAL.Time.fromData(
  				{
 						year: newSimpleData.dtstart.value.year(), 
@@ -522,6 +529,10 @@ app.factory('SimpleEvent', function() {
  				},
  				endTz
  			);
+
+			//reset Moments to previous value of _isUTC 
+			newSimpleData.dtstart.value._isUTC = isUTC[0];
+			newSimpleData.dtend.value._isUTC = isUTC[1];
 
 			var availableTimezones = [];
 			var vtimezones = vevent.parent.getAllSubcomponents('vtimezone');


### PR DESCRIPTION
I implemented the changes from [this](https://github.com/owncloud/calendar/pull/667)  previously reverted pull request. Additionally, before creating the ICAL objects, `newSimpleData.dtstart.value._isUTC` and `newSimpleData.dtend.value._isUTC`  are set to `false`. This value being `true` was causing Moment.js to output UTC times, even when local times were requested which caused the additional offset. `_isUTC` is then returned to its previous once the ICAL objects are created so nothing else should be affected by this change.

I'm not sure why `_isUTC` is being set to true, but it seems like when `SimpleEvent.specificReader.date()`  is being called the Moment objects are in a state where they think they are local, but `_isUTC` is true so trying to get a local time returns a UTC time and getting a UTC time returns a doubly offset time.

@georgehrke, I want to do a little more poking around and testing before this is merged in, but I wanted to post this now so you could have a look at it and tell me if it fixes the offset problem you were seeing.