### PR TITLE
Add "Gym" as keyword for working out illustrations

### DIFF
--- a/src/utils/illustration.js
+++ b/src/utils/illustration.js
@@ -369,6 +369,7 @@ const data = [{
 		'Exercise',
 		'Work out',
 		'Working out',
+		'Gym',
 		// TRANSLATORS This string is used for matching the event title to an illustration
 		t('calendar', 'Training'),
 		// TRANSLATORS This string is used for matching the event title to an illustration
@@ -381,6 +382,8 @@ const data = [{
 		t('calendar', 'Work out'),
 		// TRANSLATORS This string is used for matching the event title to an illustration
 		t('calendar', 'Working out'),
+		// TRANSLATORS This string is used for matching the event title to an illustration
+		t('calendar', 'Gym'),
 	],
 	illustrationNames: [
 		'personal_trainer',


### PR DESCRIPTION
This commit adds "Gym" as a word to show working out illustrations,
as well as adds translations to Afrikaans and Esperanto.

## Description

Adds a word to match to working out events.
Fixes #1888 

### Type of change

- [x] New feature (non-breaking change which adds functionality)

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I signed off my changes (`git commit -sm "Your commit message"`)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

