### PR TITLE
fixes unittest that fails recently

### DIFF
--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -12,11 +12,15 @@
  */
 define('PHPUNIT_RUN', 1);
 
+// ugly hack to fix issues with template code using static code
+$_SERVER['REQUEST_URI'] = '/index.php/apps/calendar/';
+$_SERVER['SCRIPT_NAME'] = '/index.php';
+
 require_once __DIR__.'/../../../lib/base.php';
 
 if (version_compare(implode('.', \OCP\Util::getVersion()), '8.2', '>=')) {
 	\OC::$loader->addValidRoot(OC::$SERVERROOT . '/tests');
-	\OC_App::loadApp('mail');
+	\OC_App::loadApp('calendar');
 }
 
 if(!class_exists('PHPUnit_Framework_TestCase')) {


### PR DESCRIPTION
Some unit tests fail, because they test code that uses the template engine. Some parts of Nextcloud's template engine use static code to access `IRequest`. Therefore we can't properly inject a correct `IRequest` object and use this hack.