### PR TITLE
Set no rewrite for generateUrl, in case URL contains index.php despite configured rewrite

### DIFF
--- a/src/router.js
+++ b/src/router.js
@@ -21,7 +21,7 @@
 
 import Vue from 'vue'
 import Router from 'vue-router'
-import { generateUrl } from '@nextcloud/router'
+import { getRootUrl, generateUrl } from '@nextcloud/router'
 
 import Calendar from './views/Calendar'
 import EditSimple from './views/EditSimple'
@@ -31,9 +31,15 @@ import { getInitialView } from './utils/router.js'
 
 Vue.use(Router)
 
+const webRootWithIndexPHP = getRootUrl() + '/index.php'
+const doesURLContainIndexPHP = window.location.pathname.startsWith(webRootWithIndexPHP)
+const base = generateUrl('apps/calendar', {}, {
+	noRewrite: doesURLContainIndexPHP,
+})
+
 const router = new Router({
 	mode: 'history',
-	base: generateUrl('/apps/calendar'),
+	base,
 	routes: [
 		{
 			path: '/p/:tokens/:view/:firstDay',


### PR DESCRIPTION
If you configure URL rewrite, `generateURL` will by default always skip the index.php
Nonetheless, you can still open the URL with the `index.php`

If you access the URL with `index.php`, the router base will be wrong and routing will break:

http://nextcloud.local/index.php/apps/calendar/p/tsQnYebgwxrF67QK/dayGridMonth/now is broken
http://nextcloud.local/apps/calendar/p/tsQnYebgwxrF67QK/dayGridMonth/now works

This branch double checks for index.php and disables rewriting if there is one.
