### PR TITLE
properly catch errors while importing

### DIFF
--- a/js/app/controllers/importcontroller.js
+++ b/js/app/controllers/importcontroller.js
@@ -54,6 +54,10 @@ app.controller('ImportController', ['$scope', '$filter', 'CalendarService', 'VEv
 						if (!response) {
 							fileWrapper.errors++;
 						}
+					}).catch(function(reason) {
+						fileWrapper.state = ImportFileWrapper.stateImporting;
+						fileWrapper.progress++;
+						fileWrapper.errors++;
 					});
 				});
 			};


### PR DESCRIPTION
please review @nextcloud/calendar 

fixes #245 

try to import a broken calendar
master just stops with the progress bar at some point
this fixes the error and shows a proper error message.

Don't know when this regression was introduced