### PR TITLE
show tooltip for description on event hover

### DIFF
--- a/css/app/calendar.scss
+++ b/css/app/calendar.scss
@@ -54,3 +54,13 @@
 #fullcalendar td.fc-day.fc-sun {
 	background-color: nc-darken($color-main-background, 3%);
 }
+
+.tooltip-inner {
+	white-space: pre-line;
+	max-height: 175px !important;
+	overflow: hidden;
+	display: -webkit-box;
+	-webkit-line-clamp: 10;
+	-webkit-box-orient: vertical;
+}
+

--- a/js/app/controllers/calcontroller.js
+++ b/js/app/controllers/calcontroller.js
@@ -295,6 +295,17 @@ app.controller('CalController', ['$scope', 'Calendar', 'CalendarService', 'VEven
 							});
 						}
 					}
+
+					if (event.description) {
+						element.tooltip({
+							container: 'body',
+							placement: function(tip, element) {
+								const position = $(element).offset();
+								return (position.top < 300) ? 'bottom' : 'top';
+							},
+							title: event.description
+						});
+					}
 				}
 		};
 	}

--- a/js/app/models/fcEventModel.js
+++ b/js/app/models/fcEventModel.js
@@ -54,7 +54,8 @@ app.factory('FcEvent', function(SimpleEvent) {
 			backgroundColor: vevent.calendar.color,
 			borderColor: vevent.calendar.color,
 			textColor: vevent.calendar.textColor,
-			title: event.getFirstPropertyValue('summary')
+			title: event.getFirstPropertyValue('summary'),
+			description: event.getFirstPropertyValue('description')
 		};
 
 		Object.defineProperties(iface, {


### PR DESCRIPTION
Currently to view the description of an event you need (with default settings) : 
- to click on an event
- click _More_ on the popup

This intends to bring a tooltip when hovering on an event.
However, since afaik we can't apply the angular attributes (ui.bootstrap.tooltip) on the fullcalendar element, any idea on how I could do this ?

@georgehrke @raghunayyar @jancborchardt 
