### PR TITLE
"Settings & Import" no longer covers bottom calendar.

### DIFF
--- a/css/app/calendarlist.scss
+++ b/css/app/calendarlist.scss
@@ -320,7 +320,7 @@ $color-border: nc-darken($color-main-background, 8%) !default;
 }
 
 ul#calendarlistcontainer {
-	padding-bottom: 44px;
+	margin-bottom: 44px;
 }
 
 #datepicker-ng-show-container {


### PR DESCRIPTION
Fixes #730, tested with Firefox 61.0.1 and Chromium 68.0.3440.84 on Nextcloud 13