### PR TITLE
Add timezone property to newly created calendars

### DIFF
--- a/js/app/service/calendarService.js
+++ b/js/app/service/calendarService.js
@@ -310,7 +310,8 @@ app.service('CalendarService', function(DavClient, StringUtility, XMLUtility, Ca
 			});
 			dPropChildren.push({
 				name: [DavClient.NS_IETF, 'c:calendar-timezone'],
-				value: icalTimezone.component.toString()
+				value: icalTimezone.component.toString(),
+				cdata: true
 			});
 			dPropChildren.push({
 				name: [DavClient.NS_APPLE, 'a:calendar-color'],

--- a/js/app/service/calendarService.js
+++ b/js/app/service/calendarService.js
@@ -287,7 +287,12 @@ app.service('CalendarService', function(DavClient, StringUtility, XMLUtility, Ca
 	 * @returns {Promise}
 	 */
 	this.create = function(name, color, components=['vevent', 'vtodo']) {
-		return context.bootPromise.then(function() {
+		const tzid = TimezoneService.getDetected();
+
+		return context.bootPromise.then(function(tz) {
+			return TimezoneService.get(tzid);
+		}).then(function(tz) {
+			const icalTimezone = new ICAL.Timezone(tz.jCal);
 			const [skeleton, dPropChildren] = XMLUtility.getRootSkeleton(
 				[DavClient.NS_DAV, 'd:mkcol'], [DavClient.NS_DAV, 'd:set'],
 				[DavClient.NS_DAV, 'd:prop']);
@@ -305,7 +310,7 @@ app.service('CalendarService', function(DavClient, StringUtility, XMLUtility, Ca
 			});
 			dPropChildren.push({
 				name: [DavClient.NS_IETF, 'c:calendar-timezone'],
-				value: TimezoneService.getDetected()
+				value: icalTimezone.component.toString()
 			});
 			dPropChildren.push({
 				name: [DavClient.NS_APPLE, 'a:calendar-color'],

--- a/js/app/service/calendarService.js
+++ b/js/app/service/calendarService.js
@@ -21,7 +21,7 @@
  *
  */
 
-app.service('CalendarService', function(DavClient, StringUtility, XMLUtility, CalendarFactory, isPublic, constants) {
+app.service('CalendarService', function(DavClient, StringUtility, XMLUtility, CalendarFactory, isPublic, constants, TimezoneService) {
 	'use strict';
 	
 	const context = {
@@ -302,6 +302,10 @@ app.service('CalendarService', function(DavClient, StringUtility, XMLUtility, Ca
 			dPropChildren.push({
 				name: [DavClient.NS_DAV, 'd:displayname'],
 				value: name
+			});
+			dPropChildren.push({
+				name: [DavClient.NS_IETF, 'c:calendar-timezone'],
+				value: TimezoneService.getDetected()
 			});
 			dPropChildren.push({
 				name: [DavClient.NS_APPLE, 'a:calendar-color'],

--- a/js/app/utility/xmlUtility.js
+++ b/js/app/utility/xmlUtility.js
@@ -36,7 +36,12 @@ app.service('XMLUtility', function() {
 		});
 
 		if (json.value) {
-			element.textContent = json.value;
+			if (json.cdata) {
+				const section = xmlDoc.createCDATASection(json.value);
+				element.appendChild(section);
+			} else {
+				element.textContent = json.value;
+			}
 		} else if (json.children) {
 			for (let key in json.children) {
 				if (json.children.hasOwnProperty(key)) {

--- a/tests/js/unit/services/calendarServiceSpec.js
+++ b/tests/js/unit/services/calendarServiceSpec.js
@@ -22,7 +22,7 @@
 describe('CalendarService non-public', function () {
 	'use strict';
 
-	let CalendarService, DavClient, StringUtility, XMLUtility, CalendarFactory, WebCal, $q, $rootScope, davService, constants;
+	let CalendarService, DavClient, StringUtility, XMLUtility, CalendarFactory, WebCal, $q, $rootScope, davService, constants, TimezoneService;
 	let firstPropFindDeferred, secondPropFindDeferred, thirdPropFindDeferred;
 	let firstRequestDeferred, secondRequestDeferred, thirdRequestDeferred;
 	let updateSpy;
@@ -735,6 +735,9 @@ END:VCALENDAR&#13;
 		OC.requestToken = 'requestToken42';
 		OC.linkToRemoteBase = jasmine.createSpy();
 
+		TimezoneService = {};
+		TimezoneService.getDetected = jasmine.createSpy();
+
 		$provide.value('DavClient', DavClient);
 		$provide.value('StringUtility', StringUtility);
 		$provide.value('XMLUtility', XMLUtility);
@@ -742,6 +745,7 @@ END:VCALENDAR&#13;
 		$provide.value('WebCal', WebCal);
 		$provide.value('isPublic', false);
 		$provide.value('constants', {});
+		$provide.value('TimezoneService', TimezoneService);
 	}));
 
 	beforeEach(inject(function (_$q_, _$rootScope_) {
@@ -757,6 +761,7 @@ END:VCALENDAR&#13;
 		OC.linkToRemoteBase.and.returnValue('remote-dav');
 		DavClient.buildUrl.and.returnValues('fancy-url-1', 'fancy-url-2', 'fancy-url-3', 'fancy-url-4');
 		StringUtility.uri.and.returnValues('uri-1', 'uri-2', 'uri-3', 'uri-4');
+		TimezoneService.getDetected.and.returnValue('Europe/Berlin');
 
 		firstPropFindDeferred = $q.defer();
 		secondPropFindDeferred = $q.defer();
@@ -1090,6 +1095,9 @@ END:VCALENDAR&#13;
 			name: ['DAV:', 'd:displayname'],
 			value: 'name-foobar-1337'
 		},{
+			name: ['urn:ietf:params:xml:ns:caldav', 'c:calendar-timezone'],
+			value: 'Europe/Berlin'
+		},{
 			name: ['http://apple.com/ns/ical/', 'a:calendar-color'],
 			value: '#eeeeee'
 		},{
@@ -1357,7 +1365,7 @@ END:VCALENDAR&#13;
 describe('CalendarService - public', function() {
 	'use strict';
 
-	let CalendarService, DavClient, StringUtility, XMLUtility, CalendarFactory, WebCal, $q, $rootScope, davService, constants;
+	let CalendarService, DavClient, StringUtility, XMLUtility, CalendarFactory, WebCal, $q, $rootScope, davService, constants, TimezoneService;
 	let firstPropFindDeferred, secondPropFindDeferred, thirdPropFindDeferred;
 	let firstRequestDeferred, secondRequestDeferred, thirdRequestDeferred;
 
@@ -1515,6 +1523,9 @@ describe('CalendarService - public', function() {
 		OC.requestToken = 'requestToken42';
 		OC.linkToRemoteBase = jasmine.createSpy();
 
+		TimezoneService = {};
+		TimezoneService.getDetected = jasmine.createSpy();
+
 		$provide.value('DavClient', DavClient);
 		$provide.value('StringUtility', StringUtility);
 		$provide.value('XMLUtility', XMLUtility);
@@ -1522,6 +1533,7 @@ describe('CalendarService - public', function() {
 		$provide.value('WebCal', WebCal);
 		$provide.value('isPublic', true);
 		$provide.value('constants', {});
+		$provide.value('TimezoneService', TimezoneService);
 	}));
 
 	beforeEach(inject(function (_$q_, _$rootScope_) {
@@ -1536,6 +1548,7 @@ describe('CalendarService - public', function() {
 
 		OC.linkToRemoteBase.and.returnValue('remote-dav');
 		DavClient.buildUrl.and.returnValues('fancy-url-1', 'fancy-url-2', 'fancy-url-3', 'fancy-url-4');
+		TimezoneService.getDetected.and.returnValue('Europe/Berlin');
 
 		firstPropFindDeferred = $q.defer();
 		secondPropFindDeferred = $q.defer();


### PR DESCRIPTION
Closes #223

I didn't add the property on WebCal collections, not sure if applicable, but it's fairly easy to add it too.

Also, I didn't consider the case when someone updates his calendar but the timezone changed since the creation.