### PR TITLE
Add user agent to guzzle requests

### DIFF
--- a/controller/proxycontroller.php
+++ b/controller/proxycontroller.php
@@ -140,6 +140,9 @@ class ProxyController extends Controller {
 			do {
 				$clientResponse = $client->get($queryUrl, [
 					'allow_redirects' => $allow_redirects,
+					'headers' => [
+						'User-Agent' => 'Nextcloud',
+					],
 				]);
 
 				$statusCode = $clientResponse->getStatusCode();


### PR DESCRIPTION
I'm facing the same issue also raised [here](https://help.nextcloud.com/t/adding-a-unique-user-agent-string-for-guzzlehttp-requests-in-calendar-app-feat-songkick-case-study/40001) of Songkick rejecting cal requests with Guzzle's default UA string. This is the proposed fix.