### PR TITLE
Maximum version of 2.0.x is 19

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -32,7 +32,7 @@
 	<screenshot>https://raw.githubusercontent.com/nextcloud/calendar/master/screenshots/sidebar_attendees.png</screenshot>
 	<screenshot>https://raw.githubusercontent.com/nextcloud/calendar/master/screenshots/sidebar_reminders.png</screenshot>
 	<dependencies>
-		<nextcloud min-version="17" max-version="20" />
+		<nextcloud min-version="17" max-version="19" />
 	</dependencies>
 	<repair-steps>
 		<post-migration>


### PR DESCRIPTION
I branched off master into the [stable2.0](https://github.com/nextcloud/calendar/tree/stable2.0) branch.
