### PR TITLE
fix property names in MailerService

### DIFF
--- a/js/app/service/mailerservice.js
+++ b/js/app/service/mailerservice.js
@@ -31,9 +31,9 @@ app.service('MailerService', ['$rootScope', 'DavClient',
 				requesttoken : oc_requesttoken
 			};
 			var mailBody = {
-				'to': dest,
+				'recipient': dest,
 				'url': url,
-				'name': name
+				'calendarName': name
 			};
 			return DavClient.request('POST', $rootScope.baseUrl + 'public/sendmail', headers, JSON.stringify(mailBody));
 		};


### PR DESCRIPTION
stupid me changed names in Emailcontroller in https://github.com/nextcloud/calendar/commit/5aefb45ad4e0fcc533e89c47acfea13de6b26323 but didn't change property names in javascript 

required for 1.5.4