### PR TITLE
fix click on disabled timeinput in firefox in sidebar

### DIFF
--- a/css/app/eventdialog.css
+++ b/css/app/eventdialog.css
@@ -159,6 +159,7 @@
 	border-left-style: solid;
 }
 
+.advanced .events--time[disabled],
 .events .events--time[disabled] {
 	pointer-events: none;
 }


### PR DESCRIPTION
fixes #388 

