### PR TITLE
Release 2.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,64 @@
+# 2.0.2 - 2020-03-02
+### Added
+- Recognize Gym as event title for illustrations
+  [#1888](https://github.com/nextcloud/calendar/issues/1888)
+- Improve illustration matching for less false positives
+  [#1916](https://github.com/nextcloud/calendar/issues/1916)
+- Add illustrations keywords related to agile development
+  [#1873](https://github.com/nextcloud/calendar/pull/1873)
+- Add hint to new calendar dropdown that subscriptions are read-only
+  [#1938](https://github.com/nextcloud/calendar/pull/1938)
+- Move navigation to appinfo
+  [#1979](https://github.com/nextcloud/calendar/pull/1979)
+- Use InitialState API
+  [#1759](https://github.com/nextcloud/calendar/issues/1759)
+- Monthly-mode: scroll-bar instead of "more"
+  [#1889](https://github.com/nextcloud/calendar/issues/1889)
+- Adds a minimum height for fullcalendar-events
+  [#2020](https://github.com/nextcloud/calendar/pull/2020)
+- Better feedback for import failures
+  [#1920](https://github.com/nextcloud/calendar/issues/1920)
+- Custom color per event
+  [#71](https://github.com/nextcloud/calendar/issues/71)
+- Allow to configure slotDuration
+  [#2042](https://github.com/nextcloud/calendar/pull/2042)
+
+### Fixed
+- Undefined color variable
+  [#1905](https://github.com/nextcloud/calendar/issues/1905)
+- Localization of sub-title in AppSidebar
+  [#1912](https://github.com/nextcloud/calendar/issues/1912)
+- Localization of tab-title
+  [#1871](https://github.com/nextcloud/calendar/issues/1871)
+- Next month button skips one month the first time
+  [#1936](https://github.com/nextcloud/calendar/issues/1936)
+- Issue with background-color for icon in datepicker
+  [#1939](https://github.com/nextcloud/calendar/pull/1939)
+- Calendar color generator doesn't handle undefined calendar displayname
+  [#1941](https://github.com/nextcloud/calendar/issues/1941)
+- Sharing with users and groups with spaces
+  [#1985](https://github.com/nextcloud/calendar/pull/1985)
+- Birthday calender entries in wrong date format (in sidebar)
+  [#1923](https://github.com/nextcloud/calendar/issues/1923)
+- Stop hardcoding saturday and sunday as weekend, change it based on locale
+  [#2016](https://github.com/nextcloud/calendar/issues/2016)
+- Duration display issue with entries having a duration of a minute or less
+  [#1963](https://github.com/nextcloud/calendar/issues/1963)
+- Navigation and Display issue in day view
+  [#1944](https://github.com/nextcloud/calendar/issues/1944)
+- Handle files_sharing app being disabled
+  [#1967](https://github.com/nextcloud/calendar/issues/1967)
+- No calendar import (in Firefox and Edge on Windows)
+  [#1898](https://github.com/nextcloud/calendar/issues/1898)
+- Issue setting the end-timezone of an event
+  [#1914](https://github.com/nextcloud/calendar/issues/1914)
+- Calendar app cannot add repeats to an event after the event is created
+  [#2013](https://github.com/nextcloud/calendar/issues/2013)
+- Preserve duration when editing start time
+  [#1929](https://github.com/nextcloud/calendar/issues/1929)
+- Changes inside subcomponents not properly tracked
+  [#1891](https://github.com/nextcloud/calendar/issues/1891)
+
 ## 2.0.1 - 2020-01-20
 ### Fixed
 - Sort categories alphabetically

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -13,7 +13,7 @@
 * ⏰ **Reminders!** Get alarms for events inside your browser and via email.
 * 🙈 **We’re not reinventing the wheel!** Based on the great [c-dav library](https://github.com/nextcloud/cdav-library), [ical.js](https://github.com/mozilla-comm/ical.js) and [fullcalendar](https://github.com/fullcalendar/fullcalendar) libraries.
 	]]></description>
-	<version>2.0.1</version>
+	<version>2.0.2</version>
 	<licence>agpl</licence>
 	<author homepage="https://georg.coffee">Georg Ehrke</author>
 	<author homepage="https://tcit.fr">Thomas Citharel</author>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "calendar",
-	"version": "2.0.1",
+	"version": "2.0.2",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "calendar",
 	"description": "A calendar app for Nextcloud. Easily sync events from various devices, share and edit them online.",
-	"version": "2.0.1",
+	"version": "2.0.2",
 	"author": "Georg Ehrke <oc.list@georgehrke.com>",
 	"contributors": [
 		"Georg Ehrke <oc.list@georgehrke.com>",


### PR DESCRIPTION
Preparing the 2.0.2 release ...

I would still like to include the following in 2.0.2:
- [x] #2013 
- [x] #1929 
- [x] #1891 
- [x] #71 
- [x] update dependencies
- [x] https://github.com/nextcloud/calendar/pull/2042