### PR TITLE
Release 2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,26 @@
+# 2.1.0 - 2020-09-02
+### Added
+- Dashboard integration
+  [#2414](https://github.com/nextcloud/calendar/pull/2414)
+- Better routes to link to calendar from outside
+  [#2483](https://github.com/nextcloud/calendar/pull/2483)
+- Different style for all-day / timed events
+  [#30](https://github.com/nextcloud/calendar/issues/30)
+- List view
+  [#402](https://github.com/nextcloud/calendar/issues/402)
+- Search
+  [#8](https://github.com/nextcloud/calendar/issues/8)
+
+### Fixed
+- Better localization of calendar-grid
+  [#1844](https://github.com/nextcloud/calendar/issues/1844)
+- Remove double scrollbars in Firefox
+  [#1815](https://github.com/nextcloud/calendar/issues/1815)
+- Better error handling for missing events
+  [#2459](https://github.com/nextcloud/calendar/issues/2459)
+- Long description box
+  [#2187](https://github.com/nextcloud/calendar/issues/2187)
+
 # 2.0.4 - 2020-08-27
 ### Added
 - Center date in month view cell

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -13,7 +13,7 @@
 * ⏰ **Reminders!** Get alarms for events inside your browser and via email.
 * 🙈 **We’re not reinventing the wheel!** Based on the great [c-dav library](https://github.com/nextcloud/cdav-library), [ical.js](https://github.com/mozilla-comm/ical.js) and [fullcalendar](https://github.com/fullcalendar/fullcalendar) libraries.
 	]]></description>
-	<version>2.0.4</version>
+	<version>2.1.0</version>
 	<licence>agpl</licence>
 	<author homepage="https://georg.coffee">Georg Ehrke</author>
 	<author homepage="https://tcit.fr">Thomas Citharel</author>

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "calendar",
 	"description": "A calendar app for Nextcloud. Easily sync events from various devices, share and edit them online.",
-	"version": "2.0.4",
+	"version": "2.1.0",
 	"author": "Georg Ehrke <oc.list@georgehrke.com>",
 	"contributors": [
 		"Georg Ehrke <oc.list@georgehrke.com>",


### PR DESCRIPTION
Requires:
- https://github.com/nextcloud/calendar/pull/2523

Would be nice to have:
- https://github.com/nextcloud/calendar/pull/2528
- https://github.com/nextcloud/calendar/pull/2476