### PR TITLE
Provide autocompletion addresses as a single line.

### DIFF
--- a/controller/contactcontroller.php
+++ b/controller/contactcontroller.php
@@ -67,7 +67,7 @@ class ContactController extends Controller {
 			}
 
 			foreach ($r['ADR'] as $address) {
-				$address = trim(preg_replace("/\n+/", "\n", str_replace(';', "\n", $address)));
+				$address = preg_replace("/\n+/", ", ", trim(str_replace(';', "\n", $address)));
 				$contacts[] = [
 					'label' => $address,
 					'name' => $name

--- a/tests/php/controller/contactcontrollerTest.php
+++ b/tests/php/controller/contactcontrollerTest.php
@@ -47,15 +47,15 @@ class ContactControllerTest extends TestCase {
 	public function testSearchLocation() {
 		$expected = [
 			[
-				'label' => "33 42nd Street\nRandom Town\nSome State\nUnited States",
+				'label' => '33 42nd Street, Random Town, Some State, United States',
 				'name' => 'Person 1',
 			],
 			[
-				'label' => "5 Random Ave\n12782 Some big city\nYet another state\nUnited States",
+				'label' => '5 Random Ave, 12782 Some big city, Yet another state, United States',
 				'name' => 'Person 1',
 			],
 			[
-				'label' => "ABC Street 2\n01337 Village\nGermany",
+				'label' => 'ABC Street 2, 01337 Village, Germany',
 				'name' => '',
 			],
 		];


### PR DESCRIPTION
Fix issue #933 
When auto-completing an event location from a contact address,
render the address as a single line comma separated list of fields,
instead of a multi-line address.  This works better in the UI, and
works better in ICS files provided to mail clients like Thunderbird/Lightning
and Google/Calendar.

Signed-off-by: Brad Rubenstein <brad@wbr.tech>