### PR TITLE
Revert "Quick and dirty fix for entry menu align" and fix padding

### DIFF
--- a/css/app/calendarlist.css
+++ b/css/app/calendarlist.css
@@ -184,10 +184,6 @@
 	width: 75%;
 }
 
-.app-navigation-entry-menu {
-	right: 10px !important;
-}
-
 #app-navigation .app-navigation-entry-menu li {
 	width: auto !important;
 	float: inherit;


### PR DESCRIPTION
Reverts nextcloud/calendar#212

After https://github.com/nextcloud/server/pull/2545