### PR TITLE
remove eventLimit

### DIFF
--- a/js/app/directives/fullCalendarDirective.js
+++ b/js/app/directives/fullCalendarDirective.js
@@ -88,7 +88,6 @@ app.constant('fc', {})
 				dayNamesShort: dayNamesShort,
 				defaultView: attrs.defaultview,
 				editable: !isPublic,
-				eventLimit: true,
 				firstDay: firstDay,
 				header: false,
 				height: windowElement.height() - headerSize,


### PR DESCRIPTION
remove eventLimit as of https://github.com/nextcloud/calendar/issues/134#issuecomment-254757018

with the recent fixes made to the calendar list, the calendar list won't scroll together with the calendar view.

please review @nextcloud/calendar 