### PR TITLE
Fix undefined css var

### DIFF
--- a/css/fullcalendar.scss
+++ b/css/fullcalendar.scss
@@ -151,7 +151,7 @@
 .fc-today.fc-wed:not(.fc-day-header),
 .fc-today.fc-thu:not(.fc-day-header),
 .fc-today.fc-fri:not(.fc-day-header) {
-	background-color: var(--color-background) !important;
+	background-color: var(--color-main-background) !important;
 }
 
 .fc-sat,


### PR DESCRIPTION
fixes #1905 

fixes missing CSS var.

Does not change anything about the design.
Without the explicit background-color, fullcalendar is by default transparent, so the visible color was the main background-color anyway.