### PR TITLE
Fix timezone names

### DIFF
--- a/src/utils/timezone.js
+++ b/src/utils/timezone.js
@@ -32,7 +32,8 @@ export function getSortedTimezoneList(timezoneList = [], additionalTimezones = [
 	const sortedList = []
 
 	for (const timezoneId of timezoneList) {
-		let [continent, name] = timezoneId.split('/', 2)
+		const components = timezoneId.split('/')
+		let [continent, name] = [components.shift(), components.join('/')]
 		if (!name) {
 			name = continent
 			// TRANSLATORS This refers to global timezones in the timezone picker

--- a/tests/javascript/unit/utils/timezone.test.js
+++ b/tests/javascript/unit/utils/timezone.test.js
@@ -115,9 +115,10 @@ describe('utils/timezone test suite', () => {
 		expect(translate).toHaveBeenNthCalledWith(3, 'calendar', 'Global')
 	})
 
-	it ('should get a readable timezone name', () => {
+	it('should get a readable timezone name', () => {
 		expect(getReadableTimezoneName('Europe/Berlin')).toEqual('Europe - Berlin')
 		expect(getReadableTimezoneName('America/New_York')).toEqual('America - New York')
 		expect(getReadableTimezoneName('America/St_Johns')).toEqual('America - St. Johns')
+		expect(getReadableTimezoneName('America/Argentina/Buenos_Aires')).toEqual('America - Argentina - Buenos Aires')
 	})
 })


### PR DESCRIPTION
Some timezones have more than one `/` in their name, and only the first part was being used.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

| Before | After |
|:---------:|:------:|
|![nextcloud_tz_before](https://user-images.githubusercontent.com/2197836/83299499-927e5100-a1f6-11ea-951c-365ff8c7bcf7.png)|![nextcloud_tz_after](https://user-images.githubusercontent.com/2197836/83299505-97430500-a1f6-11ea-912e-318dfc5470e5.png)|
