### PR TITLE
autocompletion: Use 'POST' instead of 'GET' method to access API

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -35,8 +35,8 @@ return [
 		['name' => 'settings#getConfig', 'url' => '/v1/config', 'verb' => 'GET'],
 		['name' => 'settings#setConfig', 'url' => '/v1/config', 'verb' => 'POST'],
 		//Autocompletion
-		['name' => 'contact#searchAttendee', 'url' => '/v1/autocompletion/attendee', 'verb' => 'GET'],
-		['name' => 'contact#searchLocation', 'url' => '/v1/autocompletion/location', 'verb' => 'GET'],
+		['name' => 'contact#searchAttendee', 'url' => '/v1/autocompletion/attendee', 'verb' => 'POST'],
+		['name' => 'contact#searchLocation', 'url' => '/v1/autocompletion/location', 'verb' => 'POST'],
 
 		['name' => 'proxy#proxy', 'url' => '/v1/proxy', 'verb' => 'GET'],
 	]

--- a/js/app/service/autocompletionservice.js
+++ b/js/app/service/autocompletionservice.js
@@ -26,20 +26,16 @@ app.service('AutoCompletionService', ['$rootScope', '$http',
 		'use strict';
 
 		this.searchAttendee = function(name) {
-			return $http.get($rootScope.baseUrl + 'autocompletion/attendee', {
-				params: {
-					search: name
-				}
+			return $http.post($rootScope.baseUrl + 'autocompletion/attendee', {
+				search: name
 			}).then(function (response) {
 				return response.data;
 			});
 		};
 
 		this.searchLocation = function(address) {
-			return $http.get($rootScope.baseUrl + 'autocompletion/location', {
-				params: {
-					location: address
-				}
+			return $http.post($rootScope.baseUrl + 'autocompletion/location', {
+				location: address
 			}).then(function (response) {
 				return response.data;
 			});

--- a/tests/js/unit/services/autocompletionServiceSpec.js
+++ b/tests/js/unit/services/autocompletionServiceSpec.js
@@ -17,9 +17,11 @@ describe('AutoCompletion Service', function () {
 	});
 
 	it('should load attendees from the server', function() {
-		http.expect('GET', 'fancy-url/autocompletion/attendee?search=hans+dieter').respond(200, [{ foo: 'bar' }]);
+		var search = 'hans dieter';
 
-		AutoCompletionService.searchAttendee('hans dieter').then(function(result) {
+		http.expect('POST', 'fancy-url/autocompletion/attendee', { search: search }).respond(200, [{ foo: 'bar' }]);
+
+		AutoCompletionService.searchAttendee(search).then(function(result) {
 			expect(result).toEqual([{ foo: 'bar' }]);
 		});
 
@@ -27,9 +29,11 @@ describe('AutoCompletion Service', function () {
 	});
 
 	it('should load locations from the server', function() {
-		http.expect('GET', 'fancy-url/autocompletion/location?location=place+123').respond(200, [{ bar: 'foo' }]);
+		var location = 'place 123';
 
-		AutoCompletionService.searchLocation('place 123').then(function(result) {
+		http.expect('POST', 'fancy-url/autocompletion/location', { location: location }).respond(200, [{ bar: 'foo' }]);
+
+		AutoCompletionService.searchLocation(location).then(function(result) {
 			expect(result).toEqual([{ bar: 'foo' }]);
 		});
 


### PR DESCRIPTION
This prevents including the search term in webserver logs.
It will also break all clients using this API endpoint, which is
fine, as non-OCS APIs are meant to be private and shouldn't be used
by 3rdparty apps.