### PR TITLE
Fix read-only property of fullcalendar event sources

### DIFF
--- a/src/fullcalendar/eventSource.js
+++ b/src/fullcalendar/eventSource.js
@@ -72,7 +72,7 @@ export default function(store) {
 			},
 		}
 
-		if (calendar.isReadOnly) {
+		if (calendar.readOnly) {
 			source.editable = false
 		}
 

--- a/tests/javascript/unit/fullcalendar/eventSource.test.js
+++ b/tests/javascript/unit/fullcalendar/eventSource.test.js
@@ -45,7 +45,7 @@ describe('fullcalendar/eventSource test suite', () => {
 		const calendar = {
 			id: 'calendar-id-123',
 			color: '#ff00ff',
-			isReadOnly: false
+			readOnly: false
 		}
 
 		generateTextColorForHex
@@ -69,7 +69,7 @@ describe('fullcalendar/eventSource test suite', () => {
 		const calendar = {
 			id: 'calendar-id-123',
 			color: '#ff00ff',
-			isReadOnly: true
+			readOnly: true
 		}
 
 		generateTextColorForHex
@@ -104,7 +104,7 @@ describe('fullcalendar/eventSource test suite', () => {
 		const calendar = {
 			id: 'calendar-id-123',
 			color: '#ff00ff',
-			isReadOnly: true
+			readOnly: true
 		}
 
 		const getTimezoneForId = jest.fn()
@@ -174,7 +174,7 @@ describe('fullcalendar/eventSource test suite', () => {
 		const calendar = {
 			id: 'calendar-id-123',
 			color: '#ff00ff',
-			isReadOnly: true
+			readOnly: true
 		}
 
 		const getTimezoneForId = jest.fn()
@@ -239,7 +239,7 @@ describe('fullcalendar/eventSource test suite', () => {
 		const calendar = {
 			id: 'calendar-id-123',
 			color: '#ff00ff',
-			isReadOnly: true
+			readOnly: true
 		}
 
 		const getTimezoneForId = jest.fn()
@@ -309,7 +309,7 @@ describe('fullcalendar/eventSource test suite', () => {
 		const calendar = {
 			id: 'calendar-id-123',
 			color: '#ff00ff',
-			isReadOnly: true
+			readOnly: true
 		}
 
 		const getTimezoneForId = jest.fn()


### PR DESCRIPTION
It's `readOnly`, not `isReadOnly`:
https://github.com/nextcloud/calendar/blob/80bf6f00115b872394211cc1c5e59ec695881744/src/models/calendar.js#L59