### PR TITLE
allow some margin for organizer hint in attendee list

### DIFF
--- a/css/app-sidebar.scss
+++ b/css/app-sidebar.scss
@@ -441,6 +441,7 @@
 		&__organizer-hint {
 			color: var(--color-text-maxcontrast);
 			font-weight: 300;
+			margin-left: 5px;
 		}
 	}
 


### PR DESCRIPTION
little styling tweak:

### before

![organizer_before](https://user-images.githubusercontent.com/1804221/98244769-3e7b5380-1f70-11eb-8c22-d29dcb31f6f0.png)

### after

![organizer_after](https://user-images.githubusercontent.com/1804221/98244777-420eda80-1f70-11eb-8730-a4fc681f7874.png)
