### PR TITLE
Add @NoSameSiteCookieRequired to the publicIndexForEmbedding endpoint

### DIFF
--- a/controller/viewcontroller.php
+++ b/controller/viewcontroller.php
@@ -144,6 +144,7 @@ class ViewController extends Controller {
 	/**
 	 * @PublicPage
 	 * @NoCSRFRequired
+	 * @NoSameSiteCookieRequired
 	 *
 	 * @param string $token
 	 *


### PR DESCRIPTION
Fixes #169 (will probably require NC 15 though, I don't think https://github.com/nextcloud/server/pull/11878 can be backported)