### PR TITLE
Fix public layout rendering on Nextcloud 14

### DIFF
--- a/controller/viewcontroller.php
+++ b/controller/viewcontroller.php
@@ -155,7 +155,7 @@ class ViewController extends Controller {
 		$params = array_merge($templateParameters, $publicTemplateParameters);
 		$params['isEmbedded'] = true;
 
-		$response = new TemplateResponse('calendar', 'main', $params, 'public');
+		$response = new TemplateResponse('calendar', 'main', $params, 'base');
 
 		$response->addHeader('X-Frame-Options', 'ALLOW');
 		$csp = new ContentSecurityPolicy();

--- a/templates/main.php
+++ b/templates/main.php
@@ -55,6 +55,9 @@ foreach ($scripts as $script) {
 ?>
 <?php if($_['isPublic'] && !$_['isEmbedded']): ?>
 <style>
+	#body-public.layout-base #content {
+		padding-top: 50px;
+	}
 	@media only screen and (max-width: 768px) {
 		#app-navigation, #app-content {
 			top: 45px !important;
@@ -65,6 +68,10 @@ foreach ($scripts as $script) {
 
 <?php if($_['isEmbedded']): ?>
 <style>
+	#body-public.layout-base #app-navigation {
+		top: 0;
+		height: 100%;
+	}
 	@media only screen and (max-width: 768px) {
 		#app-navigation-toggle {
 			top: 0 !important;


### PR DESCRIPTION
This fixes the public page layout for Nextcloud 14. Before this PR calendar was using public instead of base as layout value, which isn't equal with NC14 anymore.

I didn't move it to the newly introduced PublicTemplateResponse, since calendar still supports versions below 14.

Once 14 is a minimal requirement, we should move the public page with header to the new response.

Requires https://github.com/nextcloud/server/pull/10530

