### PR TITLE
Cleaned up the changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,13 @@
-# 2.1.2 - 2020-09-24
+# Changelog
+
+## 2.1.2 - 2020-09-24
 ### Added
 - 21 compatibility
 - Fixed reminder editing
   [#2605](https://github.com/nextcloud/calendar/pull/2605)
   [#2606](https://github.com/nextcloud/calendar/pull/2606)
 
-# 2.1.1 - 2020-09-11
+## 2.1.1 - 2020-09-11
 ### Fixed
 - Dashboard fixes
   [#2574](https://github.com/nextcloud/calendar/pull/2574)
@@ -16,7 +18,7 @@
 - Updated dependencies
 - Updated translations
 
-# 2.1.0 - 2020-09-02
+## 2.1.0 - 2020-09-02
 ### Added
 - Dashboard integration
   [#2414](https://github.com/nextcloud/calendar/pull/2414)
@@ -39,7 +41,7 @@
 - Long description box
   [#2187](https://github.com/nextcloud/calendar/issues/2187)
 
-# 2.0.4 - 2020-08-27
+## 2.0.4 - 2020-08-27
 ### Added
 - Center date in month view cell
   [#2451](https://github.com/nextcloud/calendar/pull/2451)
@@ -78,7 +80,7 @@
 - Circle not found when full name is given
   [#2220](https://github.com/nextcloud/calendar/issues/2220)
 
-# 2.0.3 - 2020-04-09
+## 2.0.3 - 2020-04-09
 ### Added
 - Show week number in Datepicker
   [#2060](https://github.com/nextcloud/calendar/pull/2060)
@@ -114,7 +116,7 @@
 - Repeating events not displayed on first day of monthly calendar 
   [#1913](https://github.com/nextcloud/calendar/issues/1913)
 
-# 2.0.2 - 2020-03-02
+## 2.0.2 - 2020-03-02
 ### Added
 - Recognize Gym as event title for illustrations
   [#1888](https://github.com/nextcloud/calendar/issues/1888)
@@ -436,11 +438,11 @@ Even though all features present on the 1.x calendar app versions have been reim
 - Update link to documentation [#1409](https://github.com/nextcloud/calendar/pull/1409)
 - Don’t ship special build for IE anymore [#1447](https://github.com/nextcloud/calendar/pull/1447)
 
-
 ## 1.7.0 - 2019-03-25
 ### Added
 - Share calendars with circles
   [#602](https://github.com/nextcloud/calendar/pull/602)
+
 ### Fixed
 - compatibility with Nextcloud 16
 - Buttons not visible in dark theme
@@ -472,7 +474,6 @@ Even though all features present on the 1.x calendar app versions have been reim
 ### Fixed
 - compatibility with Nextcloud 14
 - updated translations
-
 
 ## 1.6.1 - 2018-03-06
 ### Fixed
@@ -562,7 +563,6 @@ Even though all features present on the 1.x calendar app versions have been reim
   [#417](https://github.com/nextcloud/calendar/pull/417)
 - color weekends slightly darker
   [#430](https://github.com/nextcloud/calendar/pull/430)
-
 
 ### Fixed
 - fix visual deletion of user shares


### PR DESCRIPTION
## Description

I've added an `h1` title and I've updated all the releases that were using `h1` to `h2`.

Hopefully, this would enable the "changelog" tab in the application details like we can see on other apps such as Contacts, Mail, News, etc...  
I've based my changes on Contacts' changelog: https://github.com/nextcloud/contacts/blob/master/CHANGELOG.md

Here are screenshots of Calendar vs Contacts apps details. See the "Details" and "Changelog" tabs for Contacts (in French, sorry):

Calendar | Contacts
--|--
![image](https://user-images.githubusercontent.com/6382548/102052568-3d7de300-3db4-11eb-9141-9bde834eca54.png) | ![image](https://user-images.githubusercontent.com/6382548/102051825-2ab6de80-3db3-11eb-9669-9a2a94098222.png)

### Type of change

This is a "meta" change, the app is still the same.

### How to test / use your changes?

Nothing to test.

### UI Changes

No UI changes.

### Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I signed off my changes (`git commit -sm "Your commit message"`)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

