### PR TITLE
Fix opening events from search

### DIFF
--- a/src/mixins/EditorMixin.js
+++ b/src/mixins/EditorMixin.js
@@ -625,6 +625,7 @@ export default {
 					const closeToDate = dateFactory()
 					// TODO: can we replace this by simply returning the new route since we are inside next()
 					// Probably not though, because it's async
+					await vm.loadingCalendars()
 					const recurrenceId = await vm.$store.dispatch('resolveClosestRecurrenceIdForCalendarObject', { objectId, closeToDate })
 					const params = Object.assign({}, vm.$route.params, { recurrenceId })
 					vm.$router.replace({ name: vm.$route.name, params })


### PR DESCRIPTION
Slipped through in https://github.com/nextcloud/calendar/pull/2528

Without that line, it just tries to load the event without waiting until calendars are loaded.
It fails, since it can't find the calendar.