### PR TITLE
Do not show New event button on public page

### DIFF
--- a/src/components/AppNavigation/AppNavigationHeader.vue
+++ b/src/components/AppNavigation/AppNavigationHeader.vue
@@ -23,7 +23,7 @@
 	<header class="app-navigation-header">
 		<AppNavigationHeaderDatePicker />
 		<div class="new-event-today-view-section">
-			<AppNavigationHeaderNewEvent />
+			<AppNavigationHeaderNewEvent v-if="!isPublic" />
 			<AppNavigationHeaderTodayButton />
 			<AppNavigationHeaderViewMenu />
 		</div>
@@ -43,6 +43,12 @@ export default {
 		AppNavigationHeaderTodayButton,
 		AppNavigationHeaderNewEvent,
 		AppNavigationHeaderViewMenu
+	},
+	props: {
+		isPublic: {
+			type: Boolean,
+			required: true
+		}
 	}
 }
 </script>

--- a/src/views/Calendar.vue
+++ b/src/views/Calendar.vue
@@ -23,7 +23,7 @@
 	<Content app-name="calendar" :class="classNames">
 		<AppNavigation v-if="!isEmbedded">
 			<!-- Date Picker, View Buttons, Today Button -->
-			<AppNavigationHeader />
+			<AppNavigationHeader :is-public="!isAuthenticatedUser" />
 			<!-- Calendar / Subscription List -->
 			<CalendarList
 				:is-public="!isAuthenticatedUser"


### PR DESCRIPTION
fixes #1586 

Ideally we should setup a tool like puppeteer and have travis generate screenshots for us, so we can easily spot regressions like this one. #1596

Logged in:
![3906DA99-EC7D-4D46-A1FA-A0AEA457A876](https://user-images.githubusercontent.com/1250540/67623378-cb9bb080-f824-11e9-90db-cc197207ecf6.png)

Public:
![AB9CB385-36E6-4420-8C41-A2558DF0BF1A](https://user-images.githubusercontent.com/1250540/67623379-d0f8fb00-f824-11e9-9813-e6840731f5f5.png)
