### PR TITLE
Convert eventRender from event to prop

### DIFF
--- a/src/views/Calendar.vue
+++ b/src/views/Calendar.vue
@@ -67,10 +67,10 @@
 				:progressive-event-rendering="true"
 				:unselect-auto="false"
 				:week-numbers-within-days="true"
+				:event-render="eventRender"
 				@eventClick="eventClick"
 				@eventDrop="eventDrop"
 				@eventResize="eventResize"
-				@eventRender="eventRender"
 				@select="select" />
 
 			<EmptyCalendar


### PR DESCRIPTION
Fixes:
```
main.esm.js:379 Use of eventRender as an event is deprecated. Please convert to a prop.
```