### PR TITLE
Change highlighting of today

### DIFF
--- a/css/fullcalendar.scss
+++ b/css/fullcalendar.scss
@@ -71,27 +71,10 @@
 }
 
 // Today highlighting
-.fc-day-today {
-	&.fc-col-header-cell {
-		a, span {
-			background-color: var(--color-primary);
-			color: var(--color-primary-text) !important;
-			border-radius: var(--border-radius-pill);
-			padding: 2px 6px;
-			font-weight: bold;
-		}
-	}
-
-	.fc-daygrid-day-number {
-		background: var(--color-primary);
-		color: var(--color-primary-text);
-		border-radius: 50%;
-		margin: 3px 3px 0 0;
-		width: 24px;
-		height: 24px;
-		text-align: center;
-		font-weight: bold !important;
-		padding: 1px 0 !important;
+.fc-view {
+	&.fc-daygrid .fc-day.fc-daygrid-day.fc-day-today,
+	&.fc-timegrid .fc-day.fc-col-header-cell.fc-day-today {
+		box-shadow: inset 0 4px var(--color-primary);
 	}
 }
 


### PR DESCRIPTION
| Before | After |
|:---------:|:------:|
|![before](https://user-images.githubusercontent.com/1250540/91605732-38199b80-e971-11ea-95ae-2cd4c99b2289.jpg)|![after](https://user-images.githubusercontent.com/1250540/91605747-3cde4f80-e971-11ea-904c-4186ae59b7c8.jpg)|
|Week view: |![week_after](https://user-images.githubusercontent.com/1250540/91605794-51bae300-e971-11ea-984f-0a331ff584f2.jpg)|

I'm not happy about how it looks in day / week view.

please review and test @nextcloud/designers

At the last Calendar Design review session, we discussed how to improve the highlighting of today. This is what we came up with. It's similar to what Outlook Web does.