### PR TITLE
Add Keyboard shortcuts

### DIFF
--- a/css/app-settings.scss
+++ b/css/app-settings.scss
@@ -64,3 +64,49 @@
 		}
 	}
 }
+
+.shortcut-overview-modal {
+	.modal-container {
+		min-width: 600px;
+		display: flex !important;
+		flex-wrap: wrap;
+		padding: 0 12px 12px 12px !important;
+
+		* {
+			box-sizing: border-box;
+		}
+
+		.shortcut-section {
+			width: 50%;
+			flex-grow: 0;
+			flex-shrink: 0;
+			padding: 10px;
+
+			.shortcut-section-item {
+				width: 100%;
+				display: grid;
+				grid-template-columns: 33% 67%;
+				column-gap: 10px;
+
+				&:not(:first-child) {
+					margin-top: 10px;
+				}
+
+				&__keys {
+					display: block;
+					text-align: right;
+				}
+
+				&__label {
+					display: block;
+					text-align: left;
+					padding-top: 5px;
+				}
+
+				&__spacer {
+					margin: 0 3px;
+				}
+			}
+		}
+	}
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -4796,6 +4796,11 @@
 				"array-find-index": "^1.0.1"
 			}
 		},
+		"custom-event-polyfill": {
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/custom-event-polyfill/-/custom-event-polyfill-1.0.7.tgz",
+			"integrity": "sha512-TDDkd5DkaZxZFM8p+1I3yAlvM3rSr1wbrOliG4yJiwinMZN8z/iGL7BTlDkrJcYTmgUSb4ywVCc3ZaUtOtC76w=="
+		},
 		"cyclist": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/cyclist/-/cyclist-1.0.1.tgz",
@@ -5139,6 +5144,11 @@
 			"version": "1.3.395",
 			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.395.tgz",
 			"integrity": "sha512-kdn2cX6hZXDdz/O2Q8tZscITlsSv1a/7bOq/fQs7QAJ9iaRlnhZPccarNhxZv1tXgmgwCnKp/1lJNYLOG8Dxiw=="
+		},
+		"element-matches": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/element-matches/-/element-matches-0.1.2.tgz",
+			"integrity": "sha512-yWh1otcs3OKUWDvu/IxyI36ZI3WNaRZlI0uG/DK6fu0pap0VYZ0J5pEGTk1zakme+hT0OKHwhlHc0N5TJhY6yQ=="
 		},
 		"elliptic": {
 			"version": "6.5.2",
@@ -13796,6 +13806,15 @@
 			"version": "3.1.6",
 			"resolved": "https://registry.npmjs.org/vue-router/-/vue-router-3.1.6.tgz",
 			"integrity": "sha512-GYhn2ynaZlysZMkFE5oCHRUTqE8BWs/a9YbKpNLi0i7xD6KG1EzDqpHQmv1F5gXjr8kL5iIVS8EOtRaVUEXTqA=="
+		},
+		"vue-shortkey": {
+			"version": "3.1.7",
+			"resolved": "https://registry.npmjs.org/vue-shortkey/-/vue-shortkey-3.1.7.tgz",
+			"integrity": "sha512-Wm/vPXXS+4Wl/LoYpD+cZc0J0HIoVlY8Ep0JLIqqswmAya3XUBtsqKbhzEf9sXo+3rZ5p1YsUyZfXas8XD7YjQ==",
+			"requires": {
+				"custom-event-polyfill": "^1.0.7",
+				"element-matches": "^0.1.2"
+			}
 		},
 		"vue-style-loader": {
 			"version": "4.1.2",

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
 		"vue-click-outside": "^1.1.0",
 		"vue-clipboard2": "^0.3.1",
 		"vue-router": "^3.1.6",
+		"vue-shortkey": "^3.1.7",
 		"vuex": "^3.3.0",
 		"vuex-router-sync": "^5.0.0"
 	},

--- a/src/components/AppNavigation/AppNavigationHeader/AppNavigationHeaderDatePicker.vue
+++ b/src/components/AppNavigation/AppNavigationHeader/AppNavigationHeaderDatePicker.vue
@@ -23,11 +23,13 @@
 <template>
 	<div class="datepicker-button-section">
 		<button
+			v-shortkey="previousShortKeyConf"
 			:aria-label="previousLabel"
 			class="datepicker-button-section__previous button icon icon-leftarrow"
 			:title="previousLabel"
 			type="button"
-			@click="navigateToPreviousTimeRange" />
+			@click="navigateToPreviousTimeRange"
+			@shortkey="navigateToPreviousTimeRange" />
 		<button
 			class="datepicker-button-section__datepicker-label button datepicker-label"
 			@click.stop.prevent="toggleDatepicker"
@@ -43,11 +45,13 @@
 			:open.sync="isDatepickerOpen"
 			@change="navigateToDate" />
 		<button
+			v-shortkey="nextShortKeyConf"
 			:aria-label="nextLabel"
 			class="datepicker-button-section__next button icon icon-rightarrow"
 			:title="nextLabel"
 			type="button"
-			@click="navigateToNextTimeRange" />
+			@click="navigateToNextTimeRange"
+			@shortkey="navigateToNextTimeRange" />
 	</div>
 </template>
 
@@ -81,6 +85,12 @@ export default {
 		selectedDate() {
 			return getDateFromFirstdayParam(this.$route.params.firstDay)
 		},
+		previousShortKeyConf() {
+			return {
+				previous_p: ['p'],
+				previous_k: ['k'],
+			}
+		},
 		previousLabel() {
 			switch (this.view) {
 			case 'timeGridDay':
@@ -92,6 +102,12 @@ export default {
 			case 'dayGridMonth':
 			default:
 				return this.$t('calendar', 'Previous month')
+			}
+		},
+		nextShortKeyConf() {
+			return {
+				next_j: ['j'],
+				next_n: ['n'],
 			}
 		},
 		nextLabel() {

--- a/src/components/AppNavigation/AppNavigationHeader/AppNavigationHeaderNewEvent.vue
+++ b/src/components/AppNavigation/AppNavigationHeader/AppNavigationHeaderNewEvent.vue
@@ -21,7 +21,11 @@
   -->
 
 <template>
-	<button class="button primary new-event" @click="newEvent">
+	<button
+		v-shortkey="['c']"
+		class="button primary new-event"
+		@click="newEvent"
+		@shortkey="newEvent">
 		{{ $t('calendar', '+ New event') }}
 	</button>
 </template>

--- a/src/components/AppNavigation/AppNavigationHeader/AppNavigationHeaderTodayButton.vue
+++ b/src/components/AppNavigation/AppNavigationHeader/AppNavigationHeaderTodayButton.vue
@@ -22,10 +22,12 @@
 
 <template>
 	<button
+		v-shortkey="['t']"
 		:aria-label="title"
 		class="button today"
 		:title="title"
-		@click="today()">
+		@shortkey="today"
+		@click="today">
 		{{ $t('calendar', 'Today') }}
 	</button>
 </template>

--- a/src/components/AppNavigation/AppNavigationHeader/AppNavigationHeaderViewMenu.vue
+++ b/src/components/AppNavigation/AppNavigationHeader/AppNavigationHeaderViewMenu.vue
@@ -20,7 +20,11 @@
   -->
 
 <template>
-	<Actions :default-icon="defaultIcon" menu-align="right">
+	<Actions
+		v-shortkey="shortKeyConf"
+		:default-icon="defaultIcon"
+		menu-align="right"
+		@shortkey.native="selectViewFromShortcut">
 		<ActionButton
 			v-for="view in views"
 			:key="view.id"
@@ -57,6 +61,16 @@ export default {
 				label: this.$t('calendar', 'Month'),
 			}]
 		},
+		shortKeyConf() {
+			return {
+				timeGridDay: ['d'],
+				timeGridDay_Num: [1],
+				timeGridWeek: ['w'],
+				timeGridWeek_Num: [2],
+				dayGridMonth: ['m'],
+				dayGridMonth_Num: [3],
+			}
+		},
 		defaultIcon() {
 			for (const view of this.views) {
 				if (view.id === this.$route.params.view) {
@@ -80,6 +94,9 @@ export default {
 			}
 
 			this.$router.push({ name, params })
+		},
+		selectViewFromShortcut(event) {
+			this.selectView(event.srcKey.split('_')[0])
 		},
 	},
 }

--- a/src/components/AppNavigation/Settings.vue
+++ b/src/components/AppNavigation/Settings.vue
@@ -87,7 +87,7 @@
 				class="settings-fieldset-interior-item"
 				icon="icon-info"
 				@click.prevent.stop="showKeyboardShortcuts"
-				@shortkey.native="showKeyboardShortcuts">
+				@shortkey.native="toggleKeyboardShortcuts">
 				{{ $t('calendar', 'Show keyboard shortcuts') }}
 			</ActionButton>
 			<ShortcutOverview v-if="displayKeyboardShortcuts" @close="hideKeyboardShortcuts" />
@@ -331,16 +331,22 @@ export default {
 			}
 		},
 		/**
-		 * Show the keyboard shortcuts
+		 * Show the keyboard shortcuts overview
 		 */
 		showKeyboardShortcuts() {
 			this.displayKeyboardShortcuts = true
 		},
 		/**
-		 * Hide the keyboard shortcuts
+		 * Hide the keyboard shortcuts overview
 		 */
 		hideKeyboardShortcuts() {
 			this.displayKeyboardShortcuts = false
+		},
+		/**
+		 * Toggles the keyboard shortcuts overview
+		 */
+		toggleKeyboardShortcuts() {
+			this.displayKeyboardShortcuts = !this.displayKeyboardShortcuts
 		}
 	},
 }

--- a/src/components/AppNavigation/Settings.vue
+++ b/src/components/AppNavigation/Settings.vue
@@ -82,6 +82,15 @@
 			<ActionButton class="settings-fieldset-interior-item" icon="icon-clippy" @click.prevent.stop="copyAppleCalDAV">
 				{{ $t('calendar', 'Copy iOS/macOS CalDAV address') }}
 			</ActionButton>
+			<ActionButton
+				v-shortkey.propagate="['h']"
+				class="settings-fieldset-interior-item"
+				icon="icon-info"
+				@click.prevent.stop="showKeyboardShortcuts"
+				@shortkey.native="showKeyboardShortcuts">
+				{{ $t('calendar', 'Show keyboard shortcuts') }}
+			</ActionButton>
+			<ShortcutOverview v-if="displayKeyboardShortcuts" @close="hideKeyboardShortcuts" />
 		</ul>
 	</AppNavigationSettings>
 </template>
@@ -104,10 +113,12 @@ import SettingsImportSection from './Settings/SettingsImportSection.vue'
 import SettingsTimezoneSelect from './Settings/SettingsTimezoneSelect.vue'
 
 import client from '../../services/caldavService.js'
+import ShortcutOverview from './Settings/ShortcutOverview.vue'
 
 export default {
 	name: 'Settings',
 	components: {
+		ShortcutOverview,
 		ActionButton,
 		ActionCheckbox,
 		AppNavigationSettings,
@@ -130,6 +141,7 @@ export default {
 			savingSlotDuration: false,
 			savingWeekend: false,
 			savingWeekNumber: false,
+			displayKeyboardShortcuts: false,
 		}
 	},
 	computed: {
@@ -318,6 +330,18 @@ export default {
 				this.$toast.error(this.$t('calendar', 'CalDAV link could not be copied to clipboard.'))
 			}
 		},
+		/**
+		 * Show the keyboard shortcuts
+		 */
+		showKeyboardShortcuts() {
+			this.displayKeyboardShortcuts = true
+		},
+		/**
+		 * Hide the keyboard shortcuts
+		 */
+		hideKeyboardShortcuts() {
+			this.displayKeyboardShortcuts = false
+		}
 	},
 }
 </script>

--- a/src/components/AppNavigation/Settings/ShortcutOverview.vue
+++ b/src/components/AppNavigation/Settings/ShortcutOverview.vue
@@ -52,7 +52,7 @@
 							v-if="index2 !== (shortcut.keys.length - 1)"
 							:key="index2"
 							class="shortcut-section-item__spacer">
-							or
+							{{ t('calendar', 'or') }}
 						</span>
 					</template>
 				</span>

--- a/src/components/AppNavigation/Settings/ShortcutOverview.vue
+++ b/src/components/AppNavigation/Settings/ShortcutOverview.vue
@@ -1,0 +1,116 @@
+<!--
+  - @copyright Copyright (c) 2020 Georg Ehrke <oc.list@georgehrke.com>
+  - @author Georg Ehrke <oc.list@georgehrke.com>
+  -
+  - @license GNU AGPL version 3 or any later version
+  -
+  - This program is free software: you can redistribute it and/or modify
+  - it under the terms of the GNU Affero General Public License as
+  - published by the Free Software Foundation, either version 3 of the
+  - License, or (at your option) any later version.
+  -
+  - This program is distributed in the hope that it will be useful,
+  - but WITHOUT ANY WARRANTY; without even the implied warranty of
+  - MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  - GNU Affero General Public License for more details.
+  -
+  - You should have received a copy of the GNU Affero General Public License
+  - along with this program. If not, see <http://www.gnu.org/licenses/>.
+  -
+  -->
+<template>
+	<Modal
+		class="shortcut-overview-modal"
+		size="middle"
+		:title="$t('calendar', 'Shortcut overview')"
+		@close="$emit('close')">
+		<section
+			v-for="category in shortcuts"
+			:key="category.categoryId"
+			class="shortcut-section">
+			<h3 class="shortcut-section__header">
+				{{ category.categoryLabel }}
+			</h3>
+			<div
+				v-for="(shortcut, index) in category.shortcuts"
+				:key="index"
+				class="shortcut-section-item">
+				<span class="shortcut-section-item__keys">
+					<template
+						v-for="(keyCombination, index2) of shortcut.keys"
+						class="shortcut-section-item__key-combination">
+						<template v-for="(key, index3) in keyCombination">
+							<kbd :key="index3">{{ key }}</kbd>
+							<span
+								v-if="index3 !== (keyCombination.length - 1)"
+								:key="index3"
+								class="shortcut-section-item__spacer">
+								+
+							</span>
+						</template>
+						<span
+							v-if="index2 !== (shortcut.keys.length - 1)"
+							:key="index2"
+							class="shortcut-section-item__spacer">
+							or
+						</span>
+					</template>
+				</span>
+				<span class="shortcut-section-item__label">{{ shortcut.label }}</span>
+			</div>
+
+		</section>
+	</Modal>
+</template>
+
+<script>
+import { translate as t } from '@nextcloud/l10n'
+import Modal from '@nextcloud/vue/dist/Components/Modal'
+
+export default {
+	components: {
+		Modal
+	},
+	computed: {
+		shortcuts() {
+			return [{
+				categoryId: 'navigation',
+				categoryLabel: t('calendar', 'Navigation'),
+				shortcuts: [{
+					keys: [['p'], ['k']],
+					label: t('calendar', 'Previous period'),
+				}, {
+					keys: [['n'], ['j']],
+					label: t('calendar', 'Next period'),
+				}, {
+					keys: [['t']],
+					label: t('calendar', 'Today'),
+				}]
+			}, {
+				categoryId: 'views',
+				categoryLabel: t('calendar', 'Views'),
+				shortcuts: [{
+					keys: [['1'], ['d']],
+					label: t('calendar', 'Day view'),
+				}, {
+					keys: [['2'], ['w']],
+					label: t('calendar', 'Week view'),
+				}, {
+					keys: [['3'], ['m']],
+					label: t('calendar', 'Month view'),
+				}]
+			}, {
+				categoryId: 'actions',
+				categoryLabel: t('calendar', 'Actions'),
+				shortcuts: [{
+					keys: [['c']],
+					label: t('calendar', 'Create event'),
+				}, {
+					keys: [['h']],
+					label: t('calendar', 'Show shortcuts')
+				}],
+			}]
+		},
+	},
+}
+</script>

--- a/src/components/AppNavigation/Settings/ShortcutOverview.vue
+++ b/src/components/AppNavigation/Settings/ShortcutOverview.vue
@@ -21,7 +21,7 @@
 <template>
 	<Modal
 		class="shortcut-overview-modal"
-		size="middle"
+		size="normal"
 		:title="$t('calendar', 'Shortcut overview')"
 		@close="$emit('close')">
 		<section
@@ -33,24 +33,24 @@
 			</h3>
 			<div
 				v-for="(shortcut, index) in category.shortcuts"
-				:key="index"
+				:key="`${category.categoryId}-${index}`"
 				class="shortcut-section-item">
 				<span class="shortcut-section-item__keys">
 					<template
 						v-for="(keyCombination, index2) of shortcut.keys"
 						class="shortcut-section-item__key-combination">
 						<template v-for="(key, index3) in keyCombination">
-							<kbd :key="index3">{{ key }}</kbd>
+							<kbd :key="`${category.categoryId}-${index}-${index2}-${index3}`">{{ key }}</kbd>
 							<span
 								v-if="index3 !== (keyCombination.length - 1)"
-								:key="index3"
+								:key="`${category.categoryId}-${index}-${index2}-${index3}`"
 								class="shortcut-section-item__spacer">
 								+
 							</span>
 						</template>
 						<span
 							v-if="index2 !== (shortcut.keys.length - 1)"
-							:key="index2"
+							:key="`${category.categoryId}-${index}-${index2}`"
 							class="shortcut-section-item__spacer">
 							{{ t('calendar', 'or') }}
 						</span>

--- a/src/main.js
+++ b/src/main.js
@@ -34,12 +34,14 @@ import { translate, translatePlural } from '@nextcloud/l10n'
 import ClickOutside from 'vue-click-outside'
 import VueClipboard from 'vue-clipboard2'
 import VTooltip from 'v-tooltip'
+import VueShortKey from 'vue-shortkey'
 import windowTitleService from './services/windowTitleService.js'
 
 // register global components
 Vue.directive('ClickOutside', ClickOutside)
 Vue.use(VTooltip)
 Vue.use(VueClipboard)
+Vue.use(VueShortKey)
 
 // CSP config for webpack dynamic chunk loading
 // eslint-disable-next-line

--- a/src/main.js
+++ b/src/main.js
@@ -41,7 +41,7 @@ import windowTitleService from './services/windowTitleService.js'
 Vue.directive('ClickOutside', ClickOutside)
 Vue.use(VTooltip)
 Vue.use(VueClipboard)
-Vue.use(VueShortKey)
+Vue.use(VueShortKey, { prevent: ['input', 'textarea'] })
 
 // CSP config for webpack dynamic chunk loading
 // eslint-disable-next-line


### PR DESCRIPTION
Related to #157 

- [x] Add keyboard shortcuts

| Action | Shortcut |
|:---------:|:------:|
| Previous time-range | p or k |
| Next time-range | n or j |
| Today | t |
| New event | c |
| Day view | 1 or d |
| Week view | 2 or w |
| Month view | 3 or m |

Possible further shortcuts:
| Action | Shortcut |
|:---------:|:------:|
| List #402 | 4 or l |
| Search #8  | / |
| Refresh #31 | r |

I do not want to add a shortcut for deleting an event, as long as we don't provide an undo.

- [x] provide an overview for all available shortcuts 
- [ ] fix tab order of editor