### PR TITLE
Watch css files and remove lint from watch task

### DIFF
--- a/js/gulpfile.js
+++ b/js/gulpfile.js
@@ -74,12 +74,13 @@ const vendorCssSources = [
 ];
 
 const testSources = ['../tests/js/unit/**/*.js'];
-const watchSources = jsSources.concat(testSources).concat(['*.js']);
-const lintSources = watchSources;
+const lintJsSources = jsSources.concat(testSources).concat(['*.js']);
+const watchSources = lintJsSources.concat(cssSources);
 
 // tasks
-gulp.task('default', ['lint', 'csslint', '_buildSource', '_buildVendor']);
-gulp.task('build', ['lint', 'csslint', '_buildSource']);
+gulp.task('lint', ['jslint', 'csslint']);
+gulp.task('default', ['lint', '_buildSource', '_buildVendor']);
+gulp.task('build', ['lint', '_buildSource']);
 
 gulp.task('_buildAndMinifyCSSSources', gulpsync.sync(['_buildCSSSources', '_minifyCSSSources']));
 gulp.task('_buildAndMinifyJavaScriptSources', gulpsync.sync(['_buildJavaScriptSources', '_minifyJavaScriptSources']));
@@ -202,8 +203,8 @@ gulp.task('_minifyIEJavaScriptVendor', () => {
 		.pipe(gulp.dest(destinationFolder));
 });
 
-gulp.task('lint', () => {
-	return gulp.src(lintSources)
+gulp.task('jslint', () => {
+	return gulp.src(lintJsSources)
 		.pipe(jshint('.jshintrc'))
 		.pipe(jshint.reporter('default'))
 		.pipe(jshint.reporter('fail'));
@@ -220,7 +221,7 @@ gulp.task('csslint', () => {
 });
 
 gulp.task('watch', () => {
-	gulp.watch(watchSources, ['build']);
+	gulp.watch(watchSources, ['_buildSource']);
 });
 
 gulp.task('karma', (done) => {


### PR DESCRIPTION
I added the css files in the watch files to allow a dev to modify css without building by hand.

**Proposition:** I added a task lint that lints the css and the js files, but I don't think it is useful to lint in the watch task. Linters are long, while you are developing it is frustrating to wait for the build task... The linters could be a precommit hook instead.