### PR TITLE
show displayname instead of userid after creating a new user share

### DIFF
--- a/js/app/controllers/calendarlistcontroller.js
+++ b/js/app/controllers/calendarlistcontroller.js
@@ -187,23 +187,25 @@ app.controller('CalendarListController', ['$scope', '$rootScope', '$window', 'Ha
 			calendar.prepareUpdate();
 		};
 
-		$scope.onSelectSharee = function (item, model, label, calendar) {
-			// Remove content from text box
-			calendar.selectedSharee = '';
+		$scope.onSelectSharee = function (item, model, label, calendarItem) {
+			const calendar = calendarItem.calendar;
 			// Create a default share with the user/group, read only
-			calendar.share(item.type, item.identifier, false, false).then(function() {
+			calendar.share(item.type, item.identifier, item.displayname, false, false).then(function() {
+				// Remove content from text box
+				calendarItem.selectedSharee = '';
+
 				$scope.$apply();
 			});
 		};
 
-		$scope.updateExistingUserShare = function(calendar, userId, writable) {
-			calendar.share(constants.SHARE_TYPE_USER, userId, writable, true).then(function() {
+		$scope.updateExistingUserShare = function(calendar, displayname, userId, writable) {
+			calendar.share(constants.SHARE_TYPE_USER, userId, displayname, writable, true).then(function() {
 				$scope.$apply();
 			});
 		};
 
-		$scope.updateExistingGroupShare = function(calendar, groupId, writable) {
-			calendar.share(constants.SHARE_TYPE_GROUP, groupId, writable, true).then(function() {
+		$scope.updateExistingGroupShare = function(calendar, groupId, displayname, writable) {
+			calendar.share(constants.SHARE_TYPE_GROUP, groupId, displayname, writable, true).then(function() {
 				$scope.$apply();
 			});
 		};
@@ -264,6 +266,7 @@ app.controller('CalendarListController', ['$scope', '$rootScope', '$window', 'Ha
 				users = users.map(function(item){
 					return {
 						display: item.label,
+						displayname: item.label,
 						type: constants.SHARE_TYPE_USER,
 						identifier: item.value.shareWith
 					};
@@ -272,6 +275,7 @@ app.controller('CalendarListController', ['$scope', '$rootScope', '$window', 'Ha
 				groups = groups.map(function(item){
 					return {
 						display: item.label + ' (' + t('calendar', 'group') + ')',
+						displayname: item.label,
 						type: constants.SHARE_TYPE_GROUP,
 						identifier: item.value.shareWith
 					};

--- a/js/app/models/calendarmodel.js
+++ b/js/app/models/calendarmodel.js
@@ -338,8 +338,8 @@ app.factory('Calendar', function($window, Hook, VEventService, TimezoneService, 
 			return context.calendarService.delete(iface);
 		};
 
-		iface.share = function(shareType, shareWith, writable, existingShare) {
-			return context.calendarService.share(iface, shareType, shareWith, writable, existingShare);
+		iface.share = function(shareType, shareWith, shareWithDisplayname, writable, existingShare) {
+			return context.calendarService.share(iface, shareType, shareWith, shareWithDisplayname, writable, existingShare);
 		};
 
 		iface.unshare = function(shareType, shareWith, writable, existingShare) {

--- a/js/app/service/calendarService.js
+++ b/js/app/service/calendarService.js
@@ -509,11 +509,12 @@ app.service('CalendarService', function(DavClient, StringUtility, XMLUtility, Ca
 	 * @param {Calendar|WebCal} calendar
 	 * @param {number} shareType
 	 * @param {string} shareWith
+	 * @param {string} shareWithDisplayname
 	 * @param {boolean} writable
 	 * @param {boolean} existingShare
 	 * @returns {Promise}
 	 */
-	privateAPI.share = function(calendar, shareType, shareWith, writable, existingShare) {
+	privateAPI.share = function(calendar, shareType, shareWith, shareWithDisplayname, writable, existingShare) {
 		const [skeleton, oSetChildren] = XMLUtility.getRootSkeleton(
 			[DavClient.NS_OWNCLOUD, 'o:share'], [DavClient.NS_OWNCLOUD, 'o:set']);
 
@@ -552,17 +553,16 @@ app.service('CalendarService', function(DavClient, StringUtility, XMLUtility, Ca
 				return;
 			}
 
-			//TODO - fix displayname
 			if (shareType === SHARE_USER) {
 				calendar.shares.users.push({
 					id: shareWith,
-					displayname: shareWith,
+					displayname: shareWithDisplayname,
 					writable: writable
 				});
 			} else {
 				calendar.shares.groups.push({
 					id: shareWith,
-					displayname: shareWith,
+					displayname: shareWithDisplayname,
 					writable: writable
 				});
 			}

--- a/templates/part.calendarlist.item.php
+++ b/templates/part.calendarlist.item.php
@@ -153,7 +153,7 @@
 		   ng-model="item.selectedSharee"
 		   placeholder="<?php p($l->t('Share with users or groups')); ?>"
 		   type="text"
-		   typeahead-on-select="onSelectSharee($item, $model, $label, item.calendar)"
+		   typeahead-on-select="onSelectSharee($item, $model, $label, item)"
 		   typeahead-loading="loadingSharees"
 		   typeahead-template-url="customShareMatchTemplate.html"
 		   uib-typeahead="sharee.display for sharee in findSharee($viewValue, item.calendar)">
@@ -166,7 +166,7 @@
 				<input id="checkbox_sharedWithUser_{{ $parent.$index }}_{{ $id }}"
 					   name="editable"
 					   class="checkbox"
-					   ng-change="updateExistingUserShare(item.calendar, userShare.id, userShare.writable)"
+					   ng-change="updateExistingUserShare(item.calendar, userShare.id, userShare.displayname, userShare.writable)"
 					   ng-model="userShare.writable"
 					   type="checkbox"
 					   value="edit">
@@ -193,7 +193,7 @@
 				<input id="checkbox_sharedWithGroup_{{ $parent.$index }}_{{ $id }}"
 					   name="editable"
 					   class="checkbox"
-					   ng-change="updateExistingGroupShare(item.calendar, groupShare.id, groupShare.writable)"
+					   ng-change="updateExistingGroupShare(item.calendar, groupShare.id, groupShare.displayname, groupShare.writable)"
 					   ng-model="groupShare.writable"
 					   type="checkbox"
 					   value="edit">

--- a/tests/js/unit/models/calendarModelSpec.js
+++ b/tests/js/unit/models/calendarModelSpec.js
@@ -201,8 +201,8 @@ describe('The calendar factory', function () {
 	it('should call the calendarService api - share', () => {
 		const calendar = Calendar(privateCalendarServiceAPI);
 
-		calendar.share(1, 2, 3, 4);
-		expect(privateCalendarServiceAPI.share).toHaveBeenCalledWith(calendar, 1, 2, 3, 4);
+		calendar.share(1, 2, 3, 4, 5);
+		expect(privateCalendarServiceAPI.share).toHaveBeenCalledWith(calendar, 1, 2, 3, 4, 5);
 	});
 
 	it('should call the calendarService api - unshare', () => {


### PR DESCRIPTION
fixes #459 

(also empties the search field after creating new share)