### PR TITLE
Fix double scrollbar in advanced editor

### DIFF
--- a/css/app/eventdialog.css
+++ b/css/app/eventdialog.css
@@ -258,12 +258,12 @@ button.delete:focus {
 }
 
 .advanced .sidebar-top {
-	height: calc(100% - 119px);
+	height: calc(100% - 131px);
 	overflow-y: scroll;
 }
 
 .advanced .sidebar-top.new {
-	height: calc(100% - 83px);
+	height: calc(100% - 91px);
 }
 
 .advanced .pull-quarter {


### PR DESCRIPTION
Fix double scrollbar in advanced Editor. The height is not correct. It shows two scrollbars and a half button in NC12.0.0 (calendar Version 1.5.3).

Before:
![image](https://cloud.githubusercontent.com/assets/1473674/26322948/63960a06-3f2d-11e7-9b54-0ca2b6ae0a36.png)

After:
![image](https://cloud.githubusercontent.com/assets/1473674/26322954/6ba9a658-3f2d-11e7-8339-89796aa1b6c4.png)
