### PR TITLE
app should be listed in the office category too

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -24,6 +24,7 @@ It integrates with other apps, allows you to manage calendars and events, displa
 	<documentation>
 		<user>https://docs.nextcloud.com/server/10/user_manual/pim/calendar.html</user>
 	</documentation>
+	<category>office</category>
 	<category>productivity</category>
 	<website>https://github.com/nextcloud/calendar/</website>
 	<bugs>https://github.com/nextcloud/calendar/issues</bugs>


### PR DESCRIPTION
Didn't find the app on NC11 because I looked into the 'Office & text' category. IMO it should be listed there too like contacts https://github.com/nextcloud/contacts/blob/master/appinfo/info.xml and mail https://github.com/nextcloud/mail/blob/master/appinfo/info.xml