### PR TITLE
Remove deprecated color utils, replace with uidToColor, add tests

### DIFF
--- a/__mocks__/@nextcloud/l10n.js
+++ b/__mocks__/@nextcloud/l10n.js
@@ -1,0 +1,7 @@
+export function translate(app, str) {
+	return 'TRANSLATED:' + str
+}
+
+export function translatePlural(app, singularStr, pluralStr) {
+	return 'TRANSLATED:' + pluralStr
+}

--- a/__mocks__/@nextcloud/router.js
+++ b/__mocks__/@nextcloud/router.js
@@ -1,0 +1,15 @@
+export function linkTo(app, file) {
+	return [
+		'linkTo',
+		app,
+		file
+	].join('###')
+}
+
+export function imagePath(app, file) {
+	return [
+		'imagePath',
+		app,
+		file
+	].join('###')
+}

--- a/src/components/AppNavigation/CalendarList/CalendarListNew.vue
+++ b/src/components/AppNavigation/CalendarList/CalendarListNew.vue
@@ -85,7 +85,7 @@ import { ActionInput } from '@nextcloud/vue/dist/Components/ActionInput'
 import { ActionText } from '@nextcloud/vue/dist/Components/ActionText'
 import { AppNavigationItem } from '@nextcloud/vue/dist/Components/AppNavigationItem'
 
-import { getRandomColor } from '../../../utils/color.js'
+import { uidToHexColor } from '../../../utils/color.js'
 
 export default {
 	name: 'CalendarListNew',
@@ -185,7 +185,7 @@ export default {
 			try {
 				await this.$store.dispatch('appendCalendar', {
 					displayName,
-					color: getRandomColor() // TODO - use uid2color
+					color: uidToHexColor(displayName)
 				})
 			} catch (error) {
 				console.debug(error)
@@ -211,7 +211,7 @@ export default {
 			try {
 				await this.$store.dispatch('appendCalendar', {
 					displayName,
-					color: getRandomColor(), // TODO - uid2color
+					color: uidToHexColor(displayName),
 					components: ['VEVENT', 'VTODO']
 				})
 			} catch (error) {
@@ -248,7 +248,7 @@ export default {
 			try {
 				await this.$store.dispatch('appendSubscription', {
 					displayName: hostname,
-					color: getRandomColor(), // TODO - uid2color
+					color: uidToHexColor(link),
 					source: link
 				})
 			} catch (error) {

--- a/src/components/AppNavigation/Settings/ImportScreenRow.vue
+++ b/src/components/AppNavigation/Settings/ImportScreenRow.vue
@@ -34,7 +34,7 @@
 
 <script>
 import CalendarPicker from '../../Shared/CalendarPicker.vue'
-import { getDefaultColor } from '../../../utils/color.js'
+import { uidToHexColor } from '../../../utils/color.js'
 
 export default {
 	name: 'ImportScreenRow',
@@ -60,7 +60,7 @@ export default {
 					id: 'new',
 					displayName: this.$t('calendar', 'New calendar'),
 					isSharedWithMe: false,
-					color: getDefaultColor(), // TODO - use uid2color instead
+					color: uidToHexColor(this.$t('calendar', 'New calendar')),
 					owner: this.$store.getters.getCurrentUserPrincipal.url
 				}
 			}
@@ -78,7 +78,7 @@ export default {
 				id: 'new',
 				displayName: this.$t('calendar', 'New calendar'),
 				isSharedWithMe: false,
-				color: getDefaultColor(), // TODO - use uid2color instead
+				color: uidToHexColor(this.$t('calendar', 'New calendar')),
 				owner: this.$store.getters.getCurrentUserPrincipal.url
 			})
 

--- a/src/components/Editor/IllustrationHeader.vue
+++ b/src/components/Editor/IllustrationHeader.vue
@@ -33,7 +33,7 @@
 
 <script>
 import HttpClient from '@nextcloud/axios'
-import { getDefaultColor } from '../../utils/color.js'
+import { uidToHexColor } from '../../utils/color.js'
 
 export default {
 	name: 'IllustrationHeader',
@@ -57,7 +57,11 @@ export default {
 		coloredSVG() {
 			let color = this.color
 			if (!/^(#)((?:[A-Fa-f0-9]{3}){1,2})$/.test(color)) {
-				color = getDefaultColor() // TODO - use uid2Color instead
+				color = uidToHexColor(color)
+			}
+
+			if (!color.startsWith('#')) {
+				color = '#' + color
 			}
 
 			return this.svg

--- a/src/components/Shared/TimezoneSelect.vue
+++ b/src/components/Shared/TimezoneSelect.vue
@@ -21,6 +21,7 @@ import {
 	getReadableTimezoneName,
 	getSortedTimezoneList
 } from '../../utils/timezone.js'
+import getTimezoneManager from '../../services/timezoneDataProviderService.js'
 
 export default {
 	name: 'TimezoneSelect',
@@ -56,7 +57,8 @@ export default {
 			}
 		},
 		options() {
-			return getSortedTimezoneList(this.additionalTimezones)
+			const timezoneManager = getTimezoneManager()
+			return getSortedTimezoneList(timezoneManager.listAllTimezones(), this.additionalTimezones)
 		}
 	},
 	methods: {

--- a/src/mixins/EditorMixin.js
+++ b/src/mixins/EditorMixin.js
@@ -22,7 +22,6 @@
 import rfcProps from '../models/rfcProps'
 import logger from '../utils/logger.js'
 import { mapEventComponentToCalendarObjectInstanceObject } from '../models/calendarObjectInstance.js'
-import { getDefaultColor } from '../utils/color.js'
 import { getIllustrationForTitle } from '../utils/illustration.js'
 import { getPrefixedRoute } from '../utils/router.js'
 
@@ -64,10 +63,10 @@ export default {
 		},
 		selectedCalendarColor() {
 			if (!this.selectedCalendar) {
-				return getDefaultColor() // TODO: use uid2Color instead
+				return ''
 			}
 
-			return this.selectedCalendar.color || getDefaultColor() // TODO: use uid2Color instead
+			return this.selectedCalendar.color
 		},
 		title() {
 			if (!this.eventComponent) {

--- a/src/models/calendar.js
+++ b/src/models/calendar.js
@@ -19,7 +19,7 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  *
  */
-import { getDefaultColor } from '../utils/color.js'
+import { uidToHexColor } from '../utils/color.js'
 import client from '../services/caldavService.js'
 
 /**
@@ -34,7 +34,7 @@ export const getDefaultCalendarObject = (props = {}) => Object.assign({}, {
 	// Visible display name
 	displayName: '',
 	// Color of the calendar
-	color: getDefaultColor(), // TODO: use uid2Color instead
+	color: uidToHexColor(''),
 	// Whether or not the calendar is visible in the grid
 	enabled: true,
 	// Whether or not the calendar is loading events at the moment
@@ -78,7 +78,7 @@ export const getDefaultCalendarObject = (props = {}) => Object.assign({}, {
  * @returns {Object}
  */
 export function mapDavCollectionToCalendar(calendar) {
-	let color = calendar.color || getDefaultColor() // TODO: use uid2Color instead
+	let color = calendar.color || uidToHexColor(calendar.displayname)
 	if (color.length === 9) {
 		// Make sure it's #RRGGBB, not #RRGGBBAA
 		color = color.substr(0, 7)

--- a/src/store/calendars.js
+++ b/src/store/calendars.js
@@ -29,7 +29,7 @@ import CalendarObject from '../models/calendarObject'
 import { dateFactory, getUnixTimestampFromDate } from '../utils/date.js'
 import { getDefaultCalendarObject, mapDavCollectionToCalendar } from '../models/calendar'
 import pLimit from 'p-limit'
-import { getRandomColor } from '../utils/color.js'
+import { uidToHexColor } from '../utils/color.js'
 import { translate } from '@nextcloud/l10n'
 
 const state = {
@@ -791,7 +791,7 @@ const actions = {
 				const displayName = file.parser.getName() || translate('calendar', 'Imported {filename}', {
 					filename: file.name
 				})
-				const color = file.parser.getColor() || getRandomColor() // TODO - use uid2color
+				const color = file.parser.getColor() || uidToHexColor(displayName)
 				const components = []
 				if (file.parser.containsVEvents()) {
 					components.push('VEVENT')

--- a/src/utils/color.js
+++ b/src/utils/color.js
@@ -20,6 +20,7 @@
  *
  */
 import convert from 'color-convert'
+import { uidToColor } from './uidToColor.js'
 
 /**
  * Get a text-color that's readable on a given background color
@@ -47,25 +48,12 @@ export function generateTextColorForRGB({ red, green, blue }) {
 }
 
 /**
- * returns a random color
+ * Generates a rgb-hex color based on a string
  *
- * @returns {String}
- * @deprecated
+ * @param {String} uid The string to generate a color from
+ * @returns {string} The RGB HEX color
  */
-export function getRandomColor() {
-	const red = Math.floor(Math.random() * 256)
-	const green = Math.floor(Math.random() * 256)
-	const blue = Math.floor(Math.random() * 256)
-
-	return '#' + convert.rgb.hex(red, green, blue)
-}
-
-/**
- * Gets the default color of the nextcloud instance
- *
- * @returns {string}
- * @deprecated
- */
-export function getDefaultColor() {
-	return '#1483C6'
+export function uidToHexColor(uid) {
+	const color = uidToColor(uid)
+	return '#' + convert.rgb.hex(color.r, color.g, color.b)
 }

--- a/src/utils/date.js
+++ b/src/utils/date.js
@@ -19,7 +19,6 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  *
  */
-import moment from '@nextcloud/moment'
 
 /**
  * returns a new Date object
@@ -94,6 +93,7 @@ export function getDateFromDateTimeValue(dateTimeValue) {
 		dateTimeValue.day,
 		dateTimeValue.hour,
 		dateTimeValue.minute,
+		0,
 		0
 	)
 }
@@ -109,9 +109,10 @@ export function getDateFromDateTimeValue(dateTimeValue) {
  * @returns {Date}
  */
 export function modifyDate(date, { day = 0, week = 0, month = 0 }) {
-	return moment(date)
-		.add(day, 'day')
-		.add(week, 'week')
-		.add(month, 'month')
-		.toDate()
+	date = new Date(date.getTime())
+	date.setDate(date.getDate() + day)
+	date.setDate(date.getDate() + week * 7)
+	date.setMonth(date.getMonth() + month)
+
+	return date
 }

--- a/src/utils/illustration.js
+++ b/src/utils/illustration.js
@@ -595,3 +595,5 @@ const data = [{
 		'dinner'
 	]
 }]
+
+export default getIllustrationForTitle

--- a/src/utils/recurrence.js
+++ b/src/utils/recurrence.js
@@ -63,6 +63,6 @@ export function getWeekDayFromDate(jsDate) {
 	case 6:
 		return 'SA'
 	default:
-		return 'MO'
+		throw TypeError('Invalid date-object given')
 	}
 }

--- a/src/views/Calendar.vue
+++ b/src/views/Calendar.vue
@@ -90,7 +90,7 @@ import {
 	Content
 } from '@nextcloud/vue'
 import debounce from 'debounce'
-import { getRandomColor } from '../utils/color.js'
+import { uidToHexColor } from '../utils/color.js'
 import client from '../services/caldavService.js'
 import { getConfigValueFromHiddenInput } from '../utils/settings.js'
 import {
@@ -321,7 +321,7 @@ export default {
 						this.loadingCalendars = true
 						this.$store.dispatch('appendCalendar', {
 							displayName: this.$t('calendars', 'Personal'),
-							color: getRandomColor(), // TODO - use uid2color
+							color: uidToHexColor(this.$t('calendars', 'Personal')),
 							order: 0
 						}).then(() => {
 							this.loadingCalendars = false

--- a/tests/javascript/unit/utils/color.test.js
+++ b/tests/javascript/unit/utils/color.test.js
@@ -1,0 +1,48 @@
+/**
+ * @copyright Copyright (c) 2019 Georg Ehrke
+ *
+ * @author Georg Ehrke <oc.list@georgehrke.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+import {
+	generateTextColorForRGBString,
+	generateTextColorForRGB,
+	uidToHexColor
+} from '../../../../src/utils/color.js'
+
+describe('utils/color test suite', () => {
+
+	it('should provide a function to generate a text-color from an rgb string', () => {
+		expect(generateTextColorForRGBString('#fff')).toEqual('#000000')
+		expect(generateTextColorForRGBString('#000')).toEqual('#FAFAFA')
+		expect(generateTextColorForRGBString('#FF00FF')).toEqual('#FAFAFA')
+		expect(generateTextColorForRGBString('#00FF00')).toEqual('#000000')
+	})
+
+	it('should provide a function to generate a text-color from rgb values', () => {
+		expect(generateTextColorForRGB({ red: 255, green: 255, blue: 255 })).toEqual('#000000')
+		expect(generateTextColorForRGB({ red: 0, green: 0, blue: 0 })).toEqual('#FAFAFA')
+		expect(generateTextColorForRGB({ red: 255, green: 0, blue: 255 })).toEqual('#FAFAFA')
+		expect(generateTextColorForRGB({ red: 0, green: 255, blue: 0 })).toEqual('#000000')
+	})
+
+	it('should provide a HEX string for a UID', () => {
+		expect(uidToHexColor('uid123')).toEqual('#C98879')
+		expect(uidToHexColor('')).toEqual('#0082C9')
+	})
+})

--- a/tests/javascript/unit/utils/date.test.js
+++ b/tests/javascript/unit/utils/date.test.js
@@ -1,0 +1,128 @@
+/**
+ * @copyright Copyright (c) 2019 Georg Ehrke
+ *
+ * @author Georg Ehrke <oc.list@georgehrke.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+import {
+	dateFactory,
+	getYYYYMMDDFromDate,
+	getUnixTimestampFromDate,
+	getDateFromFirstdayParam,
+	getYYYYMMDDFromFirstdayParam,
+	getDateFromDateTimeValue,
+	modifyDate
+} from '../../../../src/utils/date.js'
+
+describe('utils/alarms test suite', () => {
+
+	it('should return a date', () => {
+		expect(dateFactory()).toBeInstanceOf(Date)
+	})
+
+	it('should return YYYYMMDD from a given date object', () => {
+		expect(getYYYYMMDDFromDate(new Date(2019, 0, 1, 0, 0, 0))).toEqual('2019-01-01')
+		expect(getYYYYMMDDFromDate(new Date(2019, 11, 31, 23, 59, 59))).toEqual('2019-12-31')
+	})
+
+	it('should return the unix timestamp from a given date object', () => {
+		expect(getUnixTimestampFromDate(new Date(Date.UTC(2019, 0, 1, 23, 59, 59)))).toEqual(1546387199)
+		expect(getUnixTimestampFromDate(new Date(Date.UTC(2019, 11, 31, 23, 59, 59)))).toEqual(1577836799)
+	})
+
+	it('should get a date object from the first-day-parameter', () => {
+		expect(getDateFromFirstdayParam('now')).toBeInstanceOf(Date)
+
+		const date1 = getDateFromFirstdayParam('2019-01-01')
+		const date2 = getDateFromFirstdayParam('2019-12-31')
+
+		expect(date1.getFullYear()).toEqual(2019)
+		expect(date1.getMonth()).toEqual(0)
+		expect(date1.getDate()).toEqual(1)
+		expect(date2.getFullYear()).toEqual(2019)
+		expect(date2.getMonth()).toEqual(11)
+		expect(date2.getDate()).toEqual(31)
+	})
+
+	it('shoud get YYYYMMDD from a given first day-param', () => {
+		expect(getYYYYMMDDFromFirstdayParam('now')).toEqual(expect.any(String))
+
+		const date1 = getYYYYMMDDFromFirstdayParam('2019-01-01')
+		const date2 = getYYYYMMDDFromFirstdayParam('2019-12-31')
+
+		expect(date1).toEqual('2019-01-01')
+		expect(date2).toEqual('2019-12-31')
+	})
+
+	it('should return from a date-time-value', () => {
+		const date = getDateFromDateTimeValue({
+			year: 2019,
+			month: 1,
+			day: 1,
+			hour: 14,
+			minute: 42,
+			seconds: 13
+		})
+
+		expect(date.getFullYear()).toEqual(2019)
+		expect(date.getMonth()).toEqual(0)
+		expect(date.getDate()).toEqual(1)
+		expect(date.getHours()).toEqual(14)
+		expect(date.getMinutes()).toEqual(42)
+		expect(date.getSeconds()).toEqual(0)
+		expect(date.getMilliseconds()).toEqual(0)
+	})
+
+	it('should modify a date', () => {
+		const date1 = modifyDate(new Date(2019, 0, 1, 0, 0, 0), { day: 5 })
+		const date2 = modifyDate(new Date(2019, 0, 1, 0, 0, 0), { day: 60 })
+		const date3 = modifyDate(new Date(2019, 0, 1, 0, 0, 0), { week: 1 })
+		const date4 = modifyDate(new Date(2019, 0, 1, 0, 0, 0), { week: 7 })
+		const date5 = modifyDate(new Date(2019, 0, 1, 0, 0, 0), { month: 1 })
+		const date6 = modifyDate(new Date(2019, 0, 1, 0, 0, 0), { month: 18 })
+		const date7 = modifyDate(new Date(2019, 0, 1, 0, 0, 0), { day: 22, week: 42, month: 5 })
+
+		expect(date1.getFullYear()).toEqual(2019)
+		expect(date1.getMonth()).toEqual(0)
+		expect(date1.getDate()).toEqual(6)
+
+		expect(date2.getFullYear()).toEqual(2019)
+		expect(date2.getMonth()).toEqual(2)
+		expect(date2.getDate()).toEqual(2)
+
+		expect(date3.getFullYear()).toEqual(2019)
+		expect(date3.getMonth()).toEqual(0)
+		expect(date3.getDate()).toEqual(8)
+
+		expect(date4.getFullYear()).toEqual(2019)
+		expect(date4.getMonth()).toEqual(1)
+		expect(date4.getDate()).toEqual(19)
+
+		expect(date5.getFullYear()).toEqual(2019)
+		expect(date5.getMonth()).toEqual(1)
+		expect(date5.getDate()).toEqual(1)
+
+		expect(date6.getFullYear()).toEqual(2020)
+		expect(date6.getMonth()).toEqual(6)
+		expect(date6.getDate()).toEqual(1)
+
+		expect(date7.getFullYear()).toEqual(2020)
+		expect(date7.getMonth()).toEqual(3)
+		expect(date7.getDate()).toEqual(13)
+	})
+})

--- a/tests/javascript/unit/utils/illustration.test.js
+++ b/tests/javascript/unit/utils/illustration.test.js
@@ -1,0 +1,33 @@
+/**
+ * @copyright Copyright (c) 2019 Georg Ehrke
+ *
+ * @author Georg Ehrke <oc.list@georgehrke.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+import getIllustrationForTitle from "../../../../src/utils/illustration.js";
+
+describe('utils/illustration test suite', () => {
+
+	it('should return a matching illustration', () => {
+		expect(getIllustrationForTitle('Watch movie with Jane')).toEqual('imagePath###calendar###illustrations/movie_night')
+		expect(getIllustrationForTitle('Take time to relax')).toEqual('imagePath###calendar###illustrations/relaxation')
+		expect(getIllustrationForTitle('Give presentation about calendar')).toEqual('imagePath###calendar###illustrations/presentation')
+
+		expect(getIllustrationForTitle('ABC', ['Watch',  'movie'])).toEqual('imagePath###calendar###illustrations/movie_night')
+	})
+})

--- a/tests/javascript/unit/utils/recurrence.test.js
+++ b/tests/javascript/unit/utils/recurrence.test.js
@@ -1,0 +1,68 @@
+/**
+ * @copyright Copyright (c) 2019 Georg Ehrke
+ *
+ * @author Georg Ehrke <oc.list@georgehrke.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+import {
+	getBySetPositionAndBySetFromDate,
+	getWeekDayFromDate
+} from '../../../../src/utils/recurrence.js'
+
+
+describe('utils/recurrence test suite', () => {
+
+	it('should get the BYSETPOS value for a date object', () => {
+		expect(getBySetPositionAndBySetFromDate(new Date(2019, 0, 1))).toEqual({
+			byDay: 'TU',
+			bySetPosition: 1
+		})
+		expect(getBySetPositionAndBySetFromDate(new Date(2019, 0, 8))).toEqual({
+			byDay: 'TU',
+			bySetPosition: 2
+		})
+		expect(getBySetPositionAndBySetFromDate(new Date(2019, 0, 15))).toEqual({
+			byDay: 'TU',
+			bySetPosition: 3
+		})
+		expect(getBySetPositionAndBySetFromDate(new Date(2019, 0, 22))).toEqual({
+			byDay: 'TU',
+			bySetPosition: 4
+		})
+		expect(getBySetPositionAndBySetFromDate(new Date(2019, 0, 29))).toEqual({
+			byDay: 'TU',
+			bySetPosition: 5
+		})
+	})
+
+	it('should get the weekday for a date object', () => {
+		expect(getWeekDayFromDate(new Date(2019, 0, 1))).toEqual('TU')
+		expect(getWeekDayFromDate(new Date(2019, 0, 2))).toEqual('WE')
+		expect(getWeekDayFromDate(new Date(2019, 0, 3))).toEqual('TH')
+		expect(getWeekDayFromDate(new Date(2019, 0, 4))).toEqual('FR')
+		expect(getWeekDayFromDate(new Date(2019, 0, 5))).toEqual('SA')
+		expect(getWeekDayFromDate(new Date(2019, 0, 6))).toEqual('SU')
+		expect(getWeekDayFromDate(new Date(2019, 0, 7))).toEqual('MO')
+
+		expect(() => {
+			getWeekDayFromDate({
+				getDay: () => 99
+			})
+		}).toThrow(TypeError)
+	})
+})

--- a/tests/javascript/unit/utils/router.test.js
+++ b/tests/javascript/unit/utils/router.test.js
@@ -1,0 +1,55 @@
+/**
+ * @copyright Copyright (c) 2019 Georg Ehrke
+ *
+ * @author Georg Ehrke <oc.list@georgehrke.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+import {
+	getInitialView,
+	getPrefixedRoute
+} from '../../../../src/utils/router.js'
+import * as settingsUtil from '../../../../src/utils/settings.js'
+
+jest.mock('../../../../src/utils/settings.js')
+
+describe('utils/router test suite', () => {
+
+	it('should get the initial view', () => {
+		settingsUtil.getConfigValueFromHiddenInput
+			.mockReturnValueOnce('dayGridView')
+			.mockReturnValueOnce(null)
+
+		expect(getInitialView()).toEqual('dayGridView')
+		expect(getInitialView()).toEqual('month')
+
+		expect(settingsUtil.getConfigValueFromHiddenInput.mock.calls.length).toEqual(2)
+		expect(settingsUtil.getConfigValueFromHiddenInput.mock.calls[0]).toEqual(['initial-view'])
+		expect(settingsUtil.getConfigValueFromHiddenInput.mock.calls[1]).toEqual(['initial-view'])
+	})
+
+	it('should provide the prefixed route name to navigate to', () => {
+		expect(getPrefixedRoute('PublicCalendarView', 'EditPopoverView')).toEqual('PublicEditPopoverView')
+		expect(getPrefixedRoute('PublicEditPopoverView', 'CalendarView')).toEqual('PublicCalendarView')
+
+		expect(getPrefixedRoute('EmbedCalendarView', 'EditPopoverView')).toEqual('EmbedEditPopoverView')
+		expect(getPrefixedRoute('EmbedEditPopoverView', 'CalendarView')).toEqual('EmbedCalendarView')
+
+		expect(getPrefixedRoute('CalendarView', 'EditPopoverView')).toEqual('EditPopoverView')
+		expect(getPrefixedRoute('EditPopoverView', 'CalendarView')).toEqual('CalendarView')
+	})
+})

--- a/tests/javascript/unit/utils/settings.test.js
+++ b/tests/javascript/unit/utils/settings.test.js
@@ -1,0 +1,46 @@
+/**
+ * @copyright Copyright (c) 2019 Georg Ehrke
+ *
+ * @author Georg Ehrke <oc.list@georgehrke.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+import {
+	getConfigValueFromHiddenInput,
+	getLinkToConfig
+} from '../../../../src/utils/settings.js'
+
+jest.mock('@nextcloud/router')
+
+describe('utils/settings test suite', () => {
+
+	it('should read a config value from DOM', () => {
+		document.body.innerHTML = `
+<input id="config-first-day" value="1" />
+<input id="config-show-weekends" value="0" />
+`
+
+		expect(getConfigValueFromHiddenInput('first-day')).toEqual('1')
+		expect(getConfigValueFromHiddenInput('show-weekends')).toEqual('0')
+		expect(getConfigValueFromHiddenInput('show-week-numbers')).toEqual(null)
+	})
+
+	it('should generate a link to the config api', () => {
+		expect(getLinkToConfig('view')).toEqual('linkTo###calendar###index.php/v1/config/view')
+		expect(getLinkToConfig('weekends')).toEqual('linkTo###calendar###index.php/v1/config/weekends')
+	})
+})

--- a/tests/javascript/unit/utils/timezone.test.js
+++ b/tests/javascript/unit/utils/timezone.test.js
@@ -1,0 +1,110 @@
+/**
+ * @copyright Copyright (c) 2019 Georg Ehrke
+ *
+ * @author Georg Ehrke <oc.list@georgehrke.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+import {
+	getSortedTimezoneList,
+	getReadableTimezoneName
+} from '../../../../src/utils/timezone.js'
+
+jest.mock('@nextcloud/l10n')
+
+describe('utils/timezone test suite', () => {
+
+	it('should sort a timezone list', () => {
+		const sorted = getSortedTimezoneList([
+			'Europe/Berlin',
+			'Europe/Amsterdam',
+			'Europe/Paris',
+			'America/New_York',
+			'America/Los_Angeles',
+			'UTC',
+			'Z',
+			'GMT'
+		], [{
+			continent: 'FOO',
+			label: 'ABC',
+			timezoneId: 'id123'
+		}, {
+			continent: 'TRANSLATED:Global',
+			label: 'DEF',
+			timezoneId: 'id456'
+		}])
+
+		expect(sorted.length).toEqual(4)
+		expect(sorted[0].continent).toEqual('America')
+		expect(sorted[0].regions).toEqual([{
+			cities: [],
+			label: 'Los Angeles',
+			timezoneId: 'America/Los_Angeles'
+		}, {
+			cities: [],
+			label: 'New York',
+			timezoneId: 'America/New_York'
+		}])
+
+		expect(sorted[1].continent).toEqual('Europe')
+		expect(sorted[1].regions).toEqual([{
+			cities: [],
+			label: 'Amsterdam',
+			timezoneId: 'Europe/Amsterdam'
+		}, {
+			cities: [],
+			label: 'Berlin',
+			timezoneId: 'Europe/Berlin'
+		}, {
+			cities: [],
+			label: 'Paris',
+			timezoneId: 'Europe/Paris'
+		}])
+
+		expect(sorted[2].continent).toEqual('FOO')
+		expect(sorted[2].regions).toEqual([{
+			cities: [],
+			label: 'ABC',
+			timezoneId: 'id123'
+		}])
+
+		expect(sorted[3].continent).toEqual('TRANSLATED:Global')
+		expect(sorted[3].regions).toEqual([{
+			cities: [],
+			label: 'DEF',
+			timezoneId: 'id456'
+		}, {
+			cities: [],
+			label: 'GMT',
+			timezoneId: 'GMT'
+		}, {
+			cities: [],
+			label: 'UTC',
+			timezoneId: 'UTC'
+		}, {
+			cities: [],
+			label: 'Z',
+			timezoneId: 'Z'
+		}])
+	})
+
+	it ('should get a readable timezone name', () => {
+		expect(getReadableTimezoneName('Europe/Berlin')).toEqual('Europe - Berlin')
+		expect(getReadableTimezoneName('America/New_York')).toEqual('America - New York')
+		expect(getReadableTimezoneName('America/St_Johns')).toEqual('America - St. Johns')
+	})
+})


### PR DESCRIPTION
Replaced `getRandomColor` and `getDefaultColor` with `uidToColor`.

Wrote unit tests for most modules inside `utils/`