### PR TITLE
Fix generated embed code

### DIFF
--- a/src/components/AppNavigation/CalendarList/CalendarListItemSharingPublishItem.vue
+++ b/src/components/AppNavigation/CalendarList/CalendarListItemSharingPublishItem.vue
@@ -307,7 +307,7 @@ export default {
 
 			const rootURL = generateRemoteUrl('dav')
 			const token = this.calendar.publishURL.split('/').slice(-1)[0]
-			const url = new URL(generateUrl('apps/calendar') + '/e/' + token, rootURL)
+			const url = new URL(generateUrl('apps/calendar') + '/embed/' + token, rootURL)
 
 			const code = '<iframe width="400" height="215" src="' + url + '"></iframe>'
 


### PR DESCRIPTION
Copy embed Code should use `/embed/`, not `/e/`

https://github.com/nextcloud/calendar/blob/master/appinfo/routes.php#L37
https://github.com/nextcloud/calendar/blob/master/src/router.js#L98

fixes #1861 