### PR TITLE
fix dropping between grid and allday

### DIFF
--- a/js/app/controllers/calcontroller.js
+++ b/js/app/controllers/calcontroller.js
@@ -245,7 +245,17 @@ app.controller('CalController', ['$scope', 'Calendar', 'CalendarService', 'VEven
 					});
 				},
 				eventDrop: function (fcEvent, delta, revertFunc) {
-					fcEvent.drop(delta);
+					const isAllDay = !fcEvent.start.hasTime();
+
+					const defaultAllDayEventDuration = fc.elm.fullCalendar('option', 'defaultAllDayEventDuration');
+					const defaultAllDayEventMomentDuration = moment.duration(defaultAllDayEventDuration);
+
+					const defaultTimedEventDuration = fc.elm.fullCalendar('option', 'defaultTimedEventDuration');
+					const defaultTimedEventMomentDuration = moment.duration(defaultTimedEventDuration);
+
+					const timezone = $scope.defaulttimezone;
+
+					fcEvent.drop(delta, isAllDay, timezone, defaultTimedEventMomentDuration, defaultAllDayEventMomentDuration);
 					VEventService.update(fcEvent.vevent).catch(function() {
 						revertFunc();
 					});

--- a/js/app/directives/fullCalendarDirective.js
+++ b/js/app/directives/fullCalendarDirective.js
@@ -90,6 +90,7 @@ app.constant('fc', {})
 				editable: !isPublic,
 				eventLimit: true,
 				firstDay: firstDay,
+				forceEventDuration: true,
 				header: false,
 				height: windowElement.height() - headerSize,
 				locale: moment.locale(),

--- a/tests/js/unit/models/fcEventModelSpec.js
+++ b/tests/js/unit/models/fcEventModelSpec.js
@@ -152,10 +152,74 @@ RECURRENCE-ID;TZID=Europe/Berlin:20161012T090000
 END:VEVENT
 END:VCALENDAR`;
 
+	const ics5 = `BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Apple Inc.//Mac OS X 10.11.6//EN
+CALSCALE:GREGORIAN
+BEGIN:VEVENT
+CREATED:20161004T144433Z
+UID:85560E76-1B0D-47E1-A735-21625767FCA4
+DTEND;VALUE=DATE:20161008
+TRANSP:TRANSPARENT
+DTSTART;VALUE=DATE:20161005
+DTSTAMP:20161004T144437Z
+SEQUENCE:0
+END:VEVENT
+END:VCALENDAR`;
+
+	const ics6 = `BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Apple Inc.//Mac OS X 10.11.6//EN
+CALSCALE:GREGORIAN
+BEGIN:VEVENT
+CREATED:20161004T144433Z
+UID:85560E76-1B0D-47E1-A735-21625767FCA4
+DURATION:P10DT0H0M0S
+TRANSP:TRANSPARENT
+DTSTART;VALUE=DATE:20161005
+DTSTAMP:20161004T144437Z
+SEQUENCE:0
+END:VEVENT
+END:VCALENDAR`;
+
+	const ics7 = `BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Apple Inc.//Mac OS X 10.11.6//EN
+CALSCALE:GREGORIAN
+BEGIN:VEVENT
+CREATED:20161004T144433Z
+UID:85560E76-1B0D-47E1-A735-21625767FCA4
+TRANSP:TRANSPARENT
+DTSTART;VALUE=DATE:20161005
+DTSTAMP:20161004T144437Z
+SEQUENCE:0
+END:VEVENT
+END:VCALENDAR`;
+
+
 	beforeEach(module('Calendar', function ($provide) {
 		SimpleEvent = jasmine.createSpy().and.callFake(function() {
 			return Array.from(arguments);
 		});
+
+		const tzBerlin = new ICAL.Timezone(new ICAL.Component(ICAL.parse(`BEGIN:VTIMEZONE
+TZID:Europe/Berlin
+BEGIN:DAYLIGHT
+TZOFFSETFROM:+0100
+RRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=-1SU
+DTSTART:19810329T020000
+TZNAME:GMT+2
+TZOFFSETTO:+0200
+END:DAYLIGHT
+BEGIN:STANDARD
+TZOFFSETFROM:+0200
+RRULE:FREQ=YEARLY;BYMONTH=10;BYDAY=-1SU
+DTSTART:19961027T030000
+TZNAME:GMT+1
+TZOFFSETTO:+0100
+END:STANDARD
+END:VTIMEZONE`)));
+		ICAL.TimezoneService.register('Europe/Berlin', tzBerlin);
 
 		$provide.value('SimpleEvent', SimpleEvent);
 	}));
@@ -262,7 +326,7 @@ END:VCALENDAR`;
 		expect(SimpleEvent).toHaveBeenCalledWith(event);
 	});
 
-	it ('should drop an event correctly - with DTEND', function() {
+	it ('should drop an event correctly within grid - with DTEND', function() {
 		const comp = new ICAL.Component(ICAL.parse(ics1));
 		const vevent = {
 			calendar: {
@@ -292,7 +356,7 @@ DTSTAMP:20160809T163632Z
 SEQUENCE:0
 END:VEVENT`.split("\n").join("\r\n"));
 
-		fcEvent.drop(delta);
+		fcEvent.drop(delta, false, '', moment.duration(), moment.duration());
 
 		expect(fcEvent.event.toString()).toEqual(`BEGIN:VEVENT
 CREATED:20160809T163629Z
@@ -307,7 +371,7 @@ END:VEVENT`.split("\n").join("\r\n"));
 		expect(vevent.touch).toHaveBeenCalled();
 	});
 
-	it ('should drop an event correctly - without DTEND', function() {
+	it ('should drop an event correctly within grid - without DTEND', function() {
 		const comp = new ICAL.Component(ICAL.parse(ics3));
 		const vevent = {
 			calendar: {
@@ -336,7 +400,7 @@ DTSTAMP:20161002T105648Z
 SEQUENCE:0
 END:VEVENT`.split("\n").join("\r\n"));
 
-		fcEvent.drop(delta);
+		fcEvent.drop(delta, false, '', moment.duration(), moment.duration());
 
 		expect(fcEvent.event.toString()).toEqual(`BEGIN:VEVENT
 CREATED:20161002T105635Z
@@ -346,6 +410,541 @@ X-APPLE-TRAVEL-ADVISORY-BEHAVIOR:AUTOMATIC
 SUMMARY:Event 3
 DTSTART;TZID=America/New_York:20161106T015900
 DTSTAMP:20161002T105648Z
+SEQUENCE:0
+END:VEVENT`.split("\n").join("\r\n"));
+		expect(vevent.touch).toHaveBeenCalled();
+	});
+
+
+	it ('should drop an event correctly within allDay - with DTEND', function() {
+		const comp = new ICAL.Component(ICAL.parse(ics5));
+		const vevent = {
+			calendar: {
+				color: '#000',
+				textColor: '#fff',
+				tmpId: '3.1415926536',
+				isWritable: jasmine.createSpy()
+			},
+			uri: 'fancy1337',
+			touch: jasmine.createSpy()
+		};
+		const event = comp.getFirstSubcomponent('vevent');
+		const start = event.getFirstPropertyValue('dtstart');
+		const end = event.getFirstPropertyValue('dtend');
+
+		const fcEvent = FcEvent(vevent, event, start, end);
+		const delta = moment.duration(2, 'days');
+
+		expect(fcEvent.event.toString()).toEqual(`BEGIN:VEVENT
+CREATED:20161004T144433Z
+UID:85560E76-1B0D-47E1-A735-21625767FCA4
+DTEND;VALUE=DATE:20161008
+TRANSP:TRANSPARENT
+DTSTART;VALUE=DATE:20161005
+DTSTAMP:20161004T144437Z
+SEQUENCE:0
+END:VEVENT`.split("\n").join("\r\n"));
+
+		fcEvent.drop(delta, true, '', moment.duration(), moment.duration());
+
+		expect(fcEvent.event.toString()).toEqual(`BEGIN:VEVENT
+CREATED:20161004T144433Z
+UID:85560E76-1B0D-47E1-A735-21625767FCA4
+DTEND;VALUE=DATE:20161010
+TRANSP:TRANSPARENT
+DTSTART;VALUE=DATE:20161007
+DTSTAMP:20161004T144437Z
+SEQUENCE:0
+END:VEVENT`.split("\n").join("\r\n"));
+		expect(vevent.touch).toHaveBeenCalled();
+	});
+
+
+	it ('should drop an event correctly within allDay - without DTEND', function() {
+		const comp = new ICAL.Component(ICAL.parse(ics6));
+		const vevent = {
+			calendar: {
+				color: '#000',
+				textColor: '#fff',
+				tmpId: '3.1415926536',
+				isWritable: jasmine.createSpy()
+			},
+			uri: 'fancy1337',
+			touch: jasmine.createSpy()
+		};
+		const event = comp.getFirstSubcomponent('vevent');
+		const start = event.getFirstPropertyValue('dtstart');
+
+		const fcEvent = FcEvent(vevent, event, start, start);
+		const delta = moment.duration(2, 'days');
+
+		expect(fcEvent.event.toString()).toEqual(`BEGIN:VEVENT
+CREATED:20161004T144433Z
+UID:85560E76-1B0D-47E1-A735-21625767FCA4
+DURATION:P10DT0H0M0S
+TRANSP:TRANSPARENT
+DTSTART;VALUE=DATE:20161005
+DTSTAMP:20161004T144437Z
+SEQUENCE:0
+END:VEVENT`.split("\n").join("\r\n"));
+
+		fcEvent.drop(delta, true, '', moment.duration(), moment.duration());
+
+		expect(fcEvent.event.toString()).toEqual(`BEGIN:VEVENT
+CREATED:20161004T144433Z
+UID:85560E76-1B0D-47E1-A735-21625767FCA4
+DURATION:P10DT0H0M0S
+TRANSP:TRANSPARENT
+DTSTART;VALUE=DATE:20161007
+DTSTAMP:20161004T144437Z
+SEQUENCE:0
+END:VEVENT`.split("\n").join("\r\n"));
+		expect(vevent.touch).toHaveBeenCalled();
+	});
+
+	it ('should drop an event correctly - allDay to grid - DTEND - tz', function() {
+		const comp = new ICAL.Component(ICAL.parse(ics5));
+		const vevent = {
+			calendar: {
+				color: '#000',
+				textColor: '#fff',
+				tmpId: '3.1415926536',
+				isWritable: jasmine.createSpy()
+			},
+			uri: 'fancy1337',
+			touch: jasmine.createSpy()
+		};
+		const event = comp.getFirstSubcomponent('vevent');
+		const start = event.getFirstPropertyValue('dtstart');
+		const end = event.getFirstPropertyValue('dtend');
+
+		const fcEvent = FcEvent(vevent, event, start, end);
+		const delta = moment.duration(2, 'days').add(13, 'hours');
+
+		expect(fcEvent.event.toString()).toEqual(`BEGIN:VEVENT
+CREATED:20161004T144433Z
+UID:85560E76-1B0D-47E1-A735-21625767FCA4
+DTEND;VALUE=DATE:20161008
+TRANSP:TRANSPARENT
+DTSTART;VALUE=DATE:20161005
+DTSTAMP:20161004T144437Z
+SEQUENCE:0
+END:VEVENT`.split("\n").join("\r\n"));
+
+		fcEvent.drop(delta, false, 'Europe/Berlin', moment.duration(5, 'hours'), moment.duration(3, 'days'));
+
+		expect(fcEvent.event.toString()).toEqual(`BEGIN:VEVENT
+CREATED:20161004T144433Z
+UID:85560E76-1B0D-47E1-A735-21625767FCA4
+DTEND;TZID=Europe/Berlin:20161007T180000
+TRANSP:TRANSPARENT
+DTSTART;TZID=Europe/Berlin:20161007T130000
+DTSTAMP:20161004T144437Z
+SEQUENCE:0
+END:VEVENT`.split("\n").join("\r\n"));
+		expect(vevent.touch).toHaveBeenCalled();
+	});
+
+	it ('should drop an event correctly - allDay to grid - DTEND - UTC', function() {
+		const comp = new ICAL.Component(ICAL.parse(ics5));
+		const vevent = {
+			calendar: {
+				color: '#000',
+				textColor: '#fff',
+				tmpId: '3.1415926536',
+				isWritable: jasmine.createSpy()
+			},
+			uri: 'fancy1337',
+			touch: jasmine.createSpy()
+		};
+		const event = comp.getFirstSubcomponent('vevent');
+		const start = event.getFirstPropertyValue('dtstart');
+		const end = event.getFirstPropertyValue('dtend');
+
+		const fcEvent = FcEvent(vevent, event, start, end);
+		const delta = moment.duration(2, 'days').add(13, 'hours');
+
+		expect(fcEvent.event.toString()).toEqual(`BEGIN:VEVENT
+CREATED:20161004T144433Z
+UID:85560E76-1B0D-47E1-A735-21625767FCA4
+DTEND;VALUE=DATE:20161008
+TRANSP:TRANSPARENT
+DTSTART;VALUE=DATE:20161005
+DTSTAMP:20161004T144437Z
+SEQUENCE:0
+END:VEVENT`.split("\n").join("\r\n"));
+
+		fcEvent.drop(delta, false, 'UTC', moment.duration(5, 'hours'), moment.duration(3, 'days'));
+
+		expect(fcEvent.event.toString()).toEqual(`BEGIN:VEVENT
+CREATED:20161004T144433Z
+UID:85560E76-1B0D-47E1-A735-21625767FCA4
+DTEND:20161007T180000Z
+TRANSP:TRANSPARENT
+DTSTART:20161007T130000Z
+DTSTAMP:20161004T144437Z
+SEQUENCE:0
+END:VEVENT`.split("\n").join("\r\n"));
+		expect(vevent.touch).toHaveBeenCalled();
+	});
+
+	it ('should drop an event correctly - allDay to grid - DURATION - tz', function() {
+		const comp = new ICAL.Component(ICAL.parse(ics6));
+		const vevent = {
+			calendar: {
+				color: '#000',
+				textColor: '#fff',
+				tmpId: '3.1415926536',
+				isWritable: jasmine.createSpy()
+			},
+			uri: 'fancy1337',
+			touch: jasmine.createSpy()
+		};
+		const event = comp.getFirstSubcomponent('vevent');
+		const start = event.getFirstPropertyValue('dtstart');
+
+		const fcEvent = FcEvent(vevent, event, start, start);
+		const delta = moment.duration(2, 'days').add(13, 'hours');
+
+		expect(fcEvent.event.toString()).toEqual(`BEGIN:VEVENT
+CREATED:20161004T144433Z
+UID:85560E76-1B0D-47E1-A735-21625767FCA4
+DURATION:P10DT0H0M0S
+TRANSP:TRANSPARENT
+DTSTART;VALUE=DATE:20161005
+DTSTAMP:20161004T144437Z
+SEQUENCE:0
+END:VEVENT`.split("\n").join("\r\n"));
+
+		fcEvent.drop(delta, false, 'Europe/Berlin', moment.duration(5, 'hours'), moment.duration(3, 'days'));
+
+		expect(fcEvent.event.toString()).toEqual(`BEGIN:VEVENT
+CREATED:20161004T144433Z
+UID:85560E76-1B0D-47E1-A735-21625767FCA4
+DURATION:PT5H
+TRANSP:TRANSPARENT
+DTSTART;TZID=Europe/Berlin:20161007T130000
+DTSTAMP:20161004T144437Z
+SEQUENCE:0
+END:VEVENT`.split("\n").join("\r\n"));
+		expect(vevent.touch).toHaveBeenCalled();
+	});
+
+	it ('should drop an event correctly - allDay to grid - DURATION - UTC', function() {
+		const comp = new ICAL.Component(ICAL.parse(ics6));
+		const vevent = {
+			calendar: {
+				color: '#000',
+				textColor: '#fff',
+				tmpId: '3.1415926536',
+				isWritable: jasmine.createSpy()
+			},
+			uri: 'fancy1337',
+			touch: jasmine.createSpy()
+		};
+		const event = comp.getFirstSubcomponent('vevent');
+		const start = event.getFirstPropertyValue('dtstart');
+
+		const fcEvent = FcEvent(vevent, event, start, start);
+		const delta = moment.duration(2, 'days').add(13, 'hours');
+
+		expect(fcEvent.event.toString()).toEqual(`BEGIN:VEVENT
+CREATED:20161004T144433Z
+UID:85560E76-1B0D-47E1-A735-21625767FCA4
+DURATION:P10DT0H0M0S
+TRANSP:TRANSPARENT
+DTSTART;VALUE=DATE:20161005
+DTSTAMP:20161004T144437Z
+SEQUENCE:0
+END:VEVENT`.split("\n").join("\r\n"));
+
+		fcEvent.drop(delta, false, 'UTC', moment.duration(5, 'hours'), moment.duration(3, 'days'));
+
+		expect(fcEvent.event.toString()).toEqual(`BEGIN:VEVENT
+CREATED:20161004T144433Z
+UID:85560E76-1B0D-47E1-A735-21625767FCA4
+DURATION:PT5H
+TRANSP:TRANSPARENT
+DTSTART:20161007T130000Z
+DTSTAMP:20161004T144437Z
+SEQUENCE:0
+END:VEVENT`.split("\n").join("\r\n"));
+		expect(vevent.touch).toHaveBeenCalled();
+	});
+
+	it ('should drop an event correctly - allDay to grid - neither DTEND nor DURATION - tz', function() {
+		const comp = new ICAL.Component(ICAL.parse(ics7));
+		const vevent = {
+			calendar: {
+				color: '#000',
+				textColor: '#fff',
+				tmpId: '3.1415926536',
+				isWritable: jasmine.createSpy()
+			},
+			uri: 'fancy1337',
+			touch: jasmine.createSpy()
+		};
+		const event = comp.getFirstSubcomponent('vevent');
+		const start = event.getFirstPropertyValue('dtstart');
+
+		const fcEvent = FcEvent(vevent, event, start, start);
+		const delta = moment.duration(2, 'days').add(13, 'hours');
+
+		expect(fcEvent.event.toString()).toEqual(`BEGIN:VEVENT
+CREATED:20161004T144433Z
+UID:85560E76-1B0D-47E1-A735-21625767FCA4
+TRANSP:TRANSPARENT
+DTSTART;VALUE=DATE:20161005
+DTSTAMP:20161004T144437Z
+SEQUENCE:0
+END:VEVENT`.split("\n").join("\r\n"));
+
+		fcEvent.drop(delta, false, 'Europe/Berlin', moment.duration(5, 'hours'), moment.duration(3, 'days'));
+
+		expect(fcEvent.event.toString()).toEqual(`BEGIN:VEVENT
+CREATED:20161004T144433Z
+UID:85560E76-1B0D-47E1-A735-21625767FCA4
+TRANSP:TRANSPARENT
+DTSTART;TZID=Europe/Berlin:20161007T130000
+DTSTAMP:20161004T144437Z
+SEQUENCE:0
+DTEND;TZID=Europe/Berlin:20161007T180000
+END:VEVENT`.split("\n").join("\r\n"));
+		expect(vevent.touch).toHaveBeenCalled();
+	});
+
+	it ('should drop an event correctly - allDay to grid - neither DTEND nor DURATION - UTC', function() {
+		const comp = new ICAL.Component(ICAL.parse(ics7));
+		const vevent = {
+			calendar: {
+				color: '#000',
+				textColor: '#fff',
+				tmpId: '3.1415926536',
+				isWritable: jasmine.createSpy()
+			},
+			uri: 'fancy1337',
+			touch: jasmine.createSpy()
+		};
+		const event = comp.getFirstSubcomponent('vevent');
+		const start = event.getFirstPropertyValue('dtstart');
+
+		const fcEvent = FcEvent(vevent, event, start, start);
+		const delta = moment.duration(2, 'days').add(13, 'hours');
+
+		expect(fcEvent.event.toString()).toEqual(`BEGIN:VEVENT
+CREATED:20161004T144433Z
+UID:85560E76-1B0D-47E1-A735-21625767FCA4
+TRANSP:TRANSPARENT
+DTSTART;VALUE=DATE:20161005
+DTSTAMP:20161004T144437Z
+SEQUENCE:0
+END:VEVENT`.split("\n").join("\r\n"));
+
+		fcEvent.drop(delta, false, 'UTC', moment.duration(5, 'hours'), moment.duration(3, 'days'));
+
+		expect(fcEvent.event.toString()).toEqual(`BEGIN:VEVENT
+CREATED:20161004T144433Z
+UID:85560E76-1B0D-47E1-A735-21625767FCA4
+TRANSP:TRANSPARENT
+DTSTART:20161007T130000Z
+DTSTAMP:20161004T144437Z
+SEQUENCE:0
+DTEND:20161007T180000Z
+END:VEVENT`.split("\n").join("\r\n"));
+		expect(vevent.touch).toHaveBeenCalled();
+	});
+
+	it ('should drop an event correctly - grid to allDay - DTEND', function() {
+		const comp = new ICAL.Component(ICAL.parse(ics1));
+		const vevent = {
+			calendar: {
+				color: '#000',
+				textColor: '#fff',
+				tmpId: '3.1415926536',
+				isWritable: jasmine.createSpy()
+			},
+			uri: 'fancy1337',
+			touch: jasmine.createSpy()
+		};
+		const event = comp.getFirstSubcomponent('vevent');
+		const start = event.getFirstPropertyValue('dtstart');
+		const end = event.getFirstPropertyValue('dtend');
+
+		const fcEvent = FcEvent(vevent, event, start, end);
+		const delta = moment.duration(0, 'days');
+
+		expect(fcEvent.event.toString()).toEqual(`BEGIN:VEVENT
+CREATED:20160809T163629Z
+UID:0AD16F58-01B3-463B-A215-FD09FC729A02
+DTEND;TZID=Europe/Berlin:20160816T100000
+TRANSP:OPAQUE
+SUMMARY:Test
+DTSTART;TZID=Europe/Berlin:20160816T090000
+DTSTAMP:20160809T163632Z
+SEQUENCE:0
+END:VEVENT`.split("\n").join("\r\n"));
+
+		fcEvent.drop(delta, true, '', moment.duration(5, 'hours'), moment.duration(3, 'days'));
+
+		expect(fcEvent.event.toString()).toEqual(`BEGIN:VEVENT
+CREATED:20160809T163629Z
+UID:0AD16F58-01B3-463B-A215-FD09FC729A02
+DTEND;VALUE=DATE:20160819
+TRANSP:OPAQUE
+SUMMARY:Test
+DTSTART;VALUE=DATE:20160816
+DTSTAMP:20160809T163632Z
+SEQUENCE:0
+END:VEVENT`.split("\n").join("\r\n"));
+		expect(vevent.touch).toHaveBeenCalled();
+	});
+
+	it ('should drop an event correctly - grid to allDay - DURATION', function() {
+		const comp = new ICAL.Component(ICAL.parse(ics2));
+		const vevent = {
+			calendar: {
+				color: '#000',
+				textColor: '#fff',
+				tmpId: '3.1415926536',
+				isWritable: jasmine.createSpy()
+			},
+			uri: 'fancy1337',
+			touch: jasmine.createSpy()
+		};
+		const event = comp.getFirstSubcomponent('vevent');
+		const start = event.getFirstPropertyValue('dtstart');
+
+		const fcEvent = FcEvent(vevent, event, start, start);
+		const delta = moment.duration(-3, 'days');
+
+		expect(fcEvent.event.toString()).toEqual(`BEGIN:VEVENT
+CREATED:20161002T105555Z
+UID:C8E094B8-A7E6-4CF3-9E59-58608B9B61C5
+TRANSP:OPAQUE
+X-APPLE-TRAVEL-ADVISORY-BEHAVIOR:AUTOMATIC
+SUMMARY:Event 2
+DTSTART;TZID=America/New_York:20160925T000000
+DURATION:P15DT5H0M20S
+DTSTAMP:20161002T105633Z
+SEQUENCE:0
+END:VEVENT`.split("\n").join("\r\n"));
+
+		fcEvent.drop(delta, true, '', moment.duration(5, 'hours'), moment.duration(3, 'days'));
+
+		expect(fcEvent.event.toString()).toEqual(`BEGIN:VEVENT
+CREATED:20161002T105555Z
+UID:C8E094B8-A7E6-4CF3-9E59-58608B9B61C5
+TRANSP:OPAQUE
+X-APPLE-TRAVEL-ADVISORY-BEHAVIOR:AUTOMATIC
+SUMMARY:Event 2
+DTSTART;VALUE=DATE:20160922
+DURATION:P3D
+DTSTAMP:20161002T105633Z
+SEQUENCE:0
+END:VEVENT`.split("\n").join("\r\n"));
+		expect(vevent.touch).toHaveBeenCalled();
+	});
+
+	it ('should drop an event correctly - grid to allDay - neither DTEND nor DURATION', function() {
+		const comp = new ICAL.Component(ICAL.parse(ics3));
+		const vevent = {
+			calendar: {
+				color: '#000',
+				textColor: '#fff',
+				tmpId: '3.1415926536',
+				isWritable: jasmine.createSpy()
+			},
+			uri: 'fancy1337',
+			touch: jasmine.createSpy()
+		};
+		const event = comp.getFirstSubcomponent('vevent');
+		const start = event.getFirstPropertyValue('dtstart');
+
+		const fcEvent = FcEvent(vevent, event, start, start);
+		const delta = moment.duration(3, 'days');
+
+		expect(fcEvent.event.toString()).toEqual(`BEGIN:VEVENT
+CREATED:20161002T105635Z
+UID:9D0C33D1-334E-4B46-9E0E-D62C11E60700
+TRANSP:OPAQUE
+X-APPLE-TRAVEL-ADVISORY-BEHAVIOR:AUTOMATIC
+SUMMARY:Event 3
+DTSTART;TZID=America/New_York:20161105T235900
+DTSTAMP:20161002T105648Z
+SEQUENCE:0
+END:VEVENT`.split("\n").join("\r\n"));
+
+		fcEvent.drop(delta, true, '', moment.duration(5, 'hours'), moment.duration(3, 'days'));
+
+		expect(fcEvent.event.toString()).toEqual(`BEGIN:VEVENT
+CREATED:20161002T105635Z
+UID:9D0C33D1-334E-4B46-9E0E-D62C11E60700
+TRANSP:OPAQUE
+X-APPLE-TRAVEL-ADVISORY-BEHAVIOR:AUTOMATIC
+SUMMARY:Event 3
+DTSTART;VALUE=DATE:20161108
+DTSTAMP:20161002T105648Z
+SEQUENCE:0
+DTEND;VALUE=DATE:20161111
+END:VEVENT`.split("\n").join("\r\n"));
+		expect(vevent.touch).toHaveBeenCalled();
+	});
+
+	it ('should drop an event correctly - grid to allDay to grid - DTEND', function() {
+		const comp = new ICAL.Component(ICAL.parse(ics1));
+		const vevent = {
+			calendar: {
+				color: '#000',
+				textColor: '#fff',
+				tmpId: '3.1415926536',
+				isWritable: jasmine.createSpy()
+			},
+			uri: 'fancy1337',
+			touch: jasmine.createSpy()
+		};
+		const event = comp.getFirstSubcomponent('vevent');
+		const start = event.getFirstPropertyValue('dtstart');
+		const end = event.getFirstPropertyValue('dtend');
+
+		const fcEvent = FcEvent(vevent, event, start, end);
+		const delta1 = moment.duration(-2, 'days');
+
+		expect(fcEvent.event.toString()).toEqual(`BEGIN:VEVENT
+CREATED:20160809T163629Z
+UID:0AD16F58-01B3-463B-A215-FD09FC729A02
+DTEND;TZID=Europe/Berlin:20160816T100000
+TRANSP:OPAQUE
+SUMMARY:Test
+DTSTART;TZID=Europe/Berlin:20160816T090000
+DTSTAMP:20160809T163632Z
+SEQUENCE:0
+END:VEVENT`.split("\n").join("\r\n"));
+
+		fcEvent.drop(delta1, true, '', moment.duration(5, 'hours'), moment.duration(3, 'days'));
+
+		expect(fcEvent.event.toString()).toEqual(`BEGIN:VEVENT
+CREATED:20160809T163629Z
+UID:0AD16F58-01B3-463B-A215-FD09FC729A02
+DTEND;VALUE=DATE:20160817
+TRANSP:OPAQUE
+SUMMARY:Test
+DTSTART;VALUE=DATE:20160814
+DTSTAMP:20160809T163632Z
+SEQUENCE:0
+END:VEVENT`.split("\n").join("\r\n"));
+		expect(vevent.touch).toHaveBeenCalled();
+
+		const delta2 = moment.duration(3, 'days').add(15, 'hours').add(30, 'minutes');
+		fcEvent.drop(delta2, false, 'Europe/Berlin', moment.duration(5, 'hours'), moment.duration(3, 'days'));
+
+		expect(fcEvent.event.toString()).toEqual(`BEGIN:VEVENT
+CREATED:20160809T163629Z
+UID:0AD16F58-01B3-463B-A215-FD09FC729A02
+DTEND;TZID=Europe/Berlin:20160817T203000
+TRANSP:OPAQUE
+SUMMARY:Test
+DTSTART;TZID=Europe/Berlin:20160817T153000
+DTSTAMP:20160809T163632Z
 SEQUENCE:0
 END:VEVENT`.split("\n").join("\r\n"));
 		expect(vevent.touch).toHaveBeenCalled();


### PR DESCRIPTION
fixes #16 

please review @nextcloud/calendar 

This fixes a longstanding issue, that caused users to not be able to drag and drop events between the all-day grid and the time-grids in day and week view.

Test this by dragging and dropping events from all-day to time grid and vice versa.