### PR TITLE
Handle window resize on our own instead of relying on fullcalendar

### DIFF
--- a/src/fullcalendar/windowResize.js
+++ b/src/fullcalendar/windowResize.js
@@ -1,0 +1,35 @@
+/**
+ * @copyright Copyright (c) 2020 Georg Ehrke
+ *
+ * @author Georg Ehrke <oc.list@georgehrke.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+/**
+ * Determines the height of the full-calendar element
+ *
+ * @param {Window} window The window object
+ * @param {Node=} header The header-element
+ * @returns {Function}
+ */
+export default function(window, header = null) {
+	return function() {
+		const headerHeight = header ? header.offsetHeight : 0
+		return window.innerHeight - headerHeight
+	}
+}

--- a/src/views/Calendar.vue
+++ b/src/views/Calendar.vue
@@ -42,7 +42,7 @@
 				:editable="isEditable"
 				:force-event-duration="true"
 				:header="showHeader"
-				height="parent"
+				:height="windowResize"
 				:slot-duration="slotDuration"
 				:week-numbers="showWeekNumbers"
 				:weekends="showWeekends"
@@ -126,6 +126,7 @@ import EmptyCalendar from '../components/EmptyCalendar.vue'
 import { getLocale } from '@nextcloud/l10n'
 import loadMomentLocalization from '../utils/moment.js'
 import eventLimitText from '../fullcalendar/eventLimitText.js'
+import windowResize from '../fullcalendar/windowResize.js'
 
 export default {
 	name: 'Calendar',
@@ -379,6 +380,9 @@ export default {
 		},
 		eventLimitText(...args) {
 			return eventLimitText(...args)
+		},
+		windowResize(...args) {
+			return windowResize(window, document.querySelector('#header'))(...args)
 		},
 		/**
 		 * Loads the locale data for full-calendar

--- a/tests/javascript/unit/fullcalendar/windowResize.js
+++ b/tests/javascript/unit/fullcalendar/windowResize.js
@@ -1,0 +1,48 @@
+/**
+ * @copyright Copyright (c) 2020 Georg Ehrke
+ *
+ * @author Georg Ehrke <oc.list@georgehrke.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+import windowResize from "../../../../src/fullcalendar/windowResize.js";
+
+describe('fullcalendar/windowResize test suite', () => {
+
+	it('should provide the correct height with header bar', () => {
+		const window = {
+			innerHeight: 1337
+		}
+		const header = {
+			offsetHeight: 42
+		}
+		const view = {}
+
+		expect(windowResize(window, header)(view)).toEqual(1295)
+	})
+
+	it('should provide the correct height without header bar', () => {
+		const window = {
+			innerHeight: 1337
+		}
+		const header = null
+		const view = {}
+
+		expect(windowResize(window, header)(view)).toEqual(1337)
+	})
+})


### PR DESCRIPTION
On master, if you resize a window to be bigger, fullcalendar properly scales up.
If you make the window smaller (height wise), fullcalendar will not size down.

This pull-request introduces a windowResize method that handles it instead of relying on the fullcalendar "parent" setting.