### PR TITLE
Make userid nullable

### DIFF
--- a/lib/Controller/ViewController.php
+++ b/lib/Controller/ViewController.php
@@ -63,7 +63,7 @@ class ViewController extends Controller {
 								IRequest $request,
 								IConfig $config,
 								IAppManager $appManager,
-								string $userId) {
+								?string $userId) {
 		parent::__construct($appName, $request);
 		$this->config = $config;
 		$this->userId = $userId;


### PR DESCRIPTION
Try to access the calendar directly without logging in first.

It will throw a 500, because $userId is null and not a string.
This PR allows a null $userId in the constructor.

Authentication check is run before calling `index`, so we don't need to check for null there.

Nullable syntax is available on all supported PHP Versions.