### PR TITLE
Fix french localization error

### DIFF
--- a/l10n/fr.json
+++ b/l10n/fr.json
@@ -186,7 +186,7 @@
     "last" : "dernier",
     "Changes to the recurrence-rule will only apply to this and all future occurrences." : "Les modifications apportées à la règle de récurrence ne s’appliqueront qu’à cet événement et à tous les événements futurs.",
     "Repeat" : "Répéter",
-    "Repeat every" : "Répéter chaque",
+    "Repeat every" : "Répéter tous les",
     "By day of the month" : "Par jour du mois",
     "On the" : "Le",
     "_month_::_months_" : ["mois","mois"],


### PR DESCRIPTION
## Description

In context, the "Repeat every" string is used in the "create event" widget to mean "Repeat every N days/months/years/etc".

This would translate to "Répéter tous les N jours/mois/années/etc", not "Répéter chaque N jours/mois/années"; the current translation is confusing.

This PR proposes a change to the l10n file to make this widget accurate and understandable for French users.

### Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

### How to test / use your changes?

- Open the calendar app on your browser. Set Nextcloud to a French locale.
- Create a new event a switch to the "Repeat" / "Répéter" tab.
- The text of the first row has changed 

### Checklist:

n/a
