### PR TITLE
Fix #2675: RRULE UNTIL must be in UTC if DTSTART is timezone-aware

### DIFF
--- a/src/store/calendarObjectInstance.js
+++ b/src/store/calendarObjectInstance.js
@@ -605,8 +605,12 @@ const mutations = {
 	 */
 	changeRecurrenceUntil(state, { calendarObjectInstance, recurrenceRule, until }) {
 		if (recurrenceRule.recurrenceRuleValue) {
-
-			recurrenceRule.recurrenceRuleValue.until = DateTimeValue.fromJSDate(until)
+			// RFC 5545, setion 3.3.10: until must be in UTC if the start time is timezone-aware
+			if (calendarObjectInstance.startTimezoneId !== 'floating') {
+				recurrenceRule.recurrenceRuleValue.until = DateTimeValue.fromJSDate(until, { zone: 'utc' })
+			} else {
+				recurrenceRule.recurrenceRuleValue.until = DateTimeValue.fromJSDate(until)
+			}
 			recurrenceRule.until = until
 			recurrenceRule.count = null
 


### PR DESCRIPTION
## Description

This PR makes sure that events edited in the Nextcloud Calendar webinterface have their recurrenceRule.until timestamp set to UTC in order to be compliant with [RFC 5545, section 3.3.10](https://tools.ietf.org/html/rfc5545#section-3.3.10) (for details see #2675 )
Please give a brief summary of your changes and which issue they address.

Fixes #2675 

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### How to test / use your changes?

1. Create a timezone aware recurring event with an end date
2. Retrieve the calendar in ical form, e.g. through the `/remote.php/dav/calendars/<principal>/<calendar>/?export` endpoint
3. Verify that the UNTIL timestamp is timezone-aware and in UTC (i.e. ends in `Z`)

### UI Changes

None

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I signed off my changes (`git commit -sm "Your commit message"`)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
  - N/A
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

