### PR TITLE
Quick and dirty fix for entry menu align

### DIFF
--- a/css/app/calendarlist.css
+++ b/css/app/calendarlist.css
@@ -184,6 +184,10 @@
 	width: 75%;
 }
 
+.app-navigation-entry-menu {
+	right: 10px !important;
+}
+
 #app-navigation .app-navigation-entry-menu li {
 	width: auto !important;
 	float: inherit;


### PR DESCRIPTION
Not a core issue since it's correctly aligned on other apps. I'm sure there's better ways to fix this though.

cc @georgehrke @raghunayyar 

Before
![selection_069](https://cloud.githubusercontent.com/assets/2197836/20901713/138df73a-bb34-11e6-94d5-3de7e362fd76.png)

After
![selection_070](https://cloud.githubusercontent.com/assets/2197836/20901719/19581d3a-bb34-11e6-9cfd-262af6eb0bb0.png)
