### PR TITLE
fix datepicker layout for Nextcloud 12

### DIFF
--- a/css/app/datepicker.css
+++ b/css/app/datepicker.css
@@ -66,6 +66,10 @@
 	display: none;
 }
 
+#datepicker td button {
+	min-height: 0;
+}
+
 .datepicker-heading {
 	margin: 0 5px;
 }


### PR DESCRIPTION
some change in the core styles messed with out datepicker

before:
<img width="278" alt="before" src="https://cloud.githubusercontent.com/assets/1250540/26036219/de5690c6-38d9-11e7-874d-968252469739.png">

after:
<img width="257" alt="calendar - nextcloud chromium today at 7 15 16 pm" src="https://cloud.githubusercontent.com/assets/1250540/26036225/f2d17e4e-38d9-11e7-90dd-1287319ffd16.png">
