### PR TITLE
add box sizing to fix date timepicker layout for nc 9,10,11

### DIFF
--- a/css/app/eventdialog.css
+++ b/css/app/eventdialog.css
@@ -111,6 +111,13 @@
 }
 
 .advanced .events--date,
+.events .events--date,
+.advanced .events--time,
+.events .events--time {
+	box-sizing: border-box;
+}
+
+.advanced .events--date,
 .events .events--date {
 	width: calc(100% - 70px);
 	border-right-width: 0;


### PR DESCRIPTION
before:

<img width="610" alt="calendar - nextcloud chromium today at 8 56 15 pm" src="https://cloud.githubusercontent.com/assets/1250540/26286547/b9a898f2-3e68-11e7-975c-a233e4c0bdcc.png">

after:

<img width="710" alt="calendar - nextcloud chromium today at 9 00 27 pm" src="https://cloud.githubusercontent.com/assets/1250540/26286549/bced6416-3e68-11e7-8e10-2343309612b4.png">
