### PR TITLE
Properly localize subTitle of AppSidebar

### DIFF
--- a/src/views/EditSidebar.vue
+++ b/src/views/EditSidebar.vue
@@ -226,6 +226,8 @@ import { AppSidebarTab } from '@nextcloud/vue/dist/Components/AppSidebarTab'
 import { ActionLink } from '@nextcloud/vue/dist/Components/ActionLink'
 import { ActionButton } from '@nextcloud/vue/dist/Components/ActionButton'
 
+import { mapState } from 'vuex'
+
 import AlarmList from '../components/Editor/Alarm/AlarmList'
 
 import InviteesList from '../components/Editor/Invitees/InviteesList'
@@ -266,14 +268,15 @@ export default {
 		EditorMixin,
 	],
 	computed: {
+		...mapState({
+			locale: (state) => state.settings.momentLocale,
+		}),
 		subTitle() {
 			if (!this.calendarObjectInstance) {
 				return ''
 			}
 
-			// This is hardcoded for now till https://github.com/ChristophWurst/nextcloud-moment/issues/31 is fixed
-			moment.locale('en')
-			return moment(this.calendarObjectInstance.startDate).fromNow()
+			return moment(this.calendarObjectInstance.startDate).locale(this.locale).fromNow()
 		},
 		accessClass() {
 			if (!this.calendarObjectInstance) {


### PR DESCRIPTION
fixes #1912 

![B84F0396-A36E-481F-84C3-429C602688CC](https://user-images.githubusercontent.com/1250540/73358750-a2654300-429f-11ea-97d4-88da6a3551c9.png)
