### PR TITLE
ship autosize

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -156,6 +156,7 @@ appstore:
 	"js/vendor/fullcalendar/dist/locale-all.js" \
 	"js/vendor/davclient.js/lib/client.js" \
 	"js/vendor/hsl_rgb_converter/converter.js" \
+	"js/vendor/autosize/dist/autosize.js" \
 	"COPYING" \
 	"CHANGELOG.md" \
 	$(appstore_build_directory)

--- a/controller/viewcontroller.php
+++ b/controller/viewcontroller.php
@@ -101,9 +101,11 @@ class ViewController extends Controller {
 	public function index() {
 		$runningOn = $this->config->getSystemValue('version');
 		$runningOnNextcloud10OrLater = version_compare($runningOn, '9.1', '>=');
+		$runningOnNextcloud11OrLater = version_compare($runningOn, '11', '>=');
 
 		$supportsClass = $runningOnNextcloud10OrLater;
 		$assetPipelineBroken = !$runningOnNextcloud10OrLater;
+		$needsAutosize = !$runningOnNextcloud11OrLater;
 
 		$isAssetPipelineEnabled = $this->config->getSystemValue('asset-pipeline.enabled', false);
 		if ($isAssetPipelineEnabled && $assetPipelineBroken) {
@@ -150,6 +152,7 @@ class ViewController extends Controller {
 			'defaultColor' => $defaultColor,
 			'webCalWorkaround' => $webCalWorkaround,
 			'isPublic' => false,
+			'needsAutosize' => $needsAutosize,
 		]);
 	}
 
@@ -162,9 +165,11 @@ class ViewController extends Controller {
 	public function publicIndex() {
 		$runningOn = $this->config->getSystemValue('version');
 		$runningOnServer91OrLater = version_compare($runningOn, '9.1', '>=');
+		$runningOnNextcloud11OrLater = version_compare($runningOn, '11', '>=');
 
 		$supportsClass = $runningOnServer91OrLater;
 		$assetPipelineBroken = !$runningOnServer91OrLater;
+		$needsAutosize = !$runningOnNextcloud11OrLater;
 
 		$isAssetPipelineEnabled = $this->config->getSystemValue('asset-pipeline.enabled', false);
 		if ($isAssetPipelineEnabled && $assetPipelineBroken) {
@@ -182,6 +187,7 @@ class ViewController extends Controller {
 			'isPublic' => true,
 			'shareURL' => $this->request->getServerProtocol() . '://' . $this->request->getServerHost() . $this->request->getRequestUri(),
 			'previewImage' => $this->urlGenerator->getAbsoluteURL($this->urlGenerator->imagePath('core', 'favicon-touch.png')),
+			'needsAutosize' => $needsAutosize,
 		], 'public');
 		$response->addHeader('X-Frame-Options', 'ALLOW');
 		$csp = new ContentSecurityPolicy();

--- a/js/bower.json
+++ b/js/bower.json
@@ -8,7 +8,8 @@
     "ical.js": "1.2.2",
     "davclient.js": "evert/davclient.js",
     "fullcalendar": "3.0.1",
-    "hsl_rgb_converter": "https://github.com/kayellpeee/hsl_rgb_converter.git"
+    "hsl_rgb_converter": "https://github.com/kayellpeee/hsl_rgb_converter.git",
+    "autosize": "^3.0.20"
   },
   "devDependencies": {
     "angular-mocks": "1.5.8"

--- a/templates/main.php
+++ b/templates/main.php
@@ -54,6 +54,10 @@ $scripts = [
 	'public/app.min'
 ];
 
+if ($_['needsAutosize']) {
+	$scripts[] = 'vendor/autosize/dist/autosize';
+}
+
 foreach ($scripts as $script) {
 	script('calendar', $script);
 }

--- a/tests/php/controller/viewcontrollerTest.php
+++ b/tests/php/controller/viewcontrollerTest.php
@@ -106,7 +106,7 @@ class ViewControllerTest extends \PHPUnit_Framework_TestCase {
 	/**
 	 * @dataProvider indexDataProvider
 	 */
-	public function testIndex($isAssetPipelineEnabled, $showAssetPipelineError, $serverVersion, $expectsSupportsClass, $expectsWebcalWorkaround) {
+	public function testIndex($isAssetPipelineEnabled, $showAssetPipelineError, $serverVersion, $expectsSupportsClass, $expectsWebcalWorkaround, $needsAutosize) {
 		$this->config->expects($this->at(0))
 			->method('getSystemValue')
 			->with('version')
@@ -180,6 +180,7 @@ class ViewControllerTest extends \PHPUnit_Framework_TestCase {
 				'defaultColor' => '#ff00ff',
 				'webCalWorkaround' => $expectsWebcalWorkaround,
 				'isPublic' => false,
+				'needsAutosize' => $needsAutosize,
 			], $actual->getParams());
 			$this->assertEquals('main', $actual->getTemplateName());
 		}
@@ -188,10 +189,11 @@ class ViewControllerTest extends \PHPUnit_Framework_TestCase {
 
 	public function indexDataProvider() {
 		return [
-			[true, true, '9.0.5.2', false, 'yes'],
-			[true, false, '9.1.0.0', true, 'no'],
-			[false, false, '9.0.5.2', false, 'yes'],
-			[false, false, '9.1.0.0', true, 'no']
+			[true, true, '9.0.5.2', false, 'yes', true],
+			[true, false, '9.1.0.0', true, 'no', true],
+			[false, false, '9.0.5.2', false, 'yes', true],
+			[false, false, '9.1.0.0', true, 'no', true],
+			[false, false, '11.0.1', true, 'no', false],
 		];
 	}
 
@@ -262,6 +264,7 @@ class ViewControllerTest extends \PHPUnit_Framework_TestCase {
 			'defaultColor' => '#ff00ff',
 			'webCalWorkaround' => 'no',
 			'isPublic' => false,
+			'needsAutosize' => true,
 		], $actual->getParams());
 		$this->assertEquals('main', $actual->getTemplateName());
 	}
@@ -342,6 +345,7 @@ class ViewControllerTest extends \PHPUnit_Framework_TestCase {
 			'defaultColor' => '#ff00ff',
 			'webCalWorkaround' => 'no',
 			'isPublic' => false,
+			'needsAutosize' => true,
 		], $actual->getParams());
 		$this->assertEquals('main', $actual->getTemplateName());
 	}
@@ -356,7 +360,7 @@ class ViewControllerTest extends \PHPUnit_Framework_TestCase {
 	/**
 	 * @dataProvider indexPublicDataProvider
 	 */
-	public function testPublicIndex($isAssetPipelineEnabled, $showAssetPipelineError, $serverVersion, $expectsSupportsClass) {
+	public function testPublicIndex($isAssetPipelineEnabled, $showAssetPipelineError, $serverVersion, $expectsSupportsClass, $needsAutosize) {
 		$this->config->expects($this->at(0))
 			->method('getSystemValue')
 			->with('version')
@@ -391,6 +395,7 @@ class ViewControllerTest extends \PHPUnit_Framework_TestCase {
 				'shareURL' => '://',
 				'previewImage' => null,
 				'firstRun' => 'no',
+				'needsAutosize' => $needsAutosize,
 			], $actual->getParams());
 			$this->assertEquals('main', $actual->getTemplateName());
 		}
@@ -399,10 +404,11 @@ class ViewControllerTest extends \PHPUnit_Framework_TestCase {
 
 	public function indexPublicDataProvider() {
 		return [
-			[true, true, '9.0.5.2', false],
-			[true, false, '9.1.0.0', true],
-			[false, false, '9.0.5.2', false],
-			[false, false, '9.1.0.0', true]
+			[true, true, '9.0.5.2', false, true],
+			[true, false, '9.1.0.0', true, true],
+			[false, false, '9.0.5.2', false, true],
+			[false, false, '9.1.0.0', true, true],
+			[false, false, '11.0.0', true, false],
 		];
 	}
 


### PR DESCRIPTION
Since version 1.4.1 we added autoresizable inputs for title, description and location.

Autoresize was only added with Nextcloud 11
=> ship autosize with calendar and include it if version number is lower than 11