### PR TITLE
fix date timepicker layout in events editors

### DIFF
--- a/css/app/eventdialog.css
+++ b/css/app/eventdialog.css
@@ -95,12 +95,26 @@
 }
 
 .events .events--fieldset select {
-	width: 99.5%;
+	width: 100%;
 	margin-right: 0;
 }
 
+.events .event-time-interior {
+	width: 170px;
+}
+
 .events .events--date {
-	width: 70px;
+	width: 55%;
+	border-right-width: 0;
+	border-top-right-radius: 0;
+	border-bottom-right-radius: 0;
+	margin-right: 0;
+}
+
+.events .events--date:focus,
+.events .events--date:hover {
+	border-right-width: 1px;
+	border-right-style: solid;
 }
 
 .advanced .events--date {
@@ -112,7 +126,7 @@
 }
 
 .events .h2.events--input {
-	width: 96%;
+	width: 100%;
 	font-size: 20px;
 }
 
@@ -122,7 +136,17 @@
 }
 
 .events .events--time {
-	width: 60px;
+	width: 45%;
+	border-left: 0;
+	border-top-left-radius: 0;
+	border-bottom-left-radius: 0;
+	margin-right: 0;
+}
+
+.events .events--time:focus,
+.events .events--time:hover {
+	border-left-width: 1px;
+	border-left-style: solid;
 }
 
 .events .events--time[disabled] {
@@ -139,7 +163,7 @@
 }
 
 .events .events--checkbox {
-	padding: 3px 0;
+	padding: 3px 0 10px;
 }
 
 .modal-open .modal.popover .modal-content {

--- a/css/app/eventdialog.css
+++ b/css/app/eventdialog.css
@@ -44,20 +44,8 @@
 	float: right;
 }
 
-.advanced .start-end-container {
-	margin-right: 15px;
-}
-
 .advanced .advanced--checkbox {
 	margin: 10px 0;
-}
-
-.advanced .timezone-container {
-	margin: 4px -17px;
-}
-
-.advanced .timezone-select {
-	width: 110% !important; /* very dirty hack to fix alignment issues. */
 }
 
 .modal-open .modal.popover,
@@ -99,26 +87,44 @@
 	margin-right: 0;
 }
 
+.advanced .event-time-interior,
 .events .event-time-interior {
-	width: 170px;
+	width: 40%;
 }
 
+@media (max-width: 1600px) {
+	.advanced .event-time-interior {
+		width: 45%;
+	}
+}
+
+@media (max-width: 1450px) {
+	.advanced .event-time-interior {
+		width: 48%;
+	}
+}
+
+@media (max-width: 1350px) {
+	.advanced .event-time-interior {
+		width: 100%;
+	}
+}
+
+.advanced .events--date,
 .events .events--date {
-	width: 55%;
+	width: calc(100% - 70px);
 	border-right-width: 0;
 	border-top-right-radius: 0;
 	border-bottom-right-radius: 0;
 	margin-right: 0;
 }
 
+.advanced .events--date:focus,
+.advanced .events--date:hover,
 .events .events--date:focus,
 .events .events--date:hover {
 	border-right-width: 1px;
 	border-right-style: solid;
-}
-
-.advanced .events--date {
-	width: 100%;
 }
 
 .events .events--input__full {
@@ -135,14 +141,18 @@
 	display: inline !important;
 }
 
+.advanced .events--time,
 .events .events--time {
-	width: 45%;
+	width: 70px;
 	border-left: 0;
 	border-top-left-radius: 0;
 	border-bottom-left-radius: 0;
 	margin-right: 0;
+	text-align: right;
 }
 
+.advanced .events--time:focus,
+.advanced .events--time:hover,
 .events .events--time:focus,
 .events .events--time:hover {
 	border-left-width: 1px;
@@ -156,10 +166,6 @@
 .events--textarea,
 .advanced--textarea {
 	resize: none;
-}
-
-.advanced .events--time {
-	width: 100%;
 }
 
 .events .events--checkbox {

--- a/templates/editor.popover.php
+++ b/templates/editor.popover.php
@@ -20,12 +20,12 @@
 
 		<fieldset class="event-time events--fieldset" ng-disabled="readOnly">
 			<div class="event-time-interior pull-left">
-				<span><?php p($l->t('starts')); ?></span>
+				<span><?php p($l->t('Starts')); ?></span>
 				<ocdatetimepicker ng-model="properties.dtstart.value" disabletime="properties.allDay" datetabindex="103" timetabindex="104" readonly="readOnly"></ocdatetimepicker>
 				<span ng-show="edittimezone">{{ properties.dtstart.parameters.zone | timezoneFilter }}</span>
 			</div>
 			<div class="event-time-interior pull-right">
-				<span><?php p($l->t('ends')); ?></span>
+				<span><?php p($l->t('Ends')); ?></span>
 				<ocdatetimepicker ng-model="properties.dtend.value" disabletime="properties.allDay" datetabindex="105" timetabindex="106" readonly="readOnly"></ocdatetimepicker>
 				<span ng-show="edittimezone">{{ properties.dtend.parameters.zone | timezoneFilter }}</span>
 			</div>

--- a/templates/editor.sidebar.php
+++ b/templates/editor.sidebar.php
@@ -20,14 +20,14 @@
 				</fieldset>
 
 				<fieldset class="advanced--fieldset start-end-container" ng-disabled="readOnly">
-					<div class="event-time-interior pull-left pull-half">
-						<span><?php p($l->t('starts')); ?></span>
+					<div class="event-time-interior pull-left">
+						<span><?php p($l->t('Starts')); ?></span>
 						<ocdatetimepicker ng-model="properties.dtstart.value" disabletime="properties.allDay" datetabindex="203" timetabindex="204" readonly="readOnly"></ocdatetimepicker>
 						<select ng-options="timezone.value as timezone.displayname | timezoneWithoutContinentFilter group by timezone.group for timezone in timezones" ng-model="properties.dtstart.parameters.zone" ng-show="edittimezone || readOnly" ng-disabled="properties.allDay"
 								ng-change="loadTimezone(properties.dtstart.parameters.zone)" class="timezone-select" tabindex="205"></select>
 					</div>
-					<div class="event-time-interior pull-right pull-half">
-						<span><?php p($l->t('ends')); ?></span>
+					<div class="event-time-interior pull-right">
+						<span><?php p($l->t('Ends')); ?></span>
 						<ocdatetimepicker ng-model="properties.dtend.value" disabletime="properties.allDay" datetabindex="206" timetabindex="207" readonly="readOnly"></ocdatetimepicker>
 						<select ng-options="timezone.value as timezone.displayname | timezoneWithoutContinentFilter group by timezone.group for timezone in timezones" ng-model="properties.dtend.parameters.zone" ng-show="edittimezone || readOnly" ng-disabled="properties.allDay"
 							ng-change="loadTimezone(properties.dtend.parameters.zone)" class="timezone-select" tabindex="208"></select>


### PR DESCRIPTION
fixes #72 

Before = Blue
After = green

<img width="1920" alt="calendar - nextcloud chromium today at 10 42 21 pm" src="https://cloud.githubusercontent.com/assets/1250540/24726109/81400ada-1a51-11e7-99f3-6b0106593270.png">
<img width="1920" alt="calendar - nextcloud chromium today at 10 42 34 pm" src="https://cloud.githubusercontent.com/assets/1250540/24726112/81725440-1a51-11e7-9436-034d327b1a19.png">
<img width="1920" alt="calendar - nextcloud chromium today at 10 43 07 pm" src="https://cloud.githubusercontent.com/assets/1250540/24726110/8171672e-1a51-11e7-9c9f-4f27f714bccb.png">
<img width="1920" alt="calendar - nextcloud chromium today at 10 43 18 pm" src="https://cloud.githubusercontent.com/assets/1250540/24726113/8176055e-1a51-11e7-900c-27172cf1bb6d.png">
<img width="1453" alt="calendar - nextcloud chromium today at 10 43 37 pm" src="https://cloud.githubusercontent.com/assets/1250540/24726111/81721584-1a51-11e7-89ed-c589b474e956.png">
<img width="683" alt="calendar - nextcloud chromium today at 10 44 16 pm" src="https://cloud.githubusercontent.com/assets/1250540/24726117/835b90dc-1a51-11e7-99f0-d22984ea84c2.png">
