### PR TITLE
Add a public og:description meta tag

### DIFF
--- a/templates/main.php
+++ b/templates/main.php
@@ -25,6 +25,7 @@
  /* OpenGraph */
 if($_['isPublic']) {
 	OCP\Util::addHeader('meta', ['property' => "og:title", 'content' => $theme->getName() . ' - ' . $theme->getSlogan()]);
+	OCP\Util::addHeader('meta', ['property' => "og:description", 'content' => $l->t('Public access')]);
 	OCP\Util::addHeader('meta', ['property' => "og:site_name", 'content' => $theme->getName()]);
 	OCP\Util::addHeader('meta', ['property' => "og:url", 'content' => $_['shareURL']]);
 	OCP\Util::addHeader('meta', ['property' => "og:type", 'content' => "object"]);


### PR DESCRIPTION
### What are you trying to achieve with this PR?
Fix #609. By adding the `og:description` meta tag on public templates, sites such as Riot.im (powered by [Synapse](https://github.com/matrix-org/synapse/)) now use the Open Graph content instead of scraping the text nodes on the page, thus offering a better experience for users who receive a shared calendar link.

### Why are you going with this approach?
I placed the `og:description` with the other Open Graph tags to keep them all together.

### Discussion
**Couldn't we show the shared calendar's detailed information?**
We could move `og:description` in [`part.publicinformations.php`](https://github.com/nextcloud/calendar/blob/master/templates/part.publicinformations.php) to offer detailed calendar information such as the calendar name, its owner, and the user who shared it. However, I could not get this approach to work since it requires string interpolation with Angular's `ng-repeat` directive, which (I think) has no easy way to integrate with NextCloud's string translation method (`$l->t(...)`).

**Okay, but couldn't we provide a better string instead of just "Public access"?**
Absolutely. It would require creating a new string in the [`l10n`](https://github.com/nextcloud/calendar/tree/master/l10n) files, something along those lines: "Someone has shared a public link to a calendar on `$theme->getName()`".