### PR TITLE
Fix saving current view

### DIFF
--- a/src/components/CalendarGrid.vue
+++ b/src/components/CalendarGrid.vue
@@ -246,7 +246,7 @@ export default {
 		 * When a user changes the view, remember it and
 		 * use it the next time they open the calendar app
 		 */
-		saveNewView: debounce((initialView) => {
+		saveNewView: debounce(function(initialView) {
 			if (this.isAuthenticatedUser) {
 				this.$store.dispatch('setInitialView', { initialView })
 			}


### PR DESCRIPTION
Regression introduced by #2498 

At the time the debounce function is called here, this refers to the object, not the instantiated Vue instance.
Hence we can't use arrow functions here.