### PR TITLE
Update NodeJS in CI from 6 to 10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,7 @@ before_install:
   # get a newer node.js version
   - "export DISPLAY=:99.0"
   - "sh -e /etc/init.d/xvfb start"
-  - nvm install 6
+  - nvm install 10
   - npm install -g npm@latest
   # install server
   - cd nextcloud


### PR DESCRIPTION

```
error is-wsl@2.1.0: The engine "node" is incompatible with this module. Expected version ">=8".
```