### PR TITLE
fix clicking a newly created public share

### DIFF
--- a/js/app/controllers/calendarlistcontroller.js
+++ b/js/app/controllers/calendarlistcontroller.js
@@ -167,8 +167,7 @@ app.controller('CalendarListController', ['$scope', '$rootScope', '$window', 'Ha
 				item.calendar.publish().then(function (response) {
 					if (response) {
 						CalendarService.get(item.calendar.url).then(function (calendar) {
-							item.calendar.publishurl = calendar.publishurl;
-							item.calendar.publicurl = calendar.publicurl;
+							item.calendar.publicToken = calendar.publicToken;
 							item.calendar.published = true;
 						});
 					}


### PR DESCRIPTION
we replaced `publishurl` and `publicurl` with a single `publicToken`

Therefore clicking on a newly created sharing link will take you to a 404 page.
This PR fixes this.