### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,52 +1,58 @@
 # Nextcloud Calendar 
 
 [![Build Status](https://travis-ci.org/nextcloud/calendar.svg?branch=master)](https://travis-ci.org/nextcloud/calendar)
-[![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/nextcloud/calendar/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/nextcloud/calendar/?branch=master)
-[![Code Coverage](https://scrutinizer-ci.com/g/nextcloud/calendar/badges/coverage.png?b=master)](https://scrutinizer-ci.com/g/nextcloud/calendar/?branch=master)
 [![Coverage Status](https://coveralls.io/repos/github/nextcloud/calendar/badge.svg?branch=master)](https://coveralls.io/github/nextcloud/calendar?branch=master)
-[![Dependency Status](https://www.versioneye.com/user/projects/57dc165a037c200040cdced9/badge.svg?style=flat-square)](https://www.versioneye.com/user/projects/57dc165a037c200040cdced9)
 
 **A calendar app for [Nextcloud](http://nextcloud.com). Easily sync events from various devices with your Nextcloud and edit them online.**  
 
 ![](https://raw.githubusercontent.com/nextcloud/screenshots/master/apps/Calendar/view_week.png)
 
-## Why is this so awesome?
+## :blue_heart: :tada: Why is this so awesome?
 
-* :rocket: **Integration with other Nextcloud apps!** Currently Contacts – more to come.
+* :rocket: **Integration with other Nextcloud apps!** Currently Contacts and Circles – more to come.
 * :globe_with_meridians: **WebCal Support!** Want to see your favorite team's matchdays in your calendar? No problem!
 * :raising_hand: **Attendees!** Invite people to your events.
-* :see_no_evil: **We’re not reinventing the wheel!** Based on the great [davclient.js](https://github.com/evert/davclient.js), [ical.js](https://github.com/mozilla-comm/ical.js) and [fullcalendar](https://github.com/fullcalendar/fullcalendar) libraries.
+* :alarm_clock: **Reminders!** Get alarms for events inside your browser and via email.
+* :see_no_evil: **We’re not reinventing the wheel!** Based on the great [c-dav library](https://github.com/nextcloud/cdav-library), [ical.js](https://github.com/mozilla-comm/ical.js) and [fullcalendar](https://github.com/fullcalendar/fullcalendar) libraries.
 
 And in the works for the [coming versions](https://github.com/nextcloud/calendar/milestones/):
 * :mag: Search for events ([#8](https://github.com/nextcloud/calendar/issues/8))
-* :alarm_clock: Get alarms for events inside your browser ([#51](https://github.com/nextcloud/calendar/issues/51))
 * :watch: See when other attendees are free ([#39](https://github.com/nextcloud/calendar/issues/39))
 
-## Installation
+## :hammer_and_wrench: Installation
 
 In your Nextcloud, simply navigate to »Apps«, choose the category »Organization«, find the Calendar app and enable it.
 Then open the Calendar app from the app menu.
 
-## Support
+## :satellite: Support
 
-Check out our [FAQ](https://github.com/nextcloud/calendar/wiki/FAQs). If you dont find a solution, you are welcome to [ask for support](https://help.nextcloud.com) in our Forums or the IRC-Channel. If you have found a bug, feel free to open a new Issue on GitHub. Keep in mind, that this repository only manages the frontend. If you find bugs or have problems with the CalDAV-Backend, you should ask the guys at [Nextcloud server](https://github.com/nextcloud/server) for help!
+If you need assistance or want to ask a question about Calendar, you are welcome to [ask for support](https://help.nextcloud.com/c/apps/calendar) in our Forums or the [IRC-Channel](https://webchat.freenode.net/?channels=nextcloud-calendar).
+If you have found a bug, feel free to open a new Issue on GitHub. Keep in mind, that this repository only manages the frontend.
+If you find bugs or have problems with the CalDAV-Backend, you should ask the team at [Nextcloud server](https://github.com/nextcloud/server) for help!
 
-## Supported Browsers
+## :earth_africa: Supported Browsers
 
-* Chrome/Chromium 49+
-* Edge 14+
-* Firefox 45+
+* Chrome/Chromium 76+
+* Edge 40+
+* Firefox 60+
 * Internet Explorer 11
-* Safari 10+
+* Safari 12.1+
 
-We don't support Internet Explorer 10 and below. Patches for IE9+ are accepted though.
+## Maintainers
 
-## Nightly builds
+- [Georg Ehrke](https://github.com/georgehrke)
+- [Thomas Citharel](https://github.com/tcitworld)
+- [and many more](https://github.com/nextcloud/calendar/graphs/contributors)
 
-Testing is a great way to contribute without having to write source code.
-Although it's straight forward, setting up the development environment requires some knowledge and extra tools on your device.
+If you’d like to join, just go through the [issue list](https://github.com/nextcloud/calendar/issues?utf8=✓&q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22+) and fix some. :)   
+We’re also in [#nextcloud-calendar on freenode IRC](https://webchat.freenode.net/?channels=nextcloud-calendar).
 
-We provide [nightly builds](https://nightly.portknox.net/calendar/?C=M;O=D) to enable everyone help testing without setting up the development environment.  
+We’d like to thank [BrowserStack](https://www.browserstack.com) for providing us with a free subscription.
+
+## Nightly builds / Pre-releases
+
+Instead of setting everything up manually, you can just [download the nightly builds](https://nightly.portknox.net/calendar/?C=M;O=D) or [download a pre-release](https://github.com/nextcloud/calendar/releases) instead.
+Nightly builds are updated every 24 hours, and are pre-configured with all the needed dependencies.
 
 1. Download
 2. Extract the tar archive to 'path-to-nextcloud/apps'
@@ -56,23 +62,39 @@ The nightly builds are provided by [Portknox.net](https://portknox.net)
 
 When reporting issues, please mention the date in the tar archive's name.
 
-## Maintainers
+## Build the app
 
-[Georg Ehrke](https://github.com/georgehrke), [Raghu Nayyar](https://github.com/raghunayyar), [Thomas Citharel](https://github.com/tcitworld) [and many more](https://github.com/nextcloud/calendar/graphs/contributors)
+``` bash
+# set up and build for production
+make
 
-If you’d like to join, just go through the [issue list](https://github.com/nextcloud/calendar/issues?q=is%3Aopen+is%3Aissue+label%3A%22starter+issue%22) and fix some. :)   
-We’re also in [#nextcloud-calendar on freenode IRC](https://webchat.freenode.net/?channels=nextcloud-calendar).
+# install dependencies
+make dev-setup
 
-We’d like to thank [BrowserStack](https://www.browserstack.com) for providing us with a free subscription.
+# build for dev and watch changes
+make watch-js
 
-## Developer setup info
+# build for dev
+make build-js
 
-Just clone this repo into your apps directory (Nextcloud server installation needed). Additionally,  [nodejs (>=6)](https://nodejs.org/en/download/package-manager/) and [yarn](http://yarnpkg.com) are needed for installing JavaScript dependencies.
+# build for production with minification
+make build-js-production
 
-Once node and yarn are installed, PHP and JavaScript dependencies can be installed by running
-```bash
-$ make
 ```
-Please execute this command with your ordinary user account and neither root nor sudo.
+## Running tests
+You can use the provided Makefile to run all tests by using:
 
-__We are currently moving the Calendar app from Angular 1 to Vue. (see [this PR](https://github.com/nextcloud/calendar/pull/926)). Please develop your bugfixes / features against the `vue` branch for the time being__ 
+```
+make test
+```
+
+## :v: Code of conduct
+
+The Nextcloud community has core values that are shared between all members during conferences,
+hackweeks and on all interactions in online platforms including [Github](https://github.com/nextcloud) and [Forums](https://help.nextcloud.com).
+If you contribute, participate or interact with this community, please respect [our shared values](https://nextcloud.com/code-of-conduct/). :relieved:
+
+## :heart: How to create a pull request
+
+This guide will help you get started: 
+- :dancer: :smile: [Opening a pull request](https://opensource.guide/how-to-contribute/#opening-a-pull-request) 


### PR DESCRIPTION
@tcitworld Should we also update our supported browsers?

- Firefox 45 is no longer supported by Mozilla. Latest ESR is 68, 60 ESR is still supported.
- Latest supported Chrome/Chromium is 77

Same for Edge. I think we should only support the Blink based version.
