### PR TITLE
Reduce brightness of events

### DIFF
--- a/src/fullcalendar/eventSources/eventSource.js
+++ b/src/fullcalendar/eventSources/eventSource.js
@@ -20,7 +20,7 @@
  *
  */
 import {
-	generateTextColorForHex,
+	generateAlphaColor,
 } from '../../utils/color.js'
 import getTimezoneManager from '../../services/timezoneDataProviderService'
 import { getUnixTimestampFromDate } from '../../utils/date.js'
@@ -38,9 +38,9 @@ export default function(store) {
 		const source = {
 			id: calendar.id,
 			// coloring
-			backgroundColor: calendar.color,
+			backgroundColor: generateAlphaColor(calendar.color, 0.1),
 			borderColor: calendar.color,
-			textColor: generateTextColorForHex(calendar.color),
+			textColor: calendar.color,
 			// html foo
 			events: async({ start, end, timeZone }, successCallback, failureCallback) => {
 				let timezoneObject = getTimezoneManager().getTimezoneForId(timeZone)

--- a/src/utils/color.js
+++ b/src/utils/color.js
@@ -39,6 +39,23 @@ export function isLight({ red, green, blue }) {
 }
 
 /**
+ * Returns the rgba representation of a hexColor and an alpha value
+ *
+ * @param {String} hexColor The hex color to get a text color for
+ * @param {Number} alpha The alpha-value of the rgba
+ * @returns {String} The rgba value
+ */
+export function generateAlphaColor(hexColor, alpha) {
+	const {
+		red,
+		green,
+		blue,
+	} = hexToRGB(hexColor)
+
+	return `rgba(${red}, ${green}, ${blue}, ${alpha})`
+}
+
+/**
  * Get a text-color that's readable on a given background color
  *
  * @param {String} hexColor The hex color to get a text color for

--- a/tests/javascript/unit/fullcalendar/eventSources/eventSource.test.js
+++ b/tests/javascript/unit/fullcalendar/eventSources/eventSource.test.js
@@ -21,7 +21,7 @@
  */
 import eventSource from "../../../../../src/fullcalendar/eventSources/eventSource.js";
 
-import { generateTextColorForHex } from '../../../../../src/utils/color.js'
+import { generateAlphaColor } from '../../../../../src/utils/color.js'
 import getTimezoneManager from '../../../../../src/services/timezoneDataProviderService'
 import { getUnixTimestampFromDate } from '../../../../../src/utils/date.js'
 import { eventSourceFunction } from '../../../../../src/fullcalendar/eventSources/eventSourceFunction.js'
@@ -34,7 +34,7 @@ jest.mock('../../../../../src/fullcalendar/eventSources/eventSourceFunction.js')
 describe('fullcalendar/eventSource test suite', () => {
 
 	beforeEach(() => {
-		generateTextColorForHex.mockClear()
+		generateAlphaColor.mockClear()
 		getTimezoneManager.mockClear()
 		getUnixTimestampFromDate.mockClear()
 		eventSourceFunction.mockClear()
@@ -48,20 +48,20 @@ describe('fullcalendar/eventSource test suite', () => {
 			readOnly: false
 		}
 
-		generateTextColorForHex
-			.mockReturnValue('#00ff00')
+		generateAlphaColor
+			.mockReturnValue('rgba(255, 0, 255, 0.1)')
 
 		const eventSourceFunction = eventSource(store)
 		expect(eventSourceFunction(calendar)).toEqual({
 			id: 'calendar-id-123',
-			backgroundColor: '#ff00ff',
+			backgroundColor: 'rgba(255, 0, 255, 0.1)',
 			borderColor: '#ff00ff',
-			textColor: '#00ff00',
+			textColor: '#ff00ff',
 			events: expect.any(Function)
 		})
 
-		expect(generateTextColorForHex).toHaveBeenCalledTimes(1)
-		expect(generateTextColorForHex).toHaveBeenNthCalledWith(1, '#ff00ff')
+		expect(generateAlphaColor).toHaveBeenCalledTimes(1)
+		expect(generateAlphaColor).toHaveBeenNthCalledWith(1, '#ff00ff', 0.1)
 	})
 
 	it('should provide an eventSource for a given read-only calendar', () => {
@@ -72,21 +72,21 @@ describe('fullcalendar/eventSource test suite', () => {
 			readOnly: true
 		}
 
-		generateTextColorForHex
-			.mockReturnValue('#00ff00')
+		generateAlphaColor
+			.mockReturnValue('rgba(255, 0, 255, 0.1)')
 
 		const eventSourceFunction = eventSource(store)
 		expect(eventSourceFunction(calendar)).toEqual({
 			id: 'calendar-id-123',
-			backgroundColor: '#ff00ff',
+			backgroundColor: 'rgba(255, 0, 255, 0.1)',
 			borderColor: '#ff00ff',
-			textColor: '#00ff00',
+			textColor: '#ff00ff',
 			events: expect.any(Function),
 			editable: false
 		})
 
-		expect(generateTextColorForHex).toHaveBeenCalledTimes(1)
-		expect(generateTextColorForHex).toHaveBeenNthCalledWith(1, '#ff00ff')
+		expect(generateAlphaColor).toHaveBeenCalledTimes(1)
+		expect(generateAlphaColor).toHaveBeenNthCalledWith(1, '#ff00ff', 0.1)
 	})
 
 	it('should provide an eventSource function to provide events - fetch new timerange', async () => {
@@ -118,8 +118,8 @@ describe('fullcalendar/eventSource test suite', () => {
 			.mockReturnValueOnce(1234)
 			.mockReturnValueOnce(5678)
 
-		generateTextColorForHex
-			.mockReturnValue('#00ff00')
+		generateAlphaColor
+			.mockReturnValue('rgba(255, 0, 255, 0.1)')
 
 		eventSourceFunction
 			.mockReturnValueOnce([{ fcEventId: 1 },  { fcEventId: 2 }])
@@ -188,8 +188,8 @@ describe('fullcalendar/eventSource test suite', () => {
 			.mockReturnValueOnce(1234)
 			.mockReturnValueOnce(5678)
 
-		generateTextColorForHex
-			.mockReturnValue('#00ff00')
+		generateAlphaColor
+			.mockReturnValue('rgba(255, 0, 255, 0.1)')
 
 		eventSourceFunction
 			.mockReturnValueOnce([{ fcEventId: 1 },  { fcEventId: 2 }])
@@ -254,8 +254,8 @@ describe('fullcalendar/eventSource test suite', () => {
 			.mockReturnValueOnce(1234)
 			.mockReturnValueOnce(5678)
 
-		generateTextColorForHex
-			.mockReturnValue('#00ff00')
+		generateAlphaColor
+			.mockReturnValue('rgba(255, 0, 255, 0.1)')
 
 		eventSourceFunction
 			.mockReturnValueOnce([{ fcEventId: 1 },  { fcEventId: 2 }])
@@ -323,8 +323,8 @@ describe('fullcalendar/eventSource test suite', () => {
 			.mockReturnValueOnce(1234)
 			.mockReturnValueOnce(5678)
 
-		generateTextColorForHex
-			.mockReturnValue('#00ff00')
+		generateAlphaColor
+			.mockReturnValue('rgba(255, 0, 255, 0.1)')
 
 		eventSourceFunction
 			.mockReturnValueOnce([{ fcEventId: 1 },  { fcEventId: 2 }])


### PR DESCRIPTION
| Before | After |
|:---------:|:------:|
|![before](https://user-images.githubusercontent.com/1250540/91601254-99d60780-e969-11ea-8906-8e335a8179e3.jpg)|![after](https://user-images.githubusercontent.com/1250540/91601336-c853e280-e969-11ea-9202-ef622b60efe4.jpg)|


please review and test @nextcloud/designers

At the last Calendar Design review session, we discussed whether we should reduce the brightness of events in the calendar-grid.

| Before | After |
|:---------:|:------:|
|10%|![after-0-1](https://user-images.githubusercontent.com/1250540/91606361-37cdd000-e972-11ea-9a22-ee005a5ace5e.jpg)|
|20%|![after-0-2](https://user-images.githubusercontent.com/1250540/91606370-3ac8c080-e972-11ea-8a8f-b62d74aee299.jpg)|
|30%|![after-0-3](https://user-images.githubusercontent.com/1250540/91606379-3dc3b100-e972-11ea-8043-d0152314e7d8.jpg)|