### PR TITLE
Add accesskeys to the datepicker container buttons

### DIFF
--- a/templates/part.buttonarea.php
+++ b/templates/part.buttonarea.php
@@ -24,10 +24,10 @@
 ?>
 
 <div class="togglebuttons">
-	<button class="button first" ng-value="agendaDay" ng-model="selectedView" uib-btn-radio="'agendaDay'"><?php p($l->t('Day')); ?></button>
-	<button class="button middle" ng-value="agendaWeek" ng-model="selectedView" uib-btn-radio="'agendaWeek'"><?php p($l->t('Week')); ?></button>
-	<button class="button last" ng-value="month" ng-model="selectedView" uib-btn-radio="'month'"><?php p($l->t('Month')); ?></button>
+	<button class="button first" accesskey="D" ng-value="agendaDay" ng-model="selectedView" uib-btn-radio="'agendaDay'"><?php p($l->t('Day')); ?></button>
+	<button class="button middle" accesskey="W" ng-value="agendaWeek" ng-model="selectedView" uib-btn-radio="'agendaWeek'"><?php p($l->t('Week')); ?></button>
+	<button class="button last" accesskey="M" ng-value="month" ng-model="selectedView" uib-btn-radio="'month'"><?php p($l->t('Month')); ?></button>
 </div>
 <div class="togglebuttons">
-	<button class="button today" ng-click="today()"><?php p($l->t('Today')); ?></button>
+	<button class="button today" accesskey="T" ng-click="today()"><?php p($l->t('Today')); ?></button>
 </div>

--- a/templates/part.datepicker.php
+++ b/templates/part.datepicker.php
@@ -23,13 +23,13 @@
  */
 ?>
 <div class="datepicker-heading">
-	<button type="button" class="button first" ng-click="prev()" aria-label="<?php p($l->t('Go back')) ?>">
+	<button type="button" class="button first" accesskey="P" ng-click="prev()" aria-label="<?php p($l->t('Go back')) ?>">
 		<i class="glyphicon glyphicon-chevron-left"></i>
 	</button>
 	<button ng-cloak type="button" class="button middle" ng-click="toggle()">
 		{{ dt | datepickerFilter:selectedView }}
 	</button>
-	<button type="button" class="button last" ng-click="next()" aria-label="<?php p($l->t('Go forward')) ?>">
+	<button type="button" class="button last" accesskey="N" ng-click="next()" aria-label="<?php p($l->t('Go forward')) ?>">
 		<i class="glyphicon glyphicon-chevron-right"></i>
 	</button>
 </div>


### PR DESCRIPTION
As it had been mentioned in #157, I would prefer keyboard shortcuts which do not require combinations. There are also accessibility issues known when using `accesskey` described on MDN:
https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/accesskey

Still, I have the opinion that this would be a great quick fix to make some sort of keyboard shortcuts available until there is a JavaScript handling available.

- `P` for the **p**revious period
- `N` for the **n**ext period
- `D` for the **d**ay view
- `W` for the **w**eek view
- `M` for the **m**onth view
- `T` for the current day (**t**oday)