### PR TITLE
Release/2.0.0 beta3 appstore

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -31,7 +31,7 @@
 	<screenshot>https://raw.githubusercontent.com/nextcloud/calendar/master/screenshots/sidebar_attendees.png</screenshot>
 	<screenshot>https://raw.githubusercontent.com/nextcloud/calendar/master/screenshots/sidebar_reminders.png</screenshot>
 	<dependencies>
-		<nextcloud min-version="17" max-version="18" />
+		<nextcloud min-version="18" max-version="18" />
 	</dependencies>
 	<repair-steps>
 		<post-migration>


### PR DESCRIPTION
Special build of 2.0.0 beta 3 to be released on the appstore.
Only difference is that min-version is 18.

(This allows people using Nextcloud 18 beta to easily test the calendar, without publishing it as stable for the 17 branch yet)