### PR TITLE
Fix handling of long calendar names in calendar-picker

### DIFF
--- a/css/app-sidebar.scss
+++ b/css/app-sidebar.scss
@@ -711,10 +711,19 @@
 		border-radius: 50%;
 		border: none;
 		margin-right: 8px;
+		flex-basis: 12px;
+		flex-shrink: 0;
+	}
+
+	&__label {
+		overflow: hidden;
+		text-overflow: ellipsis;
+		flex-grow: 1;
 	}
 
 	&__avatar {
-		margin-left: auto;
+		flex-basis: 18px;
+		flex-shrink: 0;
 	}
 }
 

--- a/src/components/Shared/CalendarPickerOption.vue
+++ b/src/components/Shared/CalendarPickerOption.vue
@@ -26,7 +26,8 @@
 			class="calendar-picker-option__color-indicator"
 			:style="{ backgroundColor: color }" />
 
-		<span>
+		<span
+			class="calendar-picker-option__label">
 			{{ displayName }}
 		</span>
 


### PR DESCRIPTION
fixes #2324 
| Before | After |
|:---------:|:------:|
|![before](https://user-images.githubusercontent.com/1250540/84120947-c9ded000-aa36-11ea-9f09-0a5196af3122.png)|![after](https://user-images.githubusercontent.com/1250540/84120851-addb2e80-aa36-11ea-99a2-b0cf439babc7.png)|
