### PR TITLE
move some calendarService calls into Calendar and subscription model

### DIFF
--- a/js/app/controllers/calendarlistcontroller.js
+++ b/js/app/controllers/calendarlistcontroller.js
@@ -41,8 +41,6 @@ app.controller('CalendarListController', ['$scope', '$rootScope', '$window', 'Ca
 		$scope.publicdav = 'CalDAV';
 		$scope.publicdavdesc = t('calendar', 'CalDAV address for clients');
 
-		window.scope = $scope;
-
 		$scope.$watchCollection('calendars', function(newCalendars, oldCalendars) {
 			newCalendars = newCalendars || [];
 			oldCalendars = oldCalendars || [];
@@ -155,7 +153,7 @@ app.controller('CalendarListController', ['$scope', '$rootScope', '$window', 'Ca
 
 		$scope.togglePublish = function(item) {
 			if (item.calendar.published) {
-				CalendarService.publish(item.calendar).then(function (response) {
+				item.calendar.publish().then(function (response) {
 					if (response) {
 						CalendarService.get(item.calendar.url).then(function (calendar) {
 							item.calendar.publishurl = calendar.publishurl;
@@ -166,7 +164,7 @@ app.controller('CalendarListController', ['$scope', '$rootScope', '$window', 'Ca
 					$scope.$apply();
 				});
 			} else {
-				CalendarService.unpublish(item.calendar).then(function (response) {
+				item.calendar.unpublish().then(function (response) {
 					if (response) {
 						item.calendar.published = false;
 					}
@@ -183,31 +181,31 @@ app.controller('CalendarListController', ['$scope', '$rootScope', '$window', 'Ca
 			// Remove content from text box
 			calendar.selectedSharee = '';
 			// Create a default share with the user/group, read only
-			CalendarService.share(calendar, item.type, item.identifier, false, false).then(function() {
+			calendar.share(item.type, item.identifier, false, false).then(function() {
 				$scope.$apply();
 			});
 		};
 
 		$scope.updateExistingUserShare = function(calendar, userId, writable) {
-			CalendarService.share(calendar, OC.Share.SHARE_TYPE_USER, userId, writable, true).then(function() {
+			calendar.share(OC.Share.SHARE_TYPE_USER, userId, writable, true).then(function() {
 				$scope.$apply();
 			});
 		};
 
 		$scope.updateExistingGroupShare = function(calendar, groupId, writable) {
-			CalendarService.share(calendar, OC.Share.SHARE_TYPE_GROUP, groupId, writable, true).then(function() {
+			calendar.share(OC.Share.SHARE_TYPE_GROUP, groupId, writable, true).then(function() {
 				$scope.$apply();
 			});
 		};
 
 		$scope.unshareFromUser = function(calendar, userId) {
-			CalendarService.unshare(calendar, OC.Share.SHARE_TYPE_USER, userId).then(function() {
+			calendar.unshare(OC.Share.SHARE_TYPE_USER, userId).then(function() {
 				$scope.$apply();
 			});
 		};
 
 		$scope.unshareFromGroup = function(calendar, groupId) {
-			CalendarService.unshare(calendar, OC.Share.SHARE_TYPE_GROUP, groupId).then(function() {
+			calendar.unshare(OC.Share.SHARE_TYPE_GROUP, groupId).then(function() {
 				$scope.$apply();
 			});
 		};
@@ -275,7 +273,7 @@ app.controller('CalendarListController', ['$scope', '$rootScope', '$window', 'Ca
 
 		$scope.performUpdate = function (item) {
 			item.saveEditor();
-			CalendarService.update(item.calendar).then(function() {
+			item.calendar.update().then(function() {
 				$rootScope.$broadcast('updatedCalendar', item.calendar);
 				$rootScope.$broadcast('reloadCalendarList');
 			});
@@ -285,7 +283,7 @@ app.controller('CalendarListController', ['$scope', '$rootScope', '$window', 'Ca
 		 * Updates the shares of the calendar
 		 */
 		$scope.performUpdateShares = function (calendar) {
-			CalendarService.update(calendar).then(function() {
+			calendar.update().then(function() {
 				calendar.dropPreviousState();
 				calendar.list.edit = false;
 				$rootScope.$broadcast('updatedCalendar', calendar);
@@ -296,14 +294,14 @@ app.controller('CalendarListController', ['$scope', '$rootScope', '$window', 'Ca
 		$scope.triggerEnable = function(item) {
 			item.calendar.toggleEnabled();
 
-			CalendarService.update(item.calendar).then(function() {
+			item.calendar.update().then(function() {
 				$rootScope.$broadcast('updatedCalendarsVisibility', item.calendar);
 				$rootScope.$broadcast('reloadCalendarList');
 			});
 		};
 
 		$scope.remove = function (item) {
-			CalendarService.delete(item.calendar).then(function() {
+			item.calendar.delete().then(function() {
 				$scope.$parent.calendars = $scope.$parent.calendars.filter(function(elem) {
 					return elem !== item.calendar;
 				});

--- a/js/app/factory/calendarFactory.js
+++ b/js/app/factory/calendarFactory.js
@@ -285,27 +285,29 @@ app.service('CalendarFactory', function($window, DavClient, Calendar, WebCal) {
 
 	/**
 	 * get a calendar object from raw xml data
+	 * @param {object} CalendarService
 	 * @param body
 	 * @param {string} userPrincipal
 	 * @param {boolean} publicMode
 	 * @returns {Calendar}
 	 */
-	this.calendar = function(body, userPrincipal, publicMode=false) {
+	this.calendar = function(CalendarService, body, userPrincipal, publicMode=false) {
 		const href = body.href;
 		const props = body.propStat[0].properties;
 
 		const simple = context.calendarSkeleton(props, userPrincipal, publicMode);
-		return Calendar(href, simple);
+		return Calendar(CalendarService, href, simple);
 	};
 
 	/**
 	 * get a webcal object from raw xml data
+	 * @param {object} CalendarService
 	 * @param body
 	 * @param {string} userPrincipal
 	 * @param {boolean} publicMode
 	 * @returns {WebCal}
 	 */
-	this.webcal = function(body, userPrincipal, publicMode=false) {
+	this.webcal = function(CalendarService, body, userPrincipal, publicMode=false) {
 		const href = body.href;
 		const props = body.propStat[0].properties;
 		const currentUser = context.getUserFromUserPrincipal(userPrincipal);
@@ -321,6 +323,6 @@ app.service('CalendarFactory', function($window, DavClient, Calendar, WebCal) {
 		simple.publishable = false;
 		simple.shareable = false;
 
-		return WebCal(href, simple);
+		return WebCal(CalendarService, href, simple);
 	};
 });

--- a/js/app/models/calendarmodel.js
+++ b/js/app/models/calendarmodel.js
@@ -1,11 +1,41 @@
+/**
+ * Nextcloud - Calendar App
+ *
+ * @author Georg Ehrke
+ * @copyright 2016 Georg Ehrke <oc.list@georgehrke.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU AFFERO GENERAL PUBLIC LICENSE
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU AFFERO GENERAL PUBLIC LICENSE for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
 app.factory('Calendar', function($window, Hook, VEventService, TimezoneService, ColorUtility, RandomStringService) {
 	'use strict';
 
-	function Calendar(url, props) {
+	/**
+	 * instantiate a calendar object
+	 * @param {object} CalendarService
+	 * @param {string} url
+	 * @param {object} props
+	 * @returns {object}
+	 * @constructor
+	 */
+	function Calendar(CalendarService, url, props) {
 		url = url || '';
 		props = props || {};
 
 		const context = {
+			calendarService: CalendarService,
 			fcEventSource: {},
 			components: props.components,
 			mutableProperties: {
@@ -287,6 +317,34 @@ app.factory('Calendar', function($window, Hook, VEventService, TimezoneService, 
 
 		iface.eventsAccessibleViaCalDAV = function() {
 			return true;
+		};
+
+		iface.refresh = function() {
+			// TODO in a follow up PR
+		};
+
+		iface.update = function() {
+			return context.calendarService.update(iface);
+		};
+
+		iface.delete = function() {
+			return context.calendarService.delete(iface);
+		};
+
+		iface.share = function(shareType, shareWith, writable, existingShare) {
+			return context.calendarService.share(iface, shareType, shareWith, writable, existingShare);
+		};
+
+		iface.unshare = function(shareType, shareWith, writable, existingShare) {
+			return context.calendarService.unshare(iface, shareType, shareWith, writable, existingShare);
+		};
+
+		iface.publish = function() {
+			return context.calendarService.publish(iface);
+		};
+
+		iface.unpublish = function() {
+			return context.calendarService.unpublish(iface);
 		};
 
 		Object.assign(

--- a/js/app/models/webcalModel.js
+++ b/js/app/models/webcalModel.js
@@ -22,13 +22,22 @@
 app.factory('WebCal', function($http, Calendar, VEvent, TimezoneService, WebCalService, WebCalUtility) {
 	'use strict';
 
-	function WebCal(url, props) {
+	/**
+	 * instantiate a webcal object
+	 * @param {object} CalendarService
+	 * @param {string} url
+	 * @param {object} props
+	 * @returns {object}
+	 * @constructor
+	 */
+	function WebCal(CalendarService, url, props) {
 		const context = {
+			calendarService: CalendarService,
 			storedUrl: props.href, //URL stored in CalDAV
 			url: WebCalUtility.fixURL(props.href)
 		};
 
-		const iface = Calendar(url, props);
+		const iface = Calendar(CalendarService, url, props);
 		iface._isAWebCalObject = true;
 
 		Object.defineProperties(iface, {
@@ -84,6 +93,11 @@ app.factory('WebCal', function($http, Calendar, VEvent, TimezoneService, WebCalS
 
 		iface.eventsAccessibleViaCalDAV = function() {
 			return false;
+		};
+
+		iface.delete = function() {
+			localStorage.removeItem(iface.storedUrl);
+			context.calendarService.delete(iface);
 		};
 
 		return iface;

--- a/tests/js/unit/controllers/calendarlistcontrollerSpec.js
+++ b/tests/js/unit/controllers/calendarlistcontrollerSpec.js
@@ -37,15 +37,15 @@ describe('CalendarListController', function() {
 			CalendarService = {
 				getAll: function(){},
 				get: function() {},
-				create: function() {},
-				update: function() {},
-				delete: function() {},
-				publish: function() {},
-				unpublish: function() {}
+				create: function() {}
 			};
 			Calendar = function() {
 				return {
-					list: {}
+					list: {},
+					update: jasmine.createSpy(),
+					delete: jasmine.createSpy(),
+					publish: jasmine.createSpy(),
+					unpublish: jasmine.createSpy()
 				};
 			};
 
@@ -74,31 +74,30 @@ describe('CalendarListController', function() {
 	});
 
 	it ('should delete the selected calendar', function () {
-		spyOn(CalendarService, 'delete').and.returnValue(deferred.promise);
-
 		controller = controller('CalendarListController', {
 			$scope: $scope,
 			CalendarService: CalendarService
 		});
 
-		var calendarToDelete = {};
+		var calendarToDelete = {
+			delete: jasmine.createSpy().and.returnValue(deferred.promise),
+		};
 		var calendarItem = {
 			calendar: calendarToDelete
 		};
 
 		$scope.remove(calendarItem);
-		expect(CalendarService.delete).toHaveBeenCalledWith(calendarToDelete);
+		expect(calendarToDelete.delete).toHaveBeenCalledWith();
 	});
 
 	it ('should publish the selected calendar', function () {
-		spyOn(CalendarService, 'publish').and.returnValue(deferred.promise);
-
 		controller = controller('CalendarListController', {
 			$scope: $scope,
 			CalendarService: CalendarService
 		});
 
 		var calendarToPublish = {
+			publish: jasmine.createSpy().and.returnValue(deferred.promise),
 			published: true
 		};
 		var calendarItem = {
@@ -106,18 +105,17 @@ describe('CalendarListController', function() {
 		};
 
 		$scope.togglePublish(calendarItem);
-		expect(CalendarService.publish).toHaveBeenCalledWith(calendarToPublish);
+		expect(calendarToPublish.publish).toHaveBeenCalledWith();
 	});
 
 	it ('should unpublish the selected calendar', function () {
-		spyOn(CalendarService, 'unpublish').and.returnValue(deferred.promise);
-
 		controller = controller('CalendarListController', {
 			$scope: $scope,
 			CalendarService: CalendarService
 		});
 
 		var calendarToUnPublish = {
+			unpublish: jasmine.createSpy().and.returnValue(deferred.promise),
 			published: false
 		};
 		var calendarItem = {
@@ -125,7 +123,7 @@ describe('CalendarListController', function() {
 		};
 
 		$scope.togglePublish(calendarItem);
-		expect(CalendarService.unpublish).toHaveBeenCalledWith(calendarToUnPublish);
+		expect(calendarToUnPublish.unpublish).toHaveBeenCalledWith();
 	});
 
 	afterEach(function() {

--- a/tests/js/unit/factory/calendarFactorySpec.js
+++ b/tests/js/unit/factory/calendarFactorySpec.js
@@ -25,6 +25,7 @@ describe('CalendarFactory', function () {
 	let CalendarFactory;
 	let $window, DavClient, Calendar, WebCal;
 	let davService, attrSpy, ngElementSpy;
+	let privateCalendarServiceAPI;
 
 	const calendar_default = `<?xml version="1.0"?>
 <d:multistatus xmlns:d="DAV:" xmlns:s="http://sabredav.org/ns" xmlns:cal="urn:ietf:params:xml:ns:caldav" xmlns:cs="http://calendarserver.org/ns/" xmlns:card="urn:ietf:params:xml:ns:carddav" xmlns:oc="http://owncloud.org/ns" xmlns:nc="http://nextcloud.org/ns">
@@ -839,6 +840,8 @@ describe('CalendarFactory', function () {
 		attrSpy = jasmine.createSpy();
 		ngElementSpy = spyOn(angular, 'element').and.returnValue({attr: attrSpy});
 
+		privateCalendarServiceAPI = {};
+
 		$provide.value('$window', $window);
 		$provide.value('DavClient', DavClient);
 		$provide.value('Calendar', Calendar);
@@ -855,8 +858,8 @@ describe('CalendarFactory', function () {
 
 	it('create a calendar object', function() {
 		const calendarProperties = davService.parseMultiStatus(calendar_default);
-		const calendar = CalendarFactory.calendar(calendarProperties[0], '/remote.php/dav/principals/users/admin/', false);
-		expect(calendar).toEqual(['/remote.php/dav/calendars/admin/privat/', {
+		const calendar = CalendarFactory.calendar(privateCalendarServiceAPI, calendarProperties[0], '/remote.php/dav/principals/users/admin/', false);
+		expect(calendar).toEqual([privateCalendarServiceAPI, '/remote.php/dav/calendars/admin/privat/', {
 			color: '#78e774', displayname: 'Privat', components: {vevent: true, vjournal: false, vtodo: true},
 			order: 0, writable: true, owner: 'admin', enabled: true, shares: {users: [], groups: []},
 			shareable: true, publishable: true, published: false, publishurl: null, publicurl: null,
@@ -865,8 +868,8 @@ describe('CalendarFactory', function () {
 
 	it('create a webcal object', function() {
 		const webcalProperties = davService.parseMultiStatus(webcal_default);
-		const webcal = CalendarFactory.webcal(webcalProperties[0], '/remote.php/dav/principals/users/admin/', false);
-		expect(webcal).toEqual(['/remote.php/dav/calendars/admin/some-webcal-abo/', {
+		const webcal = CalendarFactory.webcal(privateCalendarServiceAPI, webcalProperties[0], '/remote.php/dav/principals/users/admin/', false);
+		expect(webcal).toEqual([privateCalendarServiceAPI, '/remote.php/dav/calendars/admin/some-webcal-abo/', {
 			color: '#e774b5', displayname: 'http://some-fancy-webcal.com/foo.ics',
 			components: {vevent: true, vjournal: false, vtodo: true}, order: 0, writable: false, owner: 'admin',
 			enabled: true, shares: {users: [ ], groups: [  ]}, shareable: false, publishable: false, published: false,
@@ -879,8 +882,8 @@ describe('CalendarFactory', function () {
 		attrSpy.and.returnValue('#fefefe');
 
 		const calendarProperties = davService.parseMultiStatus(calendar_nocolor);
-		const calendar = CalendarFactory.calendar(calendarProperties[0], '/remote.php/dav/principals/users/admin/', false);
-		expect(calendar).toEqual(['/remote.php/dav/calendars/admin/privat/', {
+		const calendar = CalendarFactory.calendar(privateCalendarServiceAPI, calendarProperties[0], '/remote.php/dav/principals/users/admin/', false);
+		expect(calendar).toEqual([privateCalendarServiceAPI, '/remote.php/dav/calendars/admin/privat/', {
 			color: '#fefefe', displayname: 'Privat', components: {vevent: true, vjournal: false, vtodo: true},
 			order: 0, writable: true, owner: 'admin', enabled: true, shares: {users: [], groups: []},
 			shareable: true, publishable: true, published: false, publishurl: null, publicurl: null,
@@ -889,8 +892,8 @@ describe('CalendarFactory', function () {
 
 	it('enable the calendar when it\'s owned by the user and enabled is not set', function() {
 		const calendarProperties = davService.parseMultiStatus(calendar_noenabled);
-		const calendar = CalendarFactory.calendar(calendarProperties[0], '/remote.php/dav/principals/users/admin/', false);
-		expect(calendar).toEqual(['/remote.php/dav/calendars/admin/privat/', {
+		const calendar = CalendarFactory.calendar(privateCalendarServiceAPI, calendarProperties[0], '/remote.php/dav/principals/users/admin/', false);
+		expect(calendar).toEqual([privateCalendarServiceAPI, '/remote.php/dav/calendars/admin/privat/', {
 			color: '#78e774', displayname: 'Privat', components: {vevent: true, vjournal: false, vtodo: true},
 			order: 0, writable: true, owner: 'admin', enabled: true, shares: {users: [], groups: []},
 			shareable: true, publishable: true, published: false, publishurl: null, publicurl: null,
@@ -899,8 +902,8 @@ describe('CalendarFactory', function () {
 
 	it('disable the calendar when it\'s not owned by the user and enabled is not set', function() {
 		const calendarProperties = davService.parseMultiStatus(calendar_noenabled);
-		const calendar = CalendarFactory.calendar(calendarProperties[0], '/remote.php/dav/principals/users/hans_dieter/', false);
-		expect(calendar).toEqual(['/remote.php/dav/calendars/admin/privat/', {
+		const calendar = CalendarFactory.calendar(privateCalendarServiceAPI, calendarProperties[0], '/remote.php/dav/principals/users/hans_dieter/', false);
+		expect(calendar).toEqual([privateCalendarServiceAPI, '/remote.php/dav/calendars/admin/privat/', {
 			color: '#78e774', displayname: 'Privat', components: {vevent: true, vjournal: false, vtodo: true},
 			order: 0, writable: false, owner: 'admin', enabled: false, shares: {users: [], groups: []},
 			shareable: false, publishable: false, published: false, publishurl: null, publicurl: null,
@@ -911,8 +914,8 @@ describe('CalendarFactory', function () {
 		$window.location = 'http://nextcloud.dev/index.php/apps/calendar/';
 
 		const calendarProperties = davService.parseMultiStatus(calendar_published);
-		const calendar = CalendarFactory.calendar(calendarProperties[0], '/remote.php/dav/principals/users/admin/', false);
-		expect(calendar).toEqual(['/remote.php/dav/calendars/admin/privat/', {
+		const calendar = CalendarFactory.calendar(privateCalendarServiceAPI, calendarProperties[0], '/remote.php/dav/principals/users/admin/', false);
+		expect(calendar).toEqual([privateCalendarServiceAPI, '/remote.php/dav/calendars/admin/privat/', {
 			color: '#78e774', displayname: 'Privat', components: {vevent: true, vjournal: false, vtodo: true},
 			order: 0, writable: true, owner: 'admin', enabled: true, shares: {users: [], groups: []},
 			shareable: true, publishable: true, published: true,
@@ -924,8 +927,8 @@ describe('CalendarFactory', function () {
 		$window.location = 'http://nextcloud.dev/index.php/apps/calendar/#';
 
 		const calendarProperties = davService.parseMultiStatus(calendar_published);
-		const calendar = CalendarFactory.calendar(calendarProperties[0], '/remote.php/dav/principals/users/admin/', false);
-		expect(calendar).toEqual(['/remote.php/dav/calendars/admin/privat/', {
+		const calendar = CalendarFactory.calendar(privateCalendarServiceAPI, calendarProperties[0], '/remote.php/dav/principals/users/admin/', false);
+		expect(calendar).toEqual([privateCalendarServiceAPI, '/remote.php/dav/calendars/admin/privat/', {
 			color: '#78e774', displayname: 'Privat', components: {vevent: true, vjournal: false, vtodo: true},
 			order: 0, writable: true, owner: 'admin', enabled: true, shares: {users: [], groups: []},
 			shareable: true, publishable: true, published: true,
@@ -935,8 +938,8 @@ describe('CalendarFactory', function () {
 
 	it('handle shared calendars for owner', function() {
 		const calendarProperties = davService.parseMultiStatus(calendar_shared);
-		const calendar = CalendarFactory.calendar(calendarProperties[0], '/remote.php/dav/principals/users/admin/', false);
-		expect(calendar).toEqual(['/remote.php/dav/calendars/admin/privat/', {
+		const calendar = CalendarFactory.calendar(privateCalendarServiceAPI, calendarProperties[0], '/remote.php/dav/principals/users/admin/', false);
+		expect(calendar).toEqual([privateCalendarServiceAPI, '/remote.php/dav/calendars/admin/privat/', {
 			color: '#78e774', displayname: 'Privat', components: {vevent: true, vjournal: false, vtodo: true},
 			order: 0, writable: true, owner: 'admin', enabled: true,
 			shares: {
@@ -953,8 +956,8 @@ describe('CalendarFactory', function () {
 
 	it('handle shared calendars for ro sharee', function() {
 		const calendarProperties = davService.parseMultiStatus(calendar_shared);
-		const calendar = CalendarFactory.calendar(calendarProperties[0], '/remote.php/dav/principals/users/user1/', false);
-		expect(calendar).toEqual(['/remote.php/dav/calendars/admin/privat/', {
+		const calendar = CalendarFactory.calendar(privateCalendarServiceAPI, calendarProperties[0], '/remote.php/dav/principals/users/user1/', false);
+		expect(calendar).toEqual([privateCalendarServiceAPI, '/remote.php/dav/calendars/admin/privat/', {
 			color: '#78e774', displayname: 'Privat', components: {vevent: true, vjournal: false, vtodo: true},
 			order: 0, writable: false, owner: 'admin', enabled: true,
 			shares: {
@@ -971,8 +974,8 @@ describe('CalendarFactory', function () {
 
 	it('handle shared calendars for rw sharee', function() {
 		const calendarProperties = davService.parseMultiStatus(calendar_shared);
-		const calendar = CalendarFactory.calendar(calendarProperties[0], '/remote.php/dav/principals/users/user2/', false);
-		expect(calendar).toEqual(['/remote.php/dav/calendars/admin/privat/', {
+		const calendar = CalendarFactory.calendar(privateCalendarServiceAPI, calendarProperties[0], '/remote.php/dav/principals/users/user2/', false);
+		expect(calendar).toEqual([privateCalendarServiceAPI, '/remote.php/dav/calendars/admin/privat/', {
 			color: '#78e774', displayname: 'Privat', components: {vevent: true, vjournal: false, vtodo: true},
 			order: 0, writable: true, owner: 'admin', enabled: true,
 			shares: {
@@ -989,8 +992,8 @@ describe('CalendarFactory', function () {
 
 	it('handle vjournal as a component', function() {
 		const calendarProperties = davService.parseMultiStatus(calendar_vevent_vjournal);
-		const calendar = CalendarFactory.calendar(calendarProperties[0], '/remote.php/dav/principals/users/admin/', false);
-		expect(calendar).toEqual(['/remote.php/dav/calendars/admin/privat/', {
+		const calendar = CalendarFactory.calendar(privateCalendarServiceAPI, calendarProperties[0], '/remote.php/dav/principals/users/admin/', false);
+		expect(calendar).toEqual([privateCalendarServiceAPI, '/remote.php/dav/calendars/admin/privat/', {
 			color: '#78e774', displayname: 'Privat', components: {vevent: true, vjournal: true, vtodo: true},
 			order: 0, writable: true, owner: 'admin', enabled: true, shares: {users: [], groups: []},
 			shareable: true, publishable: true, published: false, publishurl: null, publicurl: null,
@@ -999,8 +1002,8 @@ describe('CalendarFactory', function () {
 
 	it('correctly determine sharing options when sharing-modes is not available - owner', function() {
 		const calendarProperties = davService.parseMultiStatus(calendar_no_sharingmodes_fallback);
-		const calendar = CalendarFactory.calendar(calendarProperties[0], '/remote.php/dav/principals/users/admin/', false);
-		expect(calendar).toEqual(['/remote.php/dav/calendars/admin/123/', {
+		const calendar = CalendarFactory.calendar(privateCalendarServiceAPI, calendarProperties[0], '/remote.php/dav/principals/users/admin/', false);
+		expect(calendar).toEqual([privateCalendarServiceAPI, '/remote.php/dav/calendars/admin/123/', {
 			color: '#FF7A66', displayname: '123', components: {vevent: true, vjournal: false, vtodo: true},
 			order: 0, writable: true, owner: 'admin', enabled: true, shares: {users: [], groups: []},
 			shareable: true, publishable: false, published: false, publishurl: null, publicurl: null,
@@ -1009,8 +1012,8 @@ describe('CalendarFactory', function () {
 
 	it('correctly determine sharing options when sharing-modes is not available - not owner', function() {
 		const calendarProperties = davService.parseMultiStatus(calendar_no_sharingmodes_fallback);
-		const calendar = CalendarFactory.calendar(calendarProperties[0], '/remote.php/dav/principals/users/foobar/', false);
-		expect(calendar).toEqual(['/remote.php/dav/calendars/admin/123/', {
+		const calendar = CalendarFactory.calendar(privateCalendarServiceAPI, calendarProperties[0], '/remote.php/dav/principals/users/foobar/', false);
+		expect(calendar).toEqual([privateCalendarServiceAPI, '/remote.php/dav/calendars/admin/123/', {
 			color: '#FF7A66', displayname: '123', components: {vevent: true, vjournal: false, vtodo: true},
 			order: 0, writable: false, owner: 'admin', enabled: true, shares: {users: [], groups: []},
 			shareable: false, publishable: false, published: false, publishurl: null, publicurl: null,
@@ -1021,8 +1024,8 @@ describe('CalendarFactory', function () {
 		$window.location = 'http://nextcloud.dev/index.php/apps/calendar/public/KCMY4V5JZ22ODGFW';
 
 		const calendarProperties = davService.parseMultiStatus(public_calendar);
-		const calendar = CalendarFactory.calendar(calendarProperties[0], '', true);
-		expect(calendar).toEqual(['/remote.php/dav/public-calendars/KCMY4V5JZ22ODGFW/', {
+		const calendar = CalendarFactory.calendar(privateCalendarServiceAPI, calendarProperties[0], '', true);
+		expect(calendar).toEqual([privateCalendarServiceAPI, '/remote.php/dav/public-calendars/KCMY4V5JZ22ODGFW/', {
 			color: undefined, displayname: 'Personal (admin)', components: {vevent: true, vjournal: false, vtodo: true},
 			order: 0, writable: false, owner: 'admin', enabled: true, shares: {users: [], groups: []}, shareable: false,
 			publishable: false, published: true, publishurl: 'http://nextcloud.dev/remote.php/dav/public-calendars/KCMY4V5JZ22ODGFW',

--- a/tests/js/unit/models/calendarModelSpec.js
+++ b/tests/js/unit/models/calendarModelSpec.js
@@ -2,6 +2,7 @@ describe('The calendar factory', function () {
 	'use strict';
 
 	var Calendar, window, hook, veventservice, timezoneservice, colorutilityservice, randomstringservice;
+	let privateCalendarServiceAPI;
 
 	beforeEach(module('Calendar', function ($provide) {
 		window = {};
@@ -14,6 +15,15 @@ describe('The calendar factory', function () {
 
 		randomstringservice = {};
 		randomstringservice.generate = jasmine.createSpy().and.returnValue('**random**');
+
+		privateCalendarServiceAPI = {
+			update: jasmine.createSpy(),
+			delete: jasmine.createSpy(),
+			share: jasmine.createSpy(),
+			unshare: jasmine.createSpy(),
+			publish: jasmine.createSpy(),
+			unpublish: jasmine.createSpy()
+		};
 
 		$provide.value('$window', window);
 		$provide.value('Hook', hook);
@@ -34,7 +44,7 @@ describe('The calendar factory', function () {
 			groups: [],
 			users: []
 		};
-		var calendar = Calendar('/remote.php/dav/caldav/foobar/', {
+		var calendar = Calendar(privateCalendarServiceAPI, '/remote.php/dav/caldav/foobar/', {
 			components: components,
 			color: '#001122',
 			displayname: 'name_1337',
@@ -69,7 +79,7 @@ describe('The calendar factory', function () {
 	});
 
 	it('should correctly reflect if it\'s shared', function() {
-		var calendar1 = Calendar('/remote.php/dav/caldav/foobar/', {
+		var calendar1 = Calendar(privateCalendarServiceAPI, '/remote.php/dav/caldav/foobar/', {
 			shares: {
 				groups: [],
 				users: []
@@ -77,7 +87,7 @@ describe('The calendar factory', function () {
 		});
 		expect(calendar1.isShared()).toEqual(false);
 
-		var calendar2 = Calendar('/remote.php/dav/caldav/foobar/', {
+		var calendar2 = Calendar(privateCalendarServiceAPI, '/remote.php/dav/caldav/foobar/', {
 			shares: {
 				groups: [{}],
 				users: []
@@ -85,7 +95,7 @@ describe('The calendar factory', function () {
 		});
 		expect(calendar2.isShared()).toEqual(true);
 
-		var calendar3 = Calendar('/remote.php/dav/caldav/foobar/', {
+		var calendar3 = Calendar(privateCalendarServiceAPI, '/remote.php/dav/caldav/foobar/', {
 			shares: {
 				groups: [],
 				users: [{}]
@@ -93,7 +103,7 @@ describe('The calendar factory', function () {
 		});
 		expect(calendar3.isShared()).toEqual(true);
 
-		var calendar4 = Calendar('/remote.php/dav/caldav/foobar/', {
+		var calendar4 = Calendar(privateCalendarServiceAPI, '/remote.php/dav/caldav/foobar/', {
 			shares: {
 				groups: [{}],
 				users: [{}]
@@ -103,7 +113,7 @@ describe('The calendar factory', function () {
 	});
 
 	it('should be able to store warnings', function() {
-		var calendar = Calendar();
+		var calendar = Calendar(privateCalendarServiceAPI);
 
 		expect(calendar.hasWarnings()).toEqual(false);
 		expect(calendar.warnings).toEqual([]);
@@ -121,7 +131,7 @@ describe('The calendar factory', function () {
 	});
 
 	it('should be able to remember updated properties', function() {
-		var calendar = Calendar();
+		var calendar = Calendar(privateCalendarServiceAPI);
 
 		expect(calendar.hasUpdated()).toEqual(false);
 		expect(calendar.getUpdated()).toEqual([]);
@@ -163,7 +173,49 @@ describe('The calendar factory', function () {
 			_isACalendarObject: true
 		})).toBe(true);
 
-		var item = Calendar('/', {});
+		var item = Calendar(privateCalendarServiceAPI, '/', {});
 		expect(Calendar.isCalendar(item)).toBe(true);
+	});
+
+	it('should call the calendarService api - update', () => {
+		const calendar = Calendar(privateCalendarServiceAPI);
+
+		calendar.update();
+		expect(privateCalendarServiceAPI.update).toHaveBeenCalledWith(calendar);
+	});
+
+	it('should call the calendarService api - delete', () => {
+		const calendar = Calendar(privateCalendarServiceAPI);
+
+		calendar.delete();
+		expect(privateCalendarServiceAPI.delete).toHaveBeenCalledWith(calendar);
+	});
+
+	it('should call the calendarService api - share', () => {
+		const calendar = Calendar(privateCalendarServiceAPI);
+
+		calendar.share(1, 2, 3, 4);
+		expect(privateCalendarServiceAPI.share).toHaveBeenCalledWith(calendar, 1, 2, 3, 4);
+	});
+
+	it('should call the calendarService api - unshare', () => {
+		const calendar = Calendar(privateCalendarServiceAPI);
+
+		calendar.unshare(5, 6, 7, 8);
+		expect(privateCalendarServiceAPI.unshare).toHaveBeenCalledWith(calendar, 5, 6, 7, 8);
+	});
+
+	it('should call the calendarService api - publish', () => {
+		const calendar = Calendar(privateCalendarServiceAPI);
+
+		calendar.publish();
+		expect(privateCalendarServiceAPI.publish).toHaveBeenCalledWith(calendar);
+	});
+
+	it('should call the calendarService api - unpublish', () => {
+		const calendar = Calendar(privateCalendarServiceAPI);
+
+		calendar.unpublish();
+		expect(privateCalendarServiceAPI.unpublish).toHaveBeenCalledWith(calendar);
 	});
 });


### PR DESCRIPTION
move `update`, `delete`, `share`, `unshare`, `publish` and `unpublish` straight into the calendar respectively the webcal object to use these functions without having the CalendarService as dependency everywhere

this will come very handy at implementing:
- https://github.com/nextcloud/calendar/issues/24
- https://github.com/nextcloud/calendar/issues/31
- https://github.com/nextcloud/calendar/issues/42