### PR TITLE
Double the height of the description text area (issue #675)

### DIFF
--- a/templates/editor.sidebar.php
+++ b/templates/editor.sidebar.php
@@ -66,7 +66,7 @@
 							  uib-typeahead="location.name for location in searchLocation($viewValue)" typeahead-show-hint="true" typeahead-min-length="3"
 							  typeahead-on-select="selectLocationFromTypeahead($item)"
 							  autocomplete="off" tabindex="210"></textarea>
-					<textarea ng-model="properties.description.value" type="text" class="advanced--input advanced--textarea" rows="1"
+					<textarea ng-model="properties.description.value" type="text" class="advanced--input advanced--textarea" rows="2"
 							  placeholder="<?php p($l->t('Description'));?>" name="description" tabindex="210"></textarea>
 					<select id="statusSelector"
 							ng-options="status.type as status.displayname for status in statusSelect"


### PR DESCRIPTION
In response to issue #675, this doubles the size of the text area input for the event description by increasing the text area to two rows.

Before:
![screenshot 1](https://user-images.githubusercontent.com/36667444/36939879-3c69a828-1efe-11e8-81a5-76c0e5553151.png)

After:
![screenshot 2](https://user-images.githubusercontent.com/36667444/36939884-4a56e6c6-1efe-11e8-9c48-9209ff616cf6.png)
