### PR TITLE
Do not allow multiline summaries in Calendar-grid

### DIFF
--- a/css/fullcalendar.scss
+++ b/css/fullcalendar.scss
@@ -187,6 +187,7 @@
 
 .fc-content {
 	background-color: inherit;
+	text-overflow: ellipsis;
 }
 
 .fc-popover.fc-more-popover {
@@ -197,5 +198,3 @@
 		background-color: var(--color-main-background);
 	}
 }
-
-

--- a/src/fullcalendar/eventSourceFunction.js
+++ b/src/fullcalendar/eventSourceFunction.js
@@ -77,7 +77,7 @@ export function eventSourceFunction(calendarObjects, calendar, start, end, timez
 
 			const fcEvent = {
 				id: [calendarObject.id, object.id].join('###'),
-				title: object.title || t('calendar', 'Untitled event'),
+				title: object.title ? object.title.replace(/\n/g, ' ') : t('calendar', 'Untitled event'),
 				allDay: object.isAllDay(),
 				start: jsStart,
 				end: jsEnd,

--- a/tests/javascript/unit/fullcalendar/eventSourceFunction.test.js
+++ b/tests/javascript/unit/fullcalendar/eventSourceFunction.test.js
@@ -96,6 +96,7 @@ describe('fullcalendar/eventSourceFunction test suite', () => {
 				})
 			},
 			hasComponent: jest.fn().mockReturnValue(false),
+			title: 'Untitled\nmultiline\nevent',
 		}, {
 			id: '1-3',
 			status: 'TENTATIVE',
@@ -202,7 +203,7 @@ describe('fullcalendar/eventSourceFunction test suite', () => {
 			},
 			{
 				id: '1###1-2',
-				title: 'Untitled event',
+				title: 'Untitled multiline event',
 				allDay: false,
 				start: event12Start,
 				end: event12End,
@@ -298,12 +299,11 @@ describe('fullcalendar/eventSourceFunction test suite', () => {
 		expect(eventComponentSet4[0].endDate.getInTimezone).toHaveBeenCalledTimes(1)
 		expect(eventComponentSet4[0].endDate.getInTimezone).toHaveBeenNthCalledWith(1, timezone)
 
-		expect(translate).toHaveBeenCalledTimes(5)
+		expect(translate).toHaveBeenCalledTimes(4)
 		expect(translate).toHaveBeenNthCalledWith(1, 'calendar', 'Untitled event')
 		expect(translate).toHaveBeenNthCalledWith(2, 'calendar', 'Untitled event')
 		expect(translate).toHaveBeenNthCalledWith(3, 'calendar', 'Untitled event')
 		expect(translate).toHaveBeenNthCalledWith(4, 'calendar', 'Untitled event')
-		expect(translate).toHaveBeenNthCalledWith(5, 'calendar', 'Untitled event')
 
 		expect(getAllObjectsInTimeRange).toHaveBeenCalledTimes(4)
 		expect(getAllObjectsInTimeRange).toHaveBeenNthCalledWith(1, calendarObjects[0], start, end)


### PR DESCRIPTION
fixes #1931 

Having multi-line summaries in the calendar-grid can cause issues, where fullcalendar only shows "+x more" for all events in the same row, although there is enough space to display the non-multiline ones of them.

Since we don't allow multiline Summaries in titles anymore, this PR makes sure that we do not show multiline summaries in the calendar-grid. New lines are replaced with a single space.

Furthermore, this PR adds a proper ellipsis for long titles:

| Before | After |
|:---------:|:------:|
|![1E11D6E5-3D5A-4006-B793-762EBEA2005C](https://user-images.githubusercontent.com/1250540/78883793-43b80480-7a5a-11ea-90a1-26b881460f08.png)|![B34456EE-2B51-4D36-B012-B66C74C55DE0](https://user-images.githubusercontent.com/1250540/78883832-50d4f380-7a5a-11ea-87d3-1fbfe2980386.png)|

