### PR TITLE
Make sure popover editor does not leave boundaries

### DIFF
--- a/css/app-sidebar.scss
+++ b/css/app-sidebar.scss
@@ -666,6 +666,10 @@
 			}
 		}
 	}
+
+	&[x-out-of-boundaries] {
+		margin-top: 75px;
+	}
 }
 
 .event-popover.tooltip[x-placement^='bottom'] {

--- a/src/views/EditSimple.vue
+++ b/src/views/EditSimple.vue
@@ -25,7 +25,7 @@
 		:open="isOpen"
 		:auto-hide="false"
 		:placement="placement"
-		boundaries-element="#app-content"
+		:boundaries-element="boundaryElement"
 		open-class="event-popover"
 		trigger="manual">
 		<PopoverLoadingIndicator
@@ -144,6 +144,7 @@ export default {
 			isOpen: false,
 			hasLocation: false,
 			hasDescription: false,
+			boundaryElement: document.querySelector('#app-content > .fc'),
 		}
 	},
 	watch: {


### PR DESCRIPTION
fixes #1925 
fixes #1934
fixes #2109 

There is still room for some improvement, but this makes sure that the popover will never be outside the current viewport.

![Kapture 2020-04-06 at 10 58 48](https://user-images.githubusercontent.com/1250540/78541329-c2603800-77f5-11ea-9438-1dc7b12e2efe.gif)
