### PR TITLE
Center date in month view cell

### DIFF
--- a/css/fullcalendar.scss
+++ b/css/fullcalendar.scss
@@ -53,6 +53,16 @@
 	color: var(--color-main-text);
 }
 
+// Center date in month view cell
+.fc-day-top {
+	text-align: center;
+
+	.fc-day-number {
+		float: none !important;
+		display: inline-block;
+	}
+}
+
 .fc-day-number.fc-other-month {
 	opacity: .1 !important;
 }


### PR DESCRIPTION
Makes it much more obvious which date corresponds to which cell – we already do this in the week view:

Before | After
-|-
![image](https://user-images.githubusercontent.com/925062/89306777-9b652600-d670-11ea-9f84-a18512c3c085.png)| ![image](https://user-images.githubusercontent.com/925062/89306724-8d170a00-d670-11ea-8ab7-b61307a3ad10.png)
