### PR TITLE
Link to event

### DIFF
--- a/src/models/calendarObject.js
+++ b/src/models/calendarObject.js
@@ -25,6 +25,9 @@ import { getParserManager } from 'calendar-js'
 import DateTimeValue from 'calendar-js/src/values/dateTimeValue'
 import CalendarComponent from 'calendar-js/src/components/calendarComponent'
 
+/**
+ * This model represents exactly
+ */
 export default class CalendarObject {
 
 	/**
@@ -161,6 +164,25 @@ export default class CalendarObject {
 		const s = DateTimeValue.fromJSDate(start, true)
 		const e = DateTimeValue.fromJSDate(end, true)
 		return firstVObject.recurrenceManager.getAllOccurrencesBetween(s, e)
+	}
+
+	/**
+	 * Get recurrence-item closest to the given recurrence-Id
+	 * This is either the one next in the future or if none exist,
+	 * the one closest in the past
+	 *
+	 * @param {Date} closeTo The time to get the
+	 * @returns {AbstractRecurringComponent|null}
+	 */
+	getClosestRecurrence(closeTo) {
+		const iterator = this.vcalendar.getVObjectIterator()
+		const firstVObject = iterator.next().value
+		if (!firstVObject) {
+			return null
+		}
+
+		const d = DateTimeValue.fromJSDate(closeTo, true)
+		return firstVObject.recurrenceManager.getClosestOccurrence(d)
 	}
 
 	/**

--- a/src/router.js
+++ b/src/router.js
@@ -92,6 +92,14 @@ const router = new Router({
 			path: '/embed/:tokens',
 			redirect: `/embed/:tokens/${getInitialView()}/now`,
 		},
+		{
+			path: '/edit/:object',
+			redirect: '/${getInitialView()}/now/edit/sidebar/:object/next'
+		},
+		{
+			path: '/edit/:object/:recurrenceId',
+			redirect: '/${getInitialView()}/now/edit/sidebar/:object/:recurrenceId'
+		},
 		/**
 		 * This is the main route that contains the current view and viewed day
 		 * It has to be last, so that other routes starting with /p/, etc. match first

--- a/src/router.js
+++ b/src/router.js
@@ -94,11 +94,11 @@ const router = new Router({
 		},
 		{
 			path: '/edit/:object',
-			redirect: '/${getInitialView()}/now/edit/sidebar/:object/next'
+			redirect: `/${getInitialView()}/now/edit/sidebar/:object/next`,
 		},
 		{
 			path: '/edit/:object/:recurrenceId',
-			redirect: '/${getInitialView()}/now/edit/sidebar/:object/:recurrenceId'
+			redirect: `/${getInitialView()}/now/edit/sidebar/:object/:recurrenceId`,
 		},
 		/**
 		 * This is the main route that contains the current view and viewed day


### PR DESCRIPTION
fixes #21 

Allows to link to a specific event without knowing a specific recurrence-id.

Opening `/:view/:date/edit/sidebar/:object/next` will automatically forward to `/:view/:date/edit/sidebar/:object/{closest occurrence}`