### PR TITLE
load FullCalendar locale dynamically

### DIFF
--- a/webpack.common.js
+++ b/webpack.common.js
@@ -53,7 +53,7 @@ module.exports = {
 	plugins: [
 		new VueLoaderPlugin(),
 		new StyleLintPlugin(),
-		new webpack.IgnorePlugin(/^\.\/locale$/, /moment$/),
+		new webpack.IgnorePlugin(/^\.\/locale(s)?$/, /(@fullcalendar\/core)$|(moment)$/),
 		new webpack.DefinePlugin({
 			appVersion: JSON.stringify(require('./package.json').version)
 		})


### PR DESCRIPTION
fixes #1569 

Summoning our Webpack export @skjnldsv 😉 

This doesn't look right to me:
Master:
```
WARNING in asset size limit: The following asset(s) exceed the recommended size limit (244 KiB).
This can impact web performance.
Assets: 
  calendar.js (1.99 MiB)
```

This branch:
```
WARNING in asset size limit: The following asset(s) exceed the recommended size limit (244 KiB).
This can impact web performance.
Assets: 
  calendar.js (2.18 MiB)
```

I would have expect it to get much smaller when loading the locales dynamically 🤔 