### PR TITLE
Remove the Shared label, because it is taking up too much space in the apps-navigation

### DIFF
--- a/css/app-navigation.scss
+++ b/css/app-navigation.scss
@@ -121,10 +121,6 @@
 		opacity: 0.7 !important;
 	}
 
-	span.shared-label {
-		margin-left: -12px;
-	}
-
 	button.icon-share:active,
 	button.icon-share:focus,
 	button.icon-share:hover,

--- a/src/components/AppNavigation/CalendarList/CalendarListItem.vue
+++ b/src/components/AppNavigation/CalendarList/CalendarListItem.vue
@@ -40,9 +40,6 @@
 			<Actions v-if="showSharingIcon">
 				<ActionButton :icon="sharingIconClass" @click="toggleShareMenu" />
 			</Actions>
-			<span v-if="isSharedOrPublished" class="shared-label" @click.prevent.stop="toggleShareMenu">
-				{{ $t('calendar', 'Shared') }}
-			</span>
 			<Avatar v-if="isSharedWithMe && loadedOwnerPrincipal" :user="ownerUserId" :display-name="ownerDisplayname" />
 			<div v-if="isSharedWithMe && !loadedOwnerPrincipal" class="icon icon-loading" />
 		</template>


### PR DESCRIPTION
fixes #1655 

![21F09D9C-1149-46F9-A6E3-040E75A9824A](https://user-images.githubusercontent.com/1250540/69414229-96df2400-0d12-11ea-986d-6354fe006989.png)


Signed-off-by: Georg Ehrke <developer@georgehrke.com>