### PR TITLE
Remove id for CalendarListItemSharingSearch component

### DIFF
--- a/src/components/AppNavigation/CalendarList/CalendarListItemSharingSearch.vue
+++ b/src/components/AppNavigation/CalendarList/CalendarListItemSharingSearch.vue
@@ -25,7 +25,6 @@
 <template>
 	<li class="app-navigation-entry__multiselect">
 		<Multiselect
-			id="users-groups-search"
 			:options="usersOrGroups"
 			:searchable="true"
 			:internal-search="false"


### PR DESCRIPTION
fixes:

```
[DOM] Found 2 elements with non-unique id #users-groups-search: (More info: https://goo.gl/9p2vKq) 
```

We are not using the Id anywhere, not even for a label....