### PR TITLE
WIP: Setting for default calendar when creating new events

### DIFF
--- a/css/app-settings.scss
+++ b/css/app-settings.scss
@@ -55,7 +55,8 @@
 		}
 
 		&--slotDuration,
-		&--timezone {
+		&--timezone,
+		&--default-calendar {
 			width: 100%;
 
 			.multiselect {

--- a/lib/Controller/PublicViewController.php
+++ b/lib/Controller/PublicViewController.php
@@ -120,6 +120,7 @@ class PublicViewController extends Controller {
 		$defaultSkipPopover = $this->config->getAppValue($this->appName, 'skipPopover', 'yes');
 		$defaultTimezone = $this->config->getAppValue($this->appName, 'timezone', 'automatic');
 		$defaultSlotDuration = $this->config->getAppValue($this->appName, 'slotDuration', '00:30:00');
+		$defaultCalendarId = $this->config->getAppValue($this->appName, 'defaultCalendarId', 'none');
 		$defaultShowTasks = $this->config->getAppValue($this->appName, 'showTasks', 'yes');
 
 		$appVersion = $this->config->getAppValue($this->appName, 'installed_version');
@@ -134,6 +135,7 @@ class PublicViewController extends Controller {
 		$this->initialStateService->provideInitialState($this->appName, 'talk_enabled', false);
 		$this->initialStateService->provideInitialState($this->appName, 'timezone', $defaultTimezone);
 		$this->initialStateService->provideInitialState($this->appName, 'slot_duration', $defaultSlotDuration);
+		$this->initialStateService->provideInitialState($this->appName, 'default_calendar_id', $defaultCalendarId);
 		$this->initialStateService->provideInitialState($this->appName, 'show_tasks', $defaultShowTasks === 'yes');
 		$this->initialStateService->provideInitialState($this->appName, 'tasks_enabled', false);
 

--- a/lib/Controller/SettingsController.php
+++ b/lib/Controller/SettingsController.php
@@ -87,6 +87,8 @@ class SettingsController extends Controller {
 				return $this->setEventLimit($value);
 			case 'slotDuration':
 				return $this->setSlotDuration($value);
+			case 'defaultCalendarId':
+				return $this->setDefaultCalendarId($value);
 			case 'showTasks':
 				return $this->setShowTasks($value);
 			default:
@@ -302,6 +304,27 @@ class SettingsController extends Controller {
 				$this->userId,
 				$this->appName,
 				'slotDuration',
+				$value
+			);
+		} catch (\Exception $e) {
+			return new JSONResponse([], Http::STATUS_INTERNAL_SERVER_ERROR);
+		}
+
+		return new JSONResponse();
+	}
+
+	/**
+	 * sets defaultCalendarId for user
+	 *
+	 * @param string $value User-selected option for default calendar when creating new events
+	 * @return JSONResponse
+	 */
+	private function setDefaultCalendarId(string $value):JSONResponse {
+		try {
+			$this->config->setUserValue(
+				$this->userId,
+				$this->appName,
+				'defaultCalendarId',
 				$value
 			);
 		} catch (\Exception $e) {

--- a/lib/Controller/ViewController.php
+++ b/lib/Controller/ViewController.php
@@ -94,6 +94,7 @@ class ViewController extends Controller {
 		$defaultSkipPopover = $this->config->getAppValue($this->appName, 'skipPopover', 'no');
 		$defaultTimezone = $this->config->getAppValue($this->appName, 'timezone', 'automatic');
 		$defaultSlotDuration = $this->config->getAppValue($this->appName, 'slotDuration', '00:30:00');
+		$defaultCalendarIdGlobal = $this->config->getAppValue($this->appName, 'defaultCalendarId', '');
 		$defaultShowTasks = $this->config->getAppValue($this->appName, 'showTasks', 'yes');
 
 		$appVersion = $this->config->getAppValue($this->appName, 'installed_version');
@@ -105,6 +106,7 @@ class ViewController extends Controller {
 		$skipPopover = $this->config->getUserValue($this->userId, $this->appName, 'skipPopover', $defaultSkipPopover) === 'yes';
 		$timezone = $this->config->getUserValue($this->userId, $this->appName, 'timezone', $defaultTimezone);
 		$slotDuration = $this->config->getUserValue($this->userId, $this->appName, 'slotDuration', $defaultSlotDuration);
+		$defaultCalendarIdUser = $this->config->getUserValue($this->userId, $this->appName, 'defaultCalendarId', $defaultCalendarId);
 		$showTasks = $this->config->getUserValue($this->userId, $this->appName, 'showTasks', $defaultShowTasks) === 'yes';
 
 		$talkEnabled = $this->appManager->isEnabledForUser('spreed');
@@ -120,6 +122,7 @@ class ViewController extends Controller {
 		$this->initialStateService->provideInitialState($this->appName, 'talk_enabled', $talkEnabled);
 		$this->initialStateService->provideInitialState($this->appName, 'timezone', $timezone);
 		$this->initialStateService->provideInitialState($this->appName, 'slot_duration', $slotDuration);
+		$this->initialStateService->provideInitialState($this->appName, 'default_calendar_id', $defaultCalendarIdUser);
 		$this->initialStateService->provideInitialState($this->appName, 'show_tasks', $showTasks);
 		$this->initialStateService->provideInitialState($this->appName, 'tasks_enabled', $tasksEnabled);
 

--- a/src/components/AppNavigation/Settings.vue
+++ b/src/components/AppNavigation/Settings.vue
@@ -82,7 +82,7 @@
 					<CalendarPicker
 						:calendars="defaultCalendarOptions"
 						:calendar="defaultCalendar"
-						:disabled="savingDefaultCalendar"
+						:disabled="savingDefaultCalendarId"
 						@selectCalendar="changeDefaultCalendar" />
 				</label>
 			</li>

--- a/src/components/Shared/CalendarPicker.vue
+++ b/src/components/Shared/CalendarPicker.vue
@@ -2,7 +2,7 @@
 	<Multiselect
 		label="displayName"
 		track-by="displayName"
-		:disabled="isDisabled"
+		:disabled="isMultiselectDisabled"
 		:options="calendars"
 		:value="calendar"
 		@select="change">
@@ -37,10 +37,14 @@ export default {
 			type: Boolean,
 			default: false,
 		},
+		disabled: {
+			type: Boolean,
+			default: false,
+		},
 	},
 	computed: {
-		isDisabled() {
-			return this.calendars.length < 2
+		isMultiselectDisabled() {
+			return this.disabled || this.calendars.length < 2
 		},
 	},
 	methods: {

--- a/src/mixins/EditorMixin.js
+++ b/src/mixins/EditorMixin.js
@@ -649,9 +649,10 @@ export default {
 				const start = parseInt(to.params.dtstart, 10)
 				const end = parseInt(to.params.dtend, 10)
 				const timezoneId = vm.$store.getters.getResolvedTimezone
+				const calendarId = vm.$store.state.settings.defaultCalendarId
 
 				try {
-					await vm.$store.dispatch('getCalendarObjectInstanceForNewEvent', { isAllDay, start, end, timezoneId })
+					await vm.$store.dispatch('getCalendarObjectInstanceForNewEvent', { isAllDay, start, end, timezoneId, calendarId })
 					vm.calendarId = vm.calendarObject.calendarId
 				} catch (error) {
 					console.debug(error)

--- a/src/store/calendarObjectInstance.js
+++ b/src/store/calendarObjectInstance.js
@@ -1413,7 +1413,7 @@ const actions = {
 	 * @param {String} data.timezoneId The timezoneId of the new event
 	 * @returns {Promise<{calendarObject: Object, calendarObjectInstance: Object}>}
 	 */
-	async getCalendarObjectInstanceForNewEvent({ state, dispatch, commit }, { isAllDay, start, end, timezoneId }) {
+	async getCalendarObjectInstanceForNewEvent({ state, dispatch, commit }, { isAllDay, start, end, timezoneId, calendarId }) {
 		if (state.isNew === true) {
 			return Promise.resolve({
 				calendarObject: state.calendarObject,
@@ -1421,7 +1421,7 @@ const actions = {
 			})
 		}
 
-		const calendarObject = await dispatch('createNewEvent', { start, end, isAllDay, timezoneId })
+		const calendarObject = await dispatch('createNewEvent', { start, end, isAllDay, timezoneId, calendarId })
 		const startDate = new Date(start * 1000)
 		const eventComponent = getObjectAtRecurrenceId(calendarObject, startDate)
 		const calendarObjectInstance = mapEventComponentToEventObject(eventComponent)

--- a/src/store/calendarObjects.js
+++ b/src/store/calendarObjects.js
@@ -312,7 +312,7 @@ const actions = {
 	 * @param {Boolean} data.isAllDay foo
 	 * @returns {Promise<CalendarObject>}
 	 */
-	createNewEvent(context, { start, end, timezoneId, isAllDay }) {
+	createNewEvent(context, { start, end, timezoneId, isAllDay, calendarId }) {
 		const timezoneManager = getTimezoneManager()
 		const timezone = timezoneManager.getTimezoneForId(timezoneId)
 
@@ -336,8 +336,7 @@ const actions = {
 			vObject.undirtify()
 		}
 
-		const firstCalendar = context.getters.sortedCalendars[0].id
-		return Promise.resolve(mapCalendarJsToCalendarObject(calendar, firstCalendar))
+		return Promise.resolve(mapCalendarJsToCalendarObject(calendar, calendarId || context.getters.sortedCalendars[0].id))
 	},
 
 	/**

--- a/src/store/settings.js
+++ b/src/store/settings.js
@@ -39,6 +39,7 @@ const state = {
 	talkEnabled: false,
 	tasksEnabled: false,
 	timezone: null,
+	defaultCalendarId: null,
 }
 
 const mutations = {
@@ -111,6 +112,17 @@ const mutations = {
 	},
 
 	/**
+	 * Updates the user's default calendar
+	 *
+	 * @param {Object} state The Vuex state
+	 * @param {Object} data The destructuring object
+	 * @param {String} data.calendarId The new calendar id
+	 */
+	setDefaultCalendarId(state, { calendarId }) {
+		state.defaultCalendarId = calendarId
+	},
+
+	/**
 	 * Initialize settings
 	 *
 	 * @param {Object} state The Vuex state
@@ -130,6 +142,7 @@ const mutations = {
 		state.talkEnabled = settings.talkEnabled
 		state.tasksEnabled = settings.tasksEnabled
 		state.timezone = settings.timezone
+		state.defaultCalendarId = settings.defaultCalendarId
 	},
 
 	/**
@@ -292,6 +305,24 @@ const actions = {
 			value: slotDuration,
 		})
 		context.commit('setSlotDuration', { slotDuration })
+	},
+
+	/**
+	 * Updates the user's default calendar for new events
+	 *
+	 * @param {Object} context The Vuex context
+	 * @param {Object} data The destructuring object
+	 * @param {String} data.slotDuration The id of the new default calendar
+	 */
+	async setDefaultCalendarId(context, { calendarId }) {
+		if (context.state.defaultCalendarId === calendarId) {
+			return
+		}
+
+		await HttpClient.post(getLinkToConfig('defaultCalendarId'), {
+			value: calendarId,
+		})
+		context.commit('setDefaultCalendarId', { calendarId })
 	},
 
 	/**

--- a/src/views/Calendar.vue
+++ b/src/views/Calendar.vue
@@ -44,6 +44,7 @@
 				:header="showHeader"
 				:height="windowResize"
 				:slot-duration="slotDuration"
+				:default-calendar-id="defaultCalendarId"
 				:week-numbers="showWeekNumbers"
 				:weekends="showWeekends"
 				:event-sources="eventSources"
@@ -171,6 +172,7 @@ export default {
 			showWeekends: state => state.settings.showWeekends,
 			showWeekNumbers: state => state.settings.showWeekNumbers,
 			slotDuration: state => state.settings.slotDuration,
+			defaultCalendarId: state => state.settings.defaultCalendarId,
 			showTasks: state => state.settings.showTasks,
 			timezone: state => state.settings.timezone,
 			modificationCount: state => state.calendarObjects.modificationCount,
@@ -303,6 +305,7 @@ export default {
 			showWeekNumbers: loadState('calendar', 'show_week_numbers'),
 			skipPopover: loadState('calendar', 'skip_popover'),
 			slotDuration: loadState('calendar', 'slot_duration'),
+			defaultCalendarId: loadState('calendar', 'default_calendar_id'),
 			talkEnabled: loadState('calendar', 'talk_enabled'),
 			tasksEnabled: loadState('calendar', 'tasks_enabled'),
 			timezone: loadState('calendar', 'timezone'),


### PR DESCRIPTION
Signed-off-by: Lukas Boersma <mail@lukas-boersma.com>

## Description

This adds a setting for the default calendar when creating a new event.

To summarize my changes:

- I added a 'disabled' property to the `CalendarPicker` component so that the dropdown for the new setting can be disabled while the setting is saved.
- I added a setting for the default calendar in the settings panel and all the other places where settings need to be handled (I just followed the usage of the existing settings here).
- In the functions `getCalendarObjectInstanceForNewEvent` (`calendarObjectInstance.js`) and `createNewEvent` (`calendarObjects.js`) I added `calendarId` as an new (optional) parameter to specify which calendar to use for a new event.
- In the event editor, I use that parameter to use the configured default calendar.
- When no default calendar is specified yet, the behaviour is the same as before (i.e. the first calendar in `sortedCalendars` is used).

**This is work in progress.** I still have an issue with the calendar picker, it does only close when double clicking it, any help here is greatly appreciated. Also I have yet to write tests for this new setting. However it would be cool if **somebody from the maintainers could let me know if this change has a chance of being merged**.

Fixes #1835

### Type of change

- [X] New feature (non-breaking change which adds functionality)

### How to test / use your changes?

1. Have more than one calendar in the calendar app.
2. Change the default calendar in the settings panel.
3. Create a new event. The previously selected default calendar will now be preselected for the new event.

### UI Changes

| Before | After |
|:---------:|:------:|
|![defaultcalendar-before](https://user-images.githubusercontent.com/614973/84567613-19483780-ad7a-11ea-8424-d86e1cde81c8.png)|![defaultcalendar-after](https://user-images.githubusercontent.com/614973/84567617-1ea58200-ad7a-11ea-98d1-cfaa359cd8e7.png)|


### Checklist:

- [X] My code follows the style guidelines of this project
- [X] I signed off my changes (`git commit -sm "Your commit message"`)
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
