### PR TITLE
increase font-size of fullcalendar labels

### DIFF
--- a/css/app/calendar.css
+++ b/css/app/calendar.css
@@ -43,3 +43,9 @@
 	max-width: 0 !important;
 	overflow: hidden !important;
 }
+
+#fullcalendar .fc-axis,
+#fullcalendar .fc-day-header {
+	font-size: 100%;
+	opacity: .5;
+}


### PR DESCRIPTION
fixes #166 

before:
![calendar - nextcloud chromium today at 11 08 36 pm](https://cloud.githubusercontent.com/assets/1250540/24727031/d66893d0-1a54-11e7-9aad-3050925a8fe5.png)

after:
![calendar - nextcloud chromium today at 11 07 31 pm](https://cloud.githubusercontent.com/assets/1250540/24727040/db07f002-1a54-11e7-83e8-16df8890e436.png)
