### PR TITLE
query Application instead of constructing it

### DIFF
--- a/appinfo/app.php
+++ b/appinfo/app.php
@@ -22,5 +22,5 @@ declare(strict_types=1);
  */
 namespace OCA\Calendar\AppInfo;
 
-$app = new Application();
+$app = \OC::$server->query(Application::class);
 $app->registerNavigation();


### PR DESCRIPTION
Stops "RuntimeException: App class OCA\Calendar\AppInfo\Application is not setup via query() but directly" log spam