### PR TITLE
fix height of summary input in event editor popover

### DIFF
--- a/css/app/eventdialog.scss
+++ b/css/app/eventdialog.scss
@@ -73,7 +73,6 @@
 }
 
 .events .events--fieldset textarea {
-	height: 4.5em;
 	width: 96%;
 	resize: vertical;
 }


### PR DESCRIPTION
before:
![before](https://user-images.githubusercontent.com/1250540/35783995-e9e924d0-0a11-11e8-83f0-2baa6d4838fe.png)

after:
![after](https://user-images.githubusercontent.com/1250540/35783996-eac0a5fe-0a11-11e8-863a-32435da13c53.png)