### PR TITLE
Refer to #314 - Make grid darker

### DIFF
--- a/css/app/calendarlist.css
+++ b/css/app/calendarlist.css
@@ -524,7 +524,9 @@ ul.dropdown-menu li > a:hover {
 .fc-unthemed .fc-divider,
 .fc-unthemed .fc-row,
 .fc-unthemed .fc-popover {
-	border-color: #ebebeb;
+	border-color: #f8f8f8;
+	border-left-color: #ebebeb;
+	border-right-color: #ebebeb;
 }
 
 /* properly size events */

--- a/css/app/calendarlist.css
+++ b/css/app/calendarlist.css
@@ -514,7 +514,7 @@ ul.dropdown-menu li > a:hover {
 }
 
 .fc-unthemed tr:nth-child(even) td {
-	border-top-color: #f8f8f8;
+	border-top-color: #ebebeb;
 }
 
 .fc-unthemed th,
@@ -524,7 +524,7 @@ ul.dropdown-menu li > a:hover {
 .fc-unthemed .fc-divider,
 .fc-unthemed .fc-row,
 .fc-unthemed .fc-popover {
-	border-color: #f8f8f8;
+	border-color: #ebebeb;
 }
 
 /* properly size events */


### PR DESCRIPTION
fixes #314
The left sidebar from NextCloud use a right border in #ebebeb _(grey)_. The grid use the color #f8f8f8 _(darker grey)_. I changed the color to #ebebeb to improve the visibility. Maybe this is a little bit better to see the borders.


Before:
![before](https://cloud.githubusercontent.com/assets/1473674/25311794/4602b5f0-280a-11e7-8919-da00ef4f3ef6.PNG)


After:
![after](https://cloud.githubusercontent.com/assets/1473674/25311795/4b07c41e-280a-11e7-8c21-313b49755eab.PNG)
