### PR TITLE
Re-add @NoSameSiteCookieRequired to embedding route

### DIFF
--- a/lib/Controller/PublicViewController.php
+++ b/lib/Controller/PublicViewController.php
@@ -88,6 +88,7 @@ class PublicViewController extends Controller {
 	 *
 	 * @PublicPage
 	 * @NoCSRFRequired
+	 * @NoSameSiteCookieRequired
 	 *
 	 * @param string $token
 	 * @return TemplateResponse


### PR DESCRIPTION
This must have gotten lost during vue rewrite.
