### PR TITLE
Duplicate calendar event

### DIFF
--- a/src/mixins/EditorMixin.js
+++ b/src/mixins/EditorMixin.js
@@ -428,6 +428,19 @@ export default {
 			this.closeEditor()
 		},
 		/**
+		 * Duplicates a calendar-object, saves it and closes the editor
+		 *
+		 * @param {Boolean} thisAndAllFuture Whether to delete only this or this and all future occurrences
+		 * @returns {Promise<void>}
+		 */
+		async duplicateEvent() {
+			await this.$store.dispatch('duplicateCalendarObjectInstance', {
+				calendarId: this.calendarId,
+			})
+			await this.saveAndLeave()
+		},
+
+		/**
 		 * Deletes a calendar-object
 		 *
 		 * @param {Boolean} thisAndAllFuture Whether to delete only this or this and all future occurrences

--- a/src/models/event.js
+++ b/src/models/event.js
@@ -22,13 +22,14 @@
 
 import { getDateFromDateTimeValue } from '../utils/date.js'
 import DurationValue from 'calendar-js/src/values/durationValue.js'
-import { getHexForColorName } from '../utils/color.js'
+import { getHexForColorName, getClosestCSS3ColorNameForHex } from '../utils/color.js'
 import { mapAlarmComponentToAlarmObject } from './alarm.js'
 import { mapAttendeePropertyToAttendeeObject } from './attendee.js'
 import {
 	getDefaultRecurrenceRuleObject,
 	mapRecurrenceRuleValueToRecurrenceRuleObject,
 } from './recurrenceRule.js'
+import DateTimeValue from 'calendar-js/src/values/dateTimeValue.js'
 
 /**
  * Creates a complete calendar-object-instance-object based on given props
@@ -179,7 +180,52 @@ const mapEventComponentToEventObject = (eventComponent) => {
 	return eventObject
 }
 
+/**
+ *
+ * @param {Object} eventObject The calendarObjectInstance object
+ * @param {EventComponent} eventComponent The calendar-js eventComponent
+ */
+const mapEventObjectToEventComponent = (eventObject, eventComponent) => {
+	eventComponent.title = eventObject.title
+	eventComponent.location = eventObject.location
+	eventComponent.description = eventObject.description
+	eventComponent.accessClass = eventObject.accessClass
+	eventComponent.status = eventObject.status
+	eventComponent.timeTransparency = eventObject.timeTransparency
+
+	for (const category of eventObject.categories) {
+		eventComponent.addCategory(category)
+	}
+
+	if (eventObject.organizer) {
+		eventComponent.setOrganizerFromNameAndEMail(eventObject.organizer.commonName, eventObject.organizer.uri)
+	}
+
+	for (const alarm of eventObject.alarms) {
+		if (alarm.isRelative) {
+			const duration = DurationValue.fromSeconds(alarm.relativeTrigger)
+			eventComponent.addRelativeAlarm(alarm.type, duration, alarm.relativeIsRelatedToStart)
+		} else {
+			const date = DateTimeValue.fromJSDate(alarm.absoluteDate)
+			eventComponent.addAbsoluteAlarm(alarm.type, date)
+		}
+	}
+
+	for (const attendee of eventObject.attendees) {
+		eventComponent.addProperty(attendee.attendeeProperty)
+	}
+
+	for (const rule of eventObject.eventComponent.getPropertyIterator('RRULE')) {
+		eventComponent.addProperty(rule)
+	}
+
+	if (eventObject.customColor) {
+		eventComponent.color = getClosestCSS3ColorNameForHex(eventObject.customColor)
+	}
+}
+
 export {
 	getDefaultEventObject,
 	mapEventComponentToEventObject,
+	mapEventObjectToEventComponent,
 }

--- a/src/store/calendarObjectInstance.js
+++ b/src/store/calendarObjectInstance.js
@@ -33,6 +33,7 @@ import { getBySetPositionAndBySetFromDate, getWeekDayFromDate } from '../utils/r
 import {
 	getDefaultEventObject,
 	mapEventComponentToEventObject,
+	mapEventObjectToEventComponent,
 } from '../models/event.js'
 import {
 	getAmountAndUnitForTimedEvents,
@@ -1514,6 +1515,33 @@ const actions = {
 				newCalendarId: calendarId,
 			})
 		}
+	},
+
+	/**
+	 * Duplicate calendar-object-instance
+	 *
+	 * @param {Object} vuex The vuex destructuring object
+	 * @param {Object} vuex.state The Vuex state
+	 * @param {Function} vuex.dispatch The Vuex dispatch function
+	 * @param {Function} vuex.commit The Vuex commit function
+	 * @returns {Promise<void>}
+	 */
+	async duplicateCalendarObjectInstance({ state, dispatch, commit }) {
+		const oldCalendarObjectInstance = state.calendarObjectInstance
+		const oldEventComponent = oldCalendarObjectInstance.eventComponent
+		const startDate = oldEventComponent.startDate.getInUTC()
+		const endDate = oldEventComponent.endDate.getInUTC()
+		const calendarObject = await dispatch('createNewEvent', {
+			start: startDate.unixTime,
+			end: endDate.unixTime,
+			timezoneId: oldEventComponent.startDate.timezoneId,
+			isAllDay: oldEventComponent.isAllDay(),
+		})
+		const eventComponent = getObjectAtRecurrenceId(calendarObject, startDate.jsDate)
+		mapEventObjectToEventComponent(oldCalendarObjectInstance, eventComponent)
+		const calendarObjectInstance = mapEventComponentToEventObject(eventComponent)
+
+		await commit('setCalendarObjectInstanceForNewEvent', { calendarObject, calendarObjectInstance })
 	},
 
 	/**

--- a/src/views/EditSidebar.vue
+++ b/src/views/EditSidebar.vue
@@ -93,6 +93,9 @@
 			<ActionButton v-if="canDelete && canCreateRecurrenceException" icon="icon-delete" @click="deleteAndLeave(true)">
 				{{ $t('calendar', 'Delete this and all future') }}
 			</ActionButton>
+			<ActionButton v-if="!isNew" icon="icon-file" @click="duplicateEvent()">
+				{{ $t('calendar', 'Duplicate') }}
+			</ActionButton>
 		</template>
 
 		<AppSidebarTab

--- a/src/views/EditSidebar.vue
+++ b/src/views/EditSidebar.vue
@@ -84,6 +84,9 @@
 				:href="downloadURL">
 				{{ $t('calendar', 'Download') }}
 			</ActionLink>
+			<ActionButton v-if="!isNew" icon="icon-category-office" @click="duplicateEvent()">
+				{{ $t('calendar', 'Duplicate') }}
+			</ActionButton>
 			<ActionButton v-if="canDelete && !canCreateRecurrenceException" icon="icon-delete" @click="deleteAndLeave(false)">
 				{{ $t('calendar', 'Delete') }}
 			</ActionButton>
@@ -92,9 +95,6 @@
 			</ActionButton>
 			<ActionButton v-if="canDelete && canCreateRecurrenceException" icon="icon-delete" @click="deleteAndLeave(true)">
 				{{ $t('calendar', 'Delete this and all future') }}
-			</ActionButton>
-			<ActionButton v-if="!isNew" icon="icon-file" @click="duplicateEvent()">
-				{{ $t('calendar', 'Duplicate') }}
 			</ActionButton>
 		</template>
 


### PR DESCRIPTION
## Description

Added a button to duplicate an existing calendar event.

Fixes #113 

### Type of change

- [X] New feature (non-breaking change which adds functionality)

### How to test / use your changes?

1. Create calendar event (one-time event or recurrent event)
2. Open event side editor
3. Open menu (same menu that the one to delete the event) and click on "Duplicate"
4. Event (or all the instances of the recurrent event) should be duplicated

### Checklist:

- [X] My code follows the style guidelines of this project
- [X] I signed off my changes (`git commit -sm "Your commit message"`)
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes

