### PR TITLE
Fix parsing of First day parameter

### DIFF
--- a/src/utils/date.js
+++ b/src/utils/date.js
@@ -62,7 +62,13 @@ export function getDateFromFirstdayParam(firstDayParam) {
 		return dateFactory()
 	}
 
-	return new Date(firstDayParam)
+	const [year, month, date] = firstDayParam.split('-')
+		.map((str) => parseInt(str, 10))
+	const dateObject = dateFactory()
+	dateObject.setFullYear(year, month - 1, date)
+	dateObject.setHours(0, 0, 0, 0)
+
+	return dateObject
 }
 
 /**

--- a/src/utils/date.js
+++ b/src/utils/date.js
@@ -20,6 +20,8 @@
  *
  */
 
+import logger from './logger.js'
+
 /**
  * returns a new Date object
  *
@@ -64,6 +66,12 @@ export function getDateFromFirstdayParam(firstDayParam) {
 
 	const [year, month, date] = firstDayParam.split('-')
 		.map((str) => parseInt(str, 10))
+
+	if (Number.isNaN(year) || Number.isNaN(month) || Number.isNaN(date)) {
+		logger.error('First day parameter contains non-numerical components, falling back to today')
+		return dateFactory()
+	}
+
 	const dateObject = dateFactory()
 	dateObject.setFullYear(year, month - 1, date)
 	dateObject.setHours(0, 0, 0, 0)

--- a/tests/javascript/unit/utils/date.test.js
+++ b/tests/javascript/unit/utils/date.test.js
@@ -28,8 +28,15 @@ import {
 	getDateFromDateTimeValue,
 	modifyDate
 } from '../../../../src/utils/date.js'
+import logger from '../../../../src/utils/logger.js'
+jest.mock('../../../../src/utils/logger.js')
 
 describe('utils/alarms test suite', () => {
+
+	beforeEach(() => {
+		logger.error.mockClear()
+	})
+
 
 	it('should return a date', () => {
 		expect(dateFactory()).toBeInstanceOf(Date)
@@ -70,6 +77,23 @@ describe('utils/alarms test suite', () => {
 		expect(date2.getSeconds()).toEqual(0)
 		expect(date2.getMilliseconds()).toEqual(0)
 		expect(date2.getTimezoneOffset()).toEqual(expectedTimezoneOffset)
+	})
+
+	it('should log an error when providing a non-numerical first-day-parameter', () => {
+		const date1 = getDateFromFirstdayParam('ab-05-05')
+		const date2 = getDateFromFirstdayParam('2020-ab-06')
+		const date3 = getDateFromFirstdayParam('2020-06-ab')
+
+		// It should return a Date anyway
+		expect(date1).toBeInstanceOf(Date)
+		expect(date2).toBeInstanceOf(Date)
+		expect(date3).toBeInstanceOf(Date)
+
+		// but also log an error message
+		expect(logger.error).toHaveBeenCalledTimes(3)
+		expect(logger.error).toHaveBeenNthCalledWith(1, 'First day parameter contains non-numerical components, falling back to today')
+		expect(logger.error).toHaveBeenNthCalledWith(2, 'First day parameter contains non-numerical components, falling back to today')
+		expect(logger.error).toHaveBeenNthCalledWith(3, 'First day parameter contains non-numerical components, falling back to today')
 	})
 
 	it('shoud get YYYYMMDD from a given first day-param', () => {

--- a/tests/javascript/unit/utils/date.test.js
+++ b/tests/javascript/unit/utils/date.test.js
@@ -51,12 +51,25 @@ describe('utils/alarms test suite', () => {
 		const date1 = getDateFromFirstdayParam('2019-01-01')
 		const date2 = getDateFromFirstdayParam('2019-12-31')
 
+		const expectedTimezoneOffset = new Date().getTimezoneOffset()
+
 		expect(date1.getFullYear()).toEqual(2019)
 		expect(date1.getMonth()).toEqual(0)
 		expect(date1.getDate()).toEqual(1)
+		expect(date1.getHours()).toEqual(0)
+		expect(date1.getMinutes()).toEqual(0)
+		expect(date1.getSeconds()).toEqual(0)
+		expect(date1.getMilliseconds()).toEqual(0)
+		expect(date1.getTimezoneOffset()).toEqual(expectedTimezoneOffset)
+
 		expect(date2.getFullYear()).toEqual(2019)
 		expect(date2.getMonth()).toEqual(11)
 		expect(date2.getDate()).toEqual(31)
+		expect(date2.getHours()).toEqual(0)
+		expect(date2.getMinutes()).toEqual(0)
+		expect(date2.getSeconds()).toEqual(0)
+		expect(date2.getMilliseconds()).toEqual(0)
+		expect(date2.getTimezoneOffset()).toEqual(expectedTimezoneOffset)
 	})
 
 	it('shoud get YYYYMMDD from a given first day-param', () => {


### PR DESCRIPTION
fixes #1944 

This fixes an issue with parsing the first day parameter.
The problem is that `new Date()` parsed the parameter as UTC, because it looked like an ISO string.

Resulting in:
`const d1 = new Date('2020-02-16')`
`Sat Feb 15 2020 16:00:00 GMT-0800 (Pacific Standard Time)`

This PR parses the first day parameter manually.
Turning `2020-02-26` into `Wed Feb 26 2020 00:00:00 GMT-0800 (Pacific Standard Time)`