### PR TITLE
'Create new event' spacing is now like 'Set up an account'

### DIFF
--- a/src/views/Dashboard.vue
+++ b/src/views/Dashboard.vue
@@ -54,9 +54,9 @@
 				icon="icon-calendar-dark">
 				<template #desc>
 					{{ t('calendar', 'No upcoming events') }}
-						<div class="empty-label">
+					<div class="empty-label">
 						<a class="button" :href="clickStartNew"> {{ t('calendar', 'Create a new event') }} </a>
-						</div>
+					</div>
 				</template>
 			</EmptyContent>
 		</template>

--- a/src/views/Dashboard.vue
+++ b/src/views/Dashboard.vue
@@ -53,16 +53,10 @@
 				id="calendar-widget-empty-content"
 				icon="icon-calendar-dark">
 				<template #desc>
-					<p class="empty-label">
-						{{ t('calendar', 'No upcoming events') }}
-					</p>
-					<p>
-						<a
-							class="button"
-							:href="clickStartNew">
-							{{ t('calendar', 'Create a new event') }}
-						</a>
-					</p>
+					{{ t('calendar', 'No upcoming events') }}
+						<div class="empty-label">
+						<a class="button" :href="clickStartNew"> {{ t('calendar', 'Create a new event') }} </a>
+						</div>
 				</template>
 			</EmptyContent>
 		</template>
@@ -311,7 +305,8 @@ export default {
 		}
 
 		.empty-label {
-			margin-bottom: 20px;
+			margin-top: 5vh;
+			margin-right: 5px;
 		}
 	}
 }


### PR DESCRIPTION
## Description

For Issue:
https://github.com/nextcloud/server/issues/22864
 - "Upcoming events" button "Create new event" button is not 44px min

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### How to test / use your changes?

1. Compile new Calendar Module
2. Replace old Calendar JS Files to new Compiled JS Files in Nextcloud Server
3. Start Nextcloud Server

### UI Changes

| Before | After |
|:---------:|:------:|
|![before](https://user-images.githubusercontent.com/64197016/101017306-33651480-356a-11eb-9505-6269b56a4c81.png)|![after](https://user-images.githubusercontent.com/64197016/101017362-4546b780-356a-11eb-9036-22b8ce6b5d65.png)|


