### PR TITLE
Let apps handle clicks on todo entries

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2173,9 +2173,9 @@
 			"dev": true
 		},
 		"@types/semver": {
-			"version": "7.3.3",
-			"resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.3.tgz",
-			"integrity": "sha512-jQxClWFzv9IXdLdhSaTf16XI3NYe6zrEbckSpb5xhKfPbWgIyAY0AFyWWWfaiDcBuj3UHmMkCIwSRqpKMTZL2Q=="
+			"version": "7.3.4",
+			"resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.4.tgz",
+			"integrity": "sha512-+nVsLKlcUCeMzD2ufHEYuJ9a2ovstb6Dp52A5VsoKxDXgvE051XgHI/33I1EymwkRGQkwnA0LkhnUzituGs4EQ=="
 		},
 		"@types/stack-utils": {
 			"version": "1.0.1",
@@ -6473,7 +6473,8 @@
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
 			"integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=",
-			"dev": true
+			"dev": true,
+			"optional": true
 		},
 		"hammerjs": {
 			"version": "2.0.8",
@@ -7189,6 +7190,7 @@
 			"resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
 			"integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
 			"dev": true,
+			"optional": true,
 			"requires": {
 				"is-docker": "^2.0.0"
 			}
@@ -9895,6 +9897,7 @@
 			"resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-8.0.1.tgz",
 			"integrity": "sha512-BvEXF+UmsnAfYfoapKM9nGxnP+Wn7P91YfXmrKnfcYCx6VBeoN5Ez5Ogck6I8Bi5k4RlpqRYaw75pAwzX9OphA==",
 			"dev": true,
+			"optional": true,
 			"requires": {
 				"growly": "^1.3.0",
 				"is-wsl": "^2.2.0",
@@ -9909,6 +9912,7 @@
 					"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
 					"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"isexe": "^2.0.0"
 					}
@@ -12280,7 +12284,8 @@
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.1.tgz",
 			"integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==",
-			"dev": true
+			"dev": true,
+			"optional": true
 		},
 		"sigmund": {
 			"version": "1.0.1",
@@ -14353,7 +14358,8 @@
 			"version": "8.3.0",
 			"resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.0.tgz",
 			"integrity": "sha512-fX6Z5o4m6XsXBdli9g7DtWgAx+osMsRRZFKma1mIUsLCz6vRvv+pz5VNbyu9UEDzpMWulZfvpgb/cmDXVulYFQ==",
-			"dev": true
+			"dev": true,
+			"optional": true
 		},
 		"v-click-outside": {
 			"version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
 		"@nextcloud/auth": "^1.3.0",
 		"@nextcloud/axios": "^1.4.0",
 		"@nextcloud/dialogs": "^2.0.1",
+		"@nextcloud/event-bus": "^1.2.0",
 		"@nextcloud/initial-state": "^1.1.2",
 		"@nextcloud/l10n": "^1.4.1",
 		"@nextcloud/logger": "^1.1.2",

--- a/src/fullcalendar/interaction/eventClick.js
+++ b/src/fullcalendar/interaction/eventClick.js
@@ -26,6 +26,7 @@ import {
 import { generateUrl } from '@nextcloud/router'
 import { translate as t } from '@nextcloud/l10n'
 import { showInfo } from '@nextcloud/dialogs'
+import { emit } from '@nextcloud/event-bus'
 
 /**
  * Returns a function for click action on event. This will open the editor.
@@ -94,17 +95,21 @@ function handleEventClick(event, store, router, route, window) {
  * @param {Window} window The window object
  */
 function handleToDoClick(event, store, route, window) {
-	if (!store.state.settings.tasksEnabled) {
-		if (!isPublicOrEmbeddedRoute(route.name)) {
-			showInfo(t('calendar', 'Please ask your administrator to enable the Tasks App.'))
-		}
+
+	if (isPublicOrEmbeddedRoute(route.name)) {
 		return
 	}
 
 	const davUrlParts = event.extendedProps.davUrl.split('/')
 	const taskId = davUrlParts.pop()
 	const calendarId = davUrlParts.pop()
-	const url = `apps/tasks/#/calendars/${calendarId}/tasks/${taskId}`
 
+	emit('calendar:handle-todo-click', { calendarId, taskId })
+
+	if (!store.state.settings.tasksEnabled) {
+		showInfo(t('calendar', 'Please ask your administrator to enable the Tasks App.'))
+		return
+	}
+	const url = `apps/tasks/#/calendars/${calendarId}/tasks/${taskId}`
 	window.location = window.location.protocol + '//' + window.location.host + generateUrl(url)
 }


### PR DESCRIPTION
## Description

Open task entries that are exposed by deck inside of the deck app by emitting an event that can be handled by apps


### Type of change

- [x] New feature (non-breaking change which adds functionality)

### How to test / use your changes?

Requires https://github.com/nextcloud/deck/pull/2683


### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I signed off my changes (`git commit -sm "Your commit message"`)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

