### PR TITLE
Always show border on calendar item

### DIFF
--- a/css/app/calendarlist.scss
+++ b/css/app/calendarlist.scss
@@ -94,9 +94,9 @@ $color-border: nc-darken($color-main-background, 8%) !default;
 	margin-top: 16px;
 	width: 12px;
 	height: 12px;
-	border: none;
 	border-radius: 50%;
 	cursor: pointer;
+	border: 1px solid var(--color-border-dark)
 }
 
 #app-navigation .app-navigation-list-item .calendarCheckbox.unchecked {

--- a/templates/part.calendarlist.item.php
+++ b/templates/part.calendarlist.item.php
@@ -30,8 +30,7 @@
 	  ng-click="triggerEnable(item)"
 	  ng-if="item.displayColorIndicator() && !item.calendar.hasWarnings()"
 	  ng-style="{
-		  'background-color' : item.calendar.enabled == true ? item.calendar.color : 'transparent',
-		  'border': item.calendar.enabled == true ? '1px solid var(--color-border-dark)' : 'none'
+		  'background-color' : item.calendar.enabled == true ? item.calendar.color : 'transparent'
 		}">
 </span>
 <a class="action permanent"


### PR DESCRIPTION
In order to improve the understanding of calendars being enabled/disabled.

For v2 let's use checkboxes instead. https://github.com/nextcloud/calendar/issues/904#issuecomment-444225498

|Before|After|
|---|---|
|![](https://framapic.org/j4vInjeusP29/XPM0xunQtjHW.png)|![](https://framapic.org/QQMzmwywWZPb/veJ4MCGLWbQ9.png)|