### PR TITLE
Bring back event-limit

### DIFF
--- a/src/fullcalendar/eventLimitText.js
+++ b/src/fullcalendar/eventLimitText.js
@@ -1,0 +1,32 @@
+/**
+ * @copyright Copyright (c) 2020 Georg Ehrke
+ *
+ * @author Georg Ehrke <oc.list@georgehrke.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+import { translatePlural as n } from '@nextcloud/l10n'
+
+/**
+ * Provide the string when the event limit is hit
+ *
+ * @param {Number} count Number of omitted event
+ * @returns {string}
+ */
+export default function(count) {
+	return n('calendar', '+%n more', '+%n more', count)
+}

--- a/src/views/Calendar.vue
+++ b/src/views/Calendar.vue
@@ -1,5 +1,5 @@
 <!--
-  - @copyright Copyright (c) 2019 Georg Ehrke <oc.list@georgehrke.com>
+  - @copyright Copyright (c) 2020 Georg Ehrke <oc.list@georgehrke.com>
   - @author Georg Ehrke <oc.list@georgehrke.com>
   -
   - @license GNU AGPL version 3 or any later version
@@ -51,6 +51,8 @@
 				:plugins="plugins"
 				:time-zone="timezoneId"
 				:event-allow="eventAllow"
+				:event-limit="true"
+				:event-limit-text="eventLimitText"
 				:default-date="defaultDate"
 				:locales="locales"
 				:locale="fullCalendarLocale"
@@ -123,6 +125,7 @@ import EmbedTopNavigation from '../components/AppNavigation/EmbedTopNavigation.v
 import EmptyCalendar from '../components/EmptyCalendar.vue'
 import { getLocale } from '@nextcloud/l10n'
 import loadMomentLocalization from '../utils/moment.js'
+import eventLimitText from '../fullcalendar/eventLimitText.js'
 
 export default {
 	name: 'Calendar',
@@ -373,6 +376,9 @@ export default {
 		},
 		navLinkWeekClick(...args) {
 			return navLinkWeekClick(this.$router, this.$route)(...args)
+		},
+		eventLimitText(...args) {
+			return eventLimitText(...args)
 		},
 		/**
 		 * Loads the locale data for full-calendar

--- a/tests/javascript/unit/fullcalendar/eventLimitText.test.js
+++ b/tests/javascript/unit/fullcalendar/eventLimitText.test.js
@@ -1,0 +1,44 @@
+/**
+ * @copyright Copyright (c) 2020 Georg Ehrke
+ *
+ * @author Georg Ehrke <oc.list@georgehrke.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+import { translatePlural } from '@nextcloud/l10n'
+import eventLimitText from "../../../../src/fullcalendar/eventLimitText.js";
+jest.mock('@nextcloud/l10n')
+
+describe('fullcalendar/eventSourceFunction test suite', () => {
+
+	beforeEach(() => {
+		translatePlural.mockClear()
+
+		translatePlural
+			.mockImplementation((app, sinStr, pluStr) => pluStr)
+	})
+
+	it('should provide a string for event-limit', () => {
+		expect(eventLimitText(1)).toEqual('+%n more')
+		expect(eventLimitText(42)).toEqual('+%n more')
+
+		expect(translatePlural).toHaveBeenCalledTimes(2)
+		expect(translatePlural).toHaveBeenNthCalledWith(1, 'calendar', '+%n more', '+%n more', 1)
+		expect(translatePlural).toHaveBeenNthCalledWith(2, 'calendar', '+%n more', '+%n more', 42)
+	})
+})


### PR DESCRIPTION
Before:
![C9D74638-E04E-4A5D-A5FD-520CE1E8E528](https://user-images.githubusercontent.com/1250540/72251865-bef64f80-35fe-11ea-9eac-dd63ada5dd19.jpg)

After:
![6776DB03-D99F-4FA3-9B7B-A78AFD757A50](https://user-images.githubusercontent.com/1250540/72251889-c4ec3080-35fe-11ea-9b8f-93358c33d5fa.jpg)

Prevents one week from taking over the entire month view.