### PR TITLE
Bring back now indicator in calendar-grid

### DIFF
--- a/src/views/Calendar.vue
+++ b/src/views/Calendar.vue
@@ -57,6 +57,7 @@
 				:selectable="isSelectable"
 				:select-mirror="true"
 				:lazy-fetching="false"
+				:now-indicator="true"
 				:progressive-event-rendering="true"
 				:unselect-auto="false"
 				:week-numbers-within-days="true"


### PR DESCRIPTION
Got lost in vue transition.