### PR TITLE
fixes encoded display of names that contain a special character

### DIFF
--- a/src/models/calendarShare.js
+++ b/src/models/calendarShare.js
@@ -62,9 +62,9 @@ const mapDavShareeToCalendarShareObject = (sharee) => {
 	if (sharee['common-name'] && sharee['common-name'].trim() !== '') {
 		displayName = sharee['common-name']
 	} else if (sharee.href.startsWith(PRINCIPAL_PREFIX_GROUP)) {
-		displayName = sharee.href.substr(28)
+		displayName = decodeURIComponent(sharee.href.substr(28))
 	} else if (sharee.href.startsWith(PRINCIPAL_PREFIX_USER)) {
-		displayName = sharee.href.substr(27)
+		displayName = decodeURIComponent(sharee.href.substr(27))
 	} else {
 		displayName = sharee.href
 	}


### PR DESCRIPTION
When a calendar is shared to a group named "Route#44" it was displayed as "Route%2344".  Companion PR for https://github.com/nextcloud/server/pull/24515