### PR TITLE
Remove unused webpack alias config

### DIFF
--- a/webpack.common.js
+++ b/webpack.common.js
@@ -59,14 +59,7 @@ module.exports = {
 		})
 	],
 	resolve: {
-		alias: {
-			Components: path.resolve(__dirname, 'src/components/'),
-			Mixins: path.resolve(__dirname, 'src/mixins/'),
-			Models: path.resolve(__dirname, 'src/models/'),
-			Services: path.resolve(__dirname, 'src/services/'),
-			Store: path.resolve(__dirname, 'src/store/'),
-			Views: path.resolve(__dirname, 'src/views/')
-		},
-		extensions: ['*', '.js', '.vue', '.json']
+		extensions: ['*', '.js', '.vue', '.json'],
+		symlinks: false,
 	}
 }


### PR DESCRIPTION
Also adds `symlink: false`, which is part of our standard conf: https://github.com/nextcloud/webpack-vue-config/blob/master/webpack.js#L65