### PR TITLE
replace old views in case migration didn't run correctly

### DIFF
--- a/lib/Controller/ViewController.php
+++ b/lib/Controller/ViewController.php
@@ -86,12 +86,34 @@ class ViewController extends Controller {
 		return new TemplateResponse($this->appName, 'main', [
 			'app_version' => $this->config->getAppValue($this->appName, 'installed_version'),
 			'first_run' => $this->config->getUserValue($this->userId, $this->appName, 'firstRun', 'yes') === 'yes',
-			'initial_view' => $this->config->getUserValue($this->userId, $this->appName, 'currentView', $defaultInitialView),
+			'initial_view' => $this->getView($this->config->getUserValue($this->userId, $this->appName, 'currentView', $defaultInitialView)),
 			'show_weekends' => $this->config->getUserValue($this->userId, $this->appName, 'showWeekends', $defaultShowWeekends) === 'yes',
 			'show_week_numbers' => $this->config->getUserValue($this->userId, $this->appName, 'showWeekNr', $defaultWeekNumbers) === 'yes',
 			'skip_popover' => $this->config->getUserValue($this->userId, $this->appName, 'skipPopover', $defaultSkipPopover) === 'yes',
 			'talk_enabled' => $this->appManager->isEnabledForUser('spreed'),
 			'timezone' => $this->config->getUserValue($this->userId, $this->appName, 'timezone', $defaultTimezone),
 		]);
+	}
+
+	/**
+	 * Makes sure we don't use the old views anymore
+	 *
+	 * @param string $view
+	 * @return string
+	 */
+	private function getView(string $view): string {
+		switch ($view) {
+			case 'agendaDay':
+				return 'timeGridDay';
+
+			case 'agendaWeek':
+				return 'timeGridWeek';
+
+			case 'month':
+				return 'dayGridMonth';
+
+			default:
+				return $view;
+		}
 	}
 }

--- a/src/utils/router.js
+++ b/src/utils/router.js
@@ -27,7 +27,7 @@ import { getConfigValueFromHiddenInput } from './settings.js'
  * @returns {String}
  */
 export function getInitialView() {
-	return getConfigValueFromHiddenInput('initial-view') || 'month'
+	return getConfigValueFromHiddenInput('initial-view') || 'dayGridMonth'
 }
 
 /**

--- a/tests/javascript/unit/utils/router.test.js
+++ b/tests/javascript/unit/utils/router.test.js
@@ -35,7 +35,7 @@ describe('utils/router test suite', () => {
 			.mockReturnValueOnce(null)
 
 		expect(getInitialView()).toEqual('dayGridView')
-		expect(getInitialView()).toEqual('month')
+		expect(getInitialView()).toEqual('dayGridMonth')
 
 		expect(settingsUtil.getConfigValueFromHiddenInput.mock.calls.length).toEqual(2)
 		expect(settingsUtil.getConfigValueFromHiddenInput.mock.calls[0]).toEqual(['initial-view'])

--- a/tests/php/unit/Controller/ViewControllerTest.php
+++ b/tests/php/unit/Controller/ViewControllerTest.php
@@ -130,4 +130,96 @@ class ViewControllerTest extends TestCase {
 		$this->assertEquals('user', $response->getRenderAs());
 		$this->assertEquals('main', $response->getTemplateName());
 	}
+
+	/**
+	 * @dataProvider viewFixDataProvider
+	 *
+	 * @param string $savedView
+	 * @param string $expectedView
+	 */
+	public function testIndexViewFix(string $savedView, string $expectedView):void {
+		$this->config->expects($this->at(0))
+			->method('getAppValue')
+			->with('calendar', 'currentView', 'dayGridMonth')
+			->willReturn('defaultCurrentView');
+		$this->config->expects($this->at(1))
+			->method('getAppValue')
+			->with('calendar', 'showWeekends', 'yes')
+			->willReturn('defaultShowWeekends');
+		$this->config->expects($this->at(2))
+			->method('getAppValue')
+			->with('calendar', 'showWeekNr', 'no')
+			->willReturn('defaultShowWeekNr');
+		$this->config->expects($this->at(3))
+			->method('getAppValue')
+			->with('calendar', 'skipPopover', 'no')
+			->willReturn('defaultSkipPopover');
+		$this->config->expects($this->at(4))
+			->method('getAppValue')
+			->with('calendar', 'timezone', 'automatic')
+			->willReturn('defaultTimezone');
+
+		$this->config->expects($this->at(5))
+			->method('getAppValue')
+			->with('calendar', 'installed_version')
+			->willReturn('1.0.0');
+		$this->config->expects($this->at(6))
+			->method('getUserValue')
+			->with('user123', 'calendar', 'firstRun', 'yes')
+			->willReturn('yes');
+		$this->config->expects($this->at(7))
+			->method('getUserValue')
+			->with('user123', 'calendar', 'currentView', 'defaultCurrentView')
+			->willReturn($savedView);
+		$this->config->expects($this->at(8))
+			->method('getUserValue')
+			->with('user123', 'calendar', 'showWeekends', 'defaultShowWeekends')
+			->willReturn('yes');
+		$this->config->expects($this->at(9))
+			->method('getUserValue')
+			->with('user123', 'calendar', 'showWeekNr', 'defaultShowWeekNr')
+			->willReturn('yes');
+		$this->config->expects($this->at(10))
+			->method('getUserValue')
+			->with('user123', 'calendar', 'skipPopover', 'defaultSkipPopover')
+			->willReturn('yes');
+		$this->config->expects($this->at(11))
+			->method('getUserValue')
+			->with('user123', 'calendar', 'timezone', 'defaultTimezone')
+			->willReturn('Europe/Berlin');
+		$this->appManager->expects($this->at(0))
+			->method('isEnabledForUser')
+			->with('spreed')
+			->willReturn(true);
+
+		$response = $this->controller->index();
+
+		$this->assertInstanceOf(TemplateResponse::class, $response);
+		$this->assertEquals([
+			'app_version' => '1.0.0',
+			'first_run' => true,
+			'initial_view' => $expectedView,
+			'show_weekends' => true,
+			'show_week_numbers' => true,
+			'skip_popover' => true,
+			'talk_enabled' => true,
+			'timezone' => 'Europe/Berlin',
+		], $response->getParams());
+		$this->assertEquals('user', $response->getRenderAs());
+		$this->assertEquals('main', $response->getTemplateName());
+	}
+
+	/**
+	 * @return array
+	 */
+	public function viewFixDataProvider(): array {
+		return [
+			['agendaDay', 'timeGridDay'],
+			['timeGridDay', 'timeGridDay'],
+			['agendaWeek', 'timeGridWeek'],
+			['timeGridWeek', 'timeGridWeek'],
+			['month', 'dayGridMonth'],
+			['dayGridMonth', 'dayGridMonth'],
+		];
+	}
 }


### PR DESCRIPTION
... e.g. because the app was disabled during update

fixes #1831 