### PR TITLE
border styles for grid, highlight full-hour horizontal lines, fix #119

### DIFF
--- a/css/app/calendarlist.css
+++ b/css/app/calendarlist.css
@@ -493,6 +493,13 @@ ul.dropdown-menu li > a:hover {
 	border-bottom: none;
 }
 
+/* border styles for grid, highlight full-hour horizontal lines */
+.fc-unthemed tr td {
+	border-top-color: #eee;
+}
+.fc-unthemed tr:nth-child(even) td {
+	border-top-color: #f8f8f8;
+}
 .fc-unthemed th,
 .fc-unthemed td,
 .fc-unthemed thead,


### PR DESCRIPTION
Fix #119, please review @moy @tcitworld @nextcloud/calendar :)

Before:
![capture du 2016-10-19 11-29-28](https://cloud.githubusercontent.com/assets/925062/19513228/7992de84-95ef-11e6-8a05-8ca2fbc5fa65.png)

After (all full-hour grid lines are darker #eee, just like the row lines in Files, user management and elsewhere):
![capture du 2016-10-19 11-28-06](https://cloud.githubusercontent.com/assets/925062/19513227/798f9044-95ef-11e6-9fc5-5e756c242046.png)
