### PR TITLE
Spelling: iframe

### DIFF
--- a/templates/part.publicinformations.php
+++ b/templates/part.publicinformations.php
@@ -45,7 +45,7 @@
 		<fieldset class="settings-fieldset">
 			<ul class="settings-fieldset-interior">
 				<li class="settings-fieldset-interior-item">
-					<label><?php p($l->t('IFrame to integrate')); ?></label>
+					<label><?php p($l->t('Iframe to integrate')); ?></label>
 			    <textarea class="integration-code"
 			      type="text"
 			      ng-value="integration(item)"


### PR DESCRIPTION
It used to be IFRAME https://www.w3.org/TR/1999/REC-html401-19991224/present/frames.html#h-16.5
for reasons unknown, but now it is "iframe"
https://www.w3.org/TR/2014/REC-html5-20141028/embedded-content-0.html#the-iframe-element
Added something to start of sentence to avoid issue with Iframe or iframe.