### PR TITLE
always show the calendar selector in the editor for read-only calendars

### DIFF
--- a/js/app/controllers/editorcontroller.js
+++ b/js/app/controllers/editorcontroller.js
@@ -208,6 +208,11 @@ app.controller('EditorController', ['$scope', 'TimezoneService', 'AutoCompletion
 		};
 
 		$scope.showCalendarSelection = function() {
+			// always show selection if it's a readonly calendar
+			if (!$scope.calendar.isWritable()) {
+				return true;
+			}
+
 			const writableCalendars = $scope.calendars.filter(function (c) {
 				return c.isWritable();
 			});


### PR DESCRIPTION
fixes #529 

before:
![before](https://user-images.githubusercontent.com/1250540/36689748-9c486756-1b30-11e8-8eb1-adbffa2f2d6d.jpeg)

after:
![after](https://user-images.githubusercontent.com/1250540/36689751-a08f845c-1b30-11e8-9d29-1743c4f6fedc.jpeg)

