### PR TITLE
Fix patch logic: Properly remove parameter if it no longer exists

### DIFF
--- a/js/app/models/simpleEventModel.js
+++ b/js/app/models/simpleEventModel.js
@@ -278,7 +278,7 @@ app.factory('SimpleEvent', function () {
 				if (simple.parameters[p]) {
 					prop.setParameter(p, simple.parameters[p]);
 				} else {
-					prop.removeParameter(simple.parameters[p]);
+					prop.removeParameter(p);
 				}
 			});
 		},


### PR DESCRIPTION
I'm committing this in behalf of @georgehrke, thanks for providing the fix.