### PR TITLE
Accessibility/semantic additions

### DIFF
--- a/templates/part.calendarlist.item.php
+++ b/templates/part.calendarlist.item.php
@@ -52,7 +52,8 @@
 			ng-class="{'icon-shared': item.calendar.isShared(), 'icon-share': !item.calendar.isShared()}"
 			ng-click="item.toggleEditingShares()"
 			ng-if="item.calendar.isShareable()"
-			title="<?php p($l->t('Share Calendar')) ?>">
+			title="<?php p($l->t('Share Calendar')) ?>"
+			role="button">
 		</span>
 		<!-- Add a label if the calendar has shares -->
 		<span
@@ -66,7 +67,8 @@
 		<span class="icon-more"
 			  href="#"
 			  on-toggle-show="#more-actions-{{ $id }}"
-			  title="<?php p($l->t('More')); ?>">
+			  title="<?php p($l->t('More')); ?>"
+			  role="button">
 		</span>
 	</span>
 </span>

--- a/templates/part.createcalendar.php
+++ b/templates/part.createcalendar.php
@@ -30,7 +30,7 @@
 		class="new-entity"
 		data-apps-slide-toggle=".add-new"
 		id="new-calendar-button">
-		<span class="new-entity-title"><?php p($l->t('New Calendar')); ?></span>
+		<span class="new-entity-title" role="button"><?php p($l->t('New Calendar')); ?></span>
 	</div>
 
 

--- a/templates/part.createsubscription.php
+++ b/templates/part.createsubscription.php
@@ -28,7 +28,7 @@
 		class="new-entity"
 		data-apps-slide-toggle=".add-new-subscription"
 		id="new-subscription-button">
-		<span class="new-entity-title"><?php p($l->t('New Subscription')); ?></span>
+		<span class="new-entity-title" role="button"><?php p($l->t('New Subscription')); ?></span>
 	</div>
 
 	<fieldset class="calendarlist-fieldset add-new-subscription hide">

--- a/templates/part.datepicker.php
+++ b/templates/part.datepicker.php
@@ -23,13 +23,13 @@
  */
 ?>
 <div class="datepicker-heading">
-	<button type="button" class="btn btn-default btn-sm btn-arrow pull-left" ng-click="prev()">
+	<button type="button" class="btn btn-default btn-sm btn-arrow pull-left" ng-click="prev()" aria-label="&lt;">
 		<i class="glyphicon glyphicon-chevron-left"></i>
 	</button>
 	<button type="button" class="btn btn-default btn-sm btn-date" ng-click="toggle()">
 		<strong ng-cloak>{{ dt | datepickerFilter:selectedView }}</strong>
 	</button>
-	<button type="button" class="btn btn-default btn-sm btn-arrow pull-right" ng-click="next()">
+	<button type="button" class="btn btn-default btn-sm btn-arrow pull-right" ng-click="next()" aria-label="&gt;">
 		<i class="glyphicon glyphicon-chevron-right"></i>
 	</button>
 </div>

--- a/templates/part.settings.php
+++ b/templates/part.settings.php
@@ -49,7 +49,7 @@
 			</li>
 			<li class="settings-fieldset-interior-item settings-fieldset-interior-upload">
 				<input type="file" name="file" accept="text/calendar" multiple id="import" />
-				<span href="#" class="settings-upload svg icon-upload"><?php p($l->t('Import calendar')); ?></span>
+				<span href="#" class="settings-upload svg icon-upload" role="button"><?php p($l->t('Import calendar')); ?></span>
 				<span ng-show="!files.length" class="hide"><?php p($l->t('No Calendars selected for import')); ?></span>
 			</li>
 


### PR DESCRIPTION
This pull request adds some role="button" attributes where it makes sense. Note that those spots are definitely not all of where it would be needed, but some additional semantics would require adding additional aria attributes (e. g. the day/month/week radio, the buttons showing/hiding part of the ui would probably want aria-collapsed etc.) and i did not feel adding ngaria dependency on my first contribution, but it is probably the only future choice, as i could not find a built in directive which would allow setting arbitrary attributes.
I did not decide what to do with the days in the calendar yet, maybe also add button roles to them, because for a visually impaired user (e. g. me) it was not obvious that you should click them when adding an event.
