### PR TITLE
Hide vertical scroll bar in Firefox

### DIFF
--- a/css/global.scss
+++ b/css/global.scss
@@ -23,3 +23,9 @@
 .toast-calendar-multiline {
 	white-space: pre-wrap;
 }
+
+#content.app-calendar {
+	> div#app-content {
+		overflow-x: hidden;
+	}
+}


### PR DESCRIPTION
On Master, Firefox has a vertical scrollbar, although all content is visible.
This pull-request disables vertical scrolling.