### PR TITLE
Add hint to new calendar dropdown that subscriptions are read-only

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6216,7 +6216,7 @@
     },
     "calendar-js": {
       "version": "git+https://github.com/georgehrke/calendar-js.git#2ed788a89947a3223931eb30296bcf3823c6ab0f",
-      "from": "git+https://github.com/georgehrke/calendar-js.git#2ed788a89947a3223931eb30296bcf3823c6ab0f",
+      "from": "git+https://github.com/georgehrke/calendar-js.git",
       "requires": {
         "ical.js": "^1.3.0",
         "uuid": "^3.4.0"

--- a/src/components/AppNavigation/CalendarList/CalendarListNew.vue
+++ b/src/components/AppNavigation/CalendarList/CalendarListNew.vue
@@ -66,7 +66,7 @@
 				v-if="showCreateSubscriptionLabel"
 				icon="icon-public"
 				@click.prevent.stop="openCreateSubscriptionInput">
-				{{ $t('calendar', 'New subscription from link') }}
+				{{ $t('calendar', 'New subscription from link (read-only)') }}
 			</ActionButton>
 			<ActionInput
 				v-if="showCreateSubscriptionInput"


### PR DESCRIPTION
Signed-off-by: Georg Ehrke <developer@georgehrke.com>

Related to https://github.com/nextcloud/calendar/issues/1837#issuecomment-580059883

| Before | After |
|:---------:|:------:|
|![before](https://user-images.githubusercontent.com/1250540/73458714-fd696980-4375-11ea-9e28-6e5470a0ad8b.jpg)|![after](https://user-images.githubusercontent.com/1250540/73458717-ff332d00-4375-11ea-9185-4a5721704242.jpg)|




