### PR TITLE
Unlike other hrefs, Sharee URIs are not encoded by the server .... Properly handle that

### DIFF
--- a/src/models/calendar.js
+++ b/src/models/calendar.js
@@ -167,7 +167,8 @@ export function mapDavCollectionToCalendar(calendar, currentUserPrincipal) {
  * @returns {Object}
  */
 export function mapDavShareeToSharee(sharee) {
-	const id = btoa(sharee.href)
+	// sharee.href might contain non-latin characters, so let's uri encode it first
+	const id = btoa(encodeURI(sharee.href))
 
 	let displayName
 	if (sharee['common-name']) {


### PR DESCRIPTION
To reproduce, just create a group with non-latin characters.
e.g. `Федот Щербаков`

Share calendar with that group and reload.
On Master the calendar won't load anymore,
With this branch, it will work just fine.

fixes #1894 