### PR TITLE
show proper am/pm labels next to timepicker

### DIFF
--- a/js/app/directives/datetimepickerDirective.js
+++ b/js/app/directives/datetimepickerDirective.js
@@ -88,7 +88,7 @@ app.directive('ocdatetimepicker', function($compile, $timeout) {
 			}
 			function initTimepicker() {
 				element.find('.events--time').timepicker({
-					showPeriodLabels: false,
+					showPeriodLabels: (localeData.longDateFormat('LT').toLowerCase().indexOf('a') !== -1),
 					showLeadingZero: true,
 					showPeriod: (localeData.longDateFormat('LT').toLowerCase().indexOf('a') !== -1),
 					duration: 0,


### PR DESCRIPTION
fixes #345 

please review @tcitworld @skjnldsv 

before:
![](https://cloud.githubusercontent.com/assets/878997/23119299/f1c36094-f757-11e6-91e2-c0f82f3c9c3e.png)

after:
<img width="513" alt="calendar - nextcloud chromium today at 11 11 57 am" src="https://cloud.githubusercontent.com/assets/1250540/23120630/6e62f9f2-f75d-11e6-9e40-794a5eb78e87.png">
