### PR TITLE
Test against php8

### DIFF
--- a/.github/workflows/php-test.yml
+++ b/.github/workflows/php-test.yml
@@ -11,12 +11,17 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-versions: ['7.2', '7.3', '7.4']
+        php-versions: ['7.3', '7.4']
         nextcloud-versions: ['stable20', 'master']
-        exclude:
+        include:
           - php-versions: '7.2'
+            nextcloud-versions: 'stable20'
+          - php-versions: '8.0'
             nextcloud-versions: 'master'
     name: php${{ matrix.php-versions }} on ${{ matrix.nextcloud-versions }} unit tests
+    env:
+      CI: true
+      XDEBUG_MODE: coverage
     steps:
     - name: Set up php${{ matrix.php-versions }}
       uses: shivammathur/setup-php@master
@@ -26,12 +31,20 @@ jobs:
         coverage: xdebug
     - name: Checkout Nextcloud
       run: git clone https://github.com/nextcloud/server.git --recursive --depth 1 -b ${{ matrix.nextcloud-versions }} nextcloud
-    - name: Run tests
+    - name: Install Nextcloud
       run: php -f nextcloud/occ maintenance:install --database-name oc_autotest --database-user oc_autotest --admin-user admin --admin-pass admin --database sqlite --database-pass=''
-    - name: Checkout
+    - name: Checkout the app
       uses: actions/checkout@master
       with:
         path: nextcloud/apps/calendar
+    - name: Fix php-parser on stable20 incompatibility with phpunit 9.3+
+      if: ${{ matrix.nextcloud-versions == 'stable20' }}
+      working-directory: nextcloud/3rdparty
+      run: composer require nikic/php-parser:4.10
+    - name: Downgrade phpunit for php7.2
+      if: ${{ matrix.php-versions == '7.2' }}
+      working-directory: nextcloud/apps/calendar
+      run: composer update christophwurst/nextcloud_testing -W
     - name: Install dependencies
       working-directory: nextcloud/apps/calendar
       run: composer install
@@ -39,5 +52,6 @@ jobs:
       working-directory: nextcloud/apps/calendar
       run: composer run test
     - name: Upload coverage to Codecov
+      if: ${{ matrix.nextcloud-versions == 'master' }}
       working-directory: nextcloud/apps/calendar
       run: curl -s https://codecov.io/bash | bash -s - -t ${{ secrets.CODECOV_TOKEN }} -F php -f clover.unit.xml -Z

--- a/.gitignore
+++ b/.gitignore
@@ -94,8 +94,10 @@ RCS/*
 
 /.project
 .php_cs.cache
+.phpunit.result.cache
 
 coverage/
 
 js/public
 css/public
+

--- a/composer.json
+++ b/composer.json
@@ -1,11 +1,10 @@
 {
     "require": {
-        "php": ">=7.2",
+        "php": "^7.2|^8.0",
         "nextcloud/coding-standard": "^0.5.0"
     },
     "require-dev": {
-        "christophwurst/nextcloud": "v20.0.4",
-        "christophwurst/nextcloud_testing": "0.10.0"
+        "christophwurst/nextcloud_testing": "0.12.1"
     },
     "scripts": {
         "cs:fix": "php-cs-fixer fix",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5bd12bbb5e973adc9555519b643c0fe7",
+    "content-hash": "9301ffb60b5791e36928d626d9c7cbe6",
     "packages": [
         {
             "name": "composer/semver",
@@ -559,6 +559,56 @@
             "time": "2017-02-14T16:28:37+00:00"
         },
         {
+            "name": "psr/event-dispatcher",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/event-dispatcher.git",
+                "reference": "dbefd12671e8a14ec7f180cab83036ed26714bb0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/event-dispatcher/zipball/dbefd12671e8a14ec7f180cab83036ed26714bb0",
+                "reference": "dbefd12671e8a14ec7f180cab83036ed26714bb0",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\EventDispatcher\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Standard interfaces for event handling.",
+            "keywords": [
+                "events",
+                "psr",
+                "psr-14"
+            ],
+            "support": {
+                "issues": "https://github.com/php-fig/event-dispatcher/issues",
+                "source": "https://github.com/php-fig/event-dispatcher/tree/1.0.0"
+            },
+            "time": "2019-01-08T18:20:26+00:00"
+        },
+        {
             "name": "psr/log",
             "version": "1.1.3",
             "source": {
@@ -610,42 +660,44 @@
         },
         {
             "name": "symfony/console",
-            "version": "v4.4.18",
+            "version": "v5.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "12e071278e396cc3e1c149857337e9e192deca0b"
+                "reference": "47c02526c532fb381374dab26df05e7313978976"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/12e071278e396cc3e1c149857337e9e192deca0b",
-                "reference": "12e071278e396cc3e1c149857337e9e192deca0b",
+                "url": "https://api.github.com/repos/symfony/console/zipball/47c02526c532fb381374dab26df05e7313978976",
+                "reference": "47c02526c532fb381374dab26df05e7313978976",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.1.3",
+                "php": ">=7.2.5",
                 "symfony/polyfill-mbstring": "~1.0",
                 "symfony/polyfill-php73": "^1.8",
                 "symfony/polyfill-php80": "^1.15",
-                "symfony/service-contracts": "^1.1|^2"
+                "symfony/service-contracts": "^1.1|^2",
+                "symfony/string": "^5.1"
             },
             "conflict": {
-                "symfony/dependency-injection": "<3.4",
-                "symfony/event-dispatcher": "<4.3|>=5",
+                "symfony/dependency-injection": "<4.4",
+                "symfony/dotenv": "<5.1",
+                "symfony/event-dispatcher": "<4.4",
                 "symfony/lock": "<4.4",
-                "symfony/process": "<3.3"
+                "symfony/process": "<4.4"
             },
             "provide": {
                 "psr/log-implementation": "1.0"
             },
             "require-dev": {
                 "psr/log": "~1.0",
-                "symfony/config": "^3.4|^4.0|^5.0",
-                "symfony/dependency-injection": "^3.4|^4.0|^5.0",
-                "symfony/event-dispatcher": "^4.3",
+                "symfony/config": "^4.4|^5.0",
+                "symfony/dependency-injection": "^4.4|^5.0",
+                "symfony/event-dispatcher": "^4.4|^5.0",
                 "symfony/lock": "^4.4|^5.0",
-                "symfony/process": "^3.4|^4.0|^5.0",
-                "symfony/var-dumper": "^4.3|^5.0"
+                "symfony/process": "^4.4|^5.0",
+                "symfony/var-dumper": "^4.4|^5.0"
             },
             "suggest": {
                 "psr/log": "For using the console logger",
@@ -678,8 +730,14 @@
             ],
             "description": "Symfony Console Component",
             "homepage": "https://symfony.com",
+            "keywords": [
+                "cli",
+                "command line",
+                "console",
+                "terminal"
+            ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v4.4.18"
+                "source": "https://github.com/symfony/console/tree/v5.2.1"
             },
             "funding": [
                 {
@@ -695,42 +753,111 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-12-18T07:41:31+00:00"
+            "time": "2020-12-18T08:03:05+00:00"
         },
         {
-            "name": "symfony/event-dispatcher",
-            "version": "v4.4.18",
+            "name": "symfony/deprecation-contracts",
+            "version": "v2.2.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/event-dispatcher.git",
-                "reference": "5d4c874b0eb1c32d40328a09dbc37307a5a910b0"
+                "url": "https://github.com/symfony/deprecation-contracts.git",
+                "reference": "5fa56b4074d1ae755beb55617ddafe6f5d78f665"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/5d4c874b0eb1c32d40328a09dbc37307a5a910b0",
-                "reference": "5d4c874b0eb1c32d40328a09dbc37307a5a910b0",
+                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/5fa56b4074d1ae755beb55617ddafe6f5d78f665",
+                "reference": "5fa56b4074d1ae755beb55617ddafe6f5d78f665",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.1.3",
-                "symfony/event-dispatcher-contracts": "^1.1"
+                "php": ">=7.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.2-dev"
+                },
+                "thanks": {
+                    "name": "symfony/contracts",
+                    "url": "https://github.com/symfony/contracts"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "function.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "A generic function and convention to trigger deprecation notices",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/deprecation-contracts/tree/master"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-09-07T11:33:47+00:00"
+        },
+        {
+            "name": "symfony/event-dispatcher",
+            "version": "v5.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/event-dispatcher.git",
+                "reference": "1c93f7a1dff592c252574c79a8635a8a80856042"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/1c93f7a1dff592c252574c79a8635a8a80856042",
+                "reference": "1c93f7a1dff592c252574c79a8635a8a80856042",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2.5",
+                "symfony/deprecation-contracts": "^2.1",
+                "symfony/event-dispatcher-contracts": "^2",
+                "symfony/polyfill-php80": "^1.15"
             },
             "conflict": {
-                "symfony/dependency-injection": "<3.4"
+                "symfony/dependency-injection": "<4.4"
             },
             "provide": {
                 "psr/event-dispatcher-implementation": "1.0",
-                "symfony/event-dispatcher-implementation": "1.1"
+                "symfony/event-dispatcher-implementation": "2.0"
             },
             "require-dev": {
                 "psr/log": "~1.0",
-                "symfony/config": "^3.4|^4.0|^5.0",
-                "symfony/dependency-injection": "^3.4|^4.0|^5.0",
-                "symfony/error-handler": "~3.4|~4.4",
-                "symfony/expression-language": "^3.4|^4.0|^5.0",
-                "symfony/http-foundation": "^3.4|^4.0|^5.0",
+                "symfony/config": "^4.4|^5.0",
+                "symfony/dependency-injection": "^4.4|^5.0",
+                "symfony/error-handler": "^4.4|^5.0",
+                "symfony/expression-language": "^4.4|^5.0",
+                "symfony/http-foundation": "^4.4|^5.0",
                 "symfony/service-contracts": "^1.1|^2",
-                "symfony/stopwatch": "^3.4|^4.0|^5.0"
+                "symfony/stopwatch": "^4.4|^5.0"
             },
             "suggest": {
                 "symfony/dependency-injection": "",
@@ -762,7 +889,7 @@
             "description": "Symfony EventDispatcher Component",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/event-dispatcher/tree/v4.4.18"
+                "source": "https://github.com/symfony/event-dispatcher/tree/v5.2.1"
             },
             "funding": [
                 {
@@ -778,33 +905,33 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-12-18T07:41:31+00:00"
+            "time": "2020-12-18T08:03:05+00:00"
         },
         {
             "name": "symfony/event-dispatcher-contracts",
-            "version": "v1.1.9",
+            "version": "v2.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher-contracts.git",
-                "reference": "84e23fdcd2517bf37aecbd16967e83f0caee25a7"
+                "reference": "0ba7d54483095a198fa51781bc608d17e84dffa2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher-contracts/zipball/84e23fdcd2517bf37aecbd16967e83f0caee25a7",
-                "reference": "84e23fdcd2517bf37aecbd16967e83f0caee25a7",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher-contracts/zipball/0ba7d54483095a198fa51781bc608d17e84dffa2",
+                "reference": "0ba7d54483095a198fa51781bc608d17e84dffa2",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.1.3"
+                "php": ">=7.2.5",
+                "psr/event-dispatcher": "^1"
             },
             "suggest": {
-                "psr/event-dispatcher": "",
                 "symfony/event-dispatcher-implementation": ""
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.1-dev"
+                    "dev-master": "2.2-dev"
                 },
                 "thanks": {
                     "name": "symfony/contracts",
@@ -841,7 +968,7 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/event-dispatcher-contracts/tree/v1.1.9"
+                "source": "https://github.com/symfony/event-dispatcher-contracts/tree/v2.2.0"
             },
             "funding": [
                 {
@@ -857,24 +984,24 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-07-06T13:19:58+00:00"
+            "time": "2020-09-07T11:33:47+00:00"
         },
         {
             "name": "symfony/filesystem",
-            "version": "v4.4.18",
+            "version": "v5.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
-                "reference": "d99fbef7e0f69bf162ae6131b31132fa3cc4bcbe"
+                "reference": "fa8f8cab6b65e2d99a118e082935344c5ba8c60d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/d99fbef7e0f69bf162ae6131b31132fa3cc4bcbe",
-                "reference": "d99fbef7e0f69bf162ae6131b31132fa3cc4bcbe",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/fa8f8cab6b65e2d99a118e082935344c5ba8c60d",
+                "reference": "fa8f8cab6b65e2d99a118e082935344c5ba8c60d",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.1.3",
+                "php": ">=7.2.5",
                 "symfony/polyfill-ctype": "~1.8"
             },
             "type": "library",
@@ -903,7 +1030,7 @@
             "description": "Symfony Filesystem Component",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/filesystem/tree/v4.4.18"
+                "source": "https://github.com/symfony/filesystem/tree/v5.2.1"
             },
             "funding": [
                 {
@@ -919,24 +1046,24 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-11-30T13:04:35+00:00"
+            "time": "2020-11-30T17:05:38+00:00"
         },
         {
             "name": "symfony/finder",
-            "version": "v4.4.18",
+            "version": "v5.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
-                "reference": "ebd0965f2dc2d4e0f11487c16fbb041e50b5c09b"
+                "reference": "0b9231a5922fd7287ba5b411893c0ecd2733e5ba"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/ebd0965f2dc2d4e0f11487c16fbb041e50b5c09b",
-                "reference": "ebd0965f2dc2d4e0f11487c16fbb041e50b5c09b",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/0b9231a5922fd7287ba5b411893c0ecd2733e5ba",
+                "reference": "0b9231a5922fd7287ba5b411893c0ecd2733e5ba",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.1.3"
+                "php": ">=7.2.5"
             },
             "type": "library",
             "autoload": {
@@ -964,7 +1091,7 @@
             "description": "Symfony Finder Component",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/finder/tree/v4.4.18"
+                "source": "https://github.com/symfony/finder/tree/v5.2.1"
             },
             "funding": [
                 {
@@ -980,24 +1107,27 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-12-08T16:59:59+00:00"
+            "time": "2020-12-08T17:02:38+00:00"
         },
         {
             "name": "symfony/options-resolver",
-            "version": "v4.4.18",
+            "version": "v5.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/options-resolver.git",
-                "reference": "157a252222251310fe50c71012b4e72f01325850"
+                "reference": "87a2a4a766244e796dd9cb9d6f58c123358cd986"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/options-resolver/zipball/157a252222251310fe50c71012b4e72f01325850",
-                "reference": "157a252222251310fe50c71012b4e72f01325850",
+                "url": "https://api.github.com/repos/symfony/options-resolver/zipball/87a2a4a766244e796dd9cb9d6f58c123358cd986",
+                "reference": "87a2a4a766244e796dd9cb9d6f58c123358cd986",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.1.3"
+                "php": ">=7.2.5",
+                "symfony/deprecation-contracts": "^2.1",
+                "symfony/polyfill-php73": "~1.0",
+                "symfony/polyfill-php80": "^1.15"
             },
             "type": "library",
             "autoload": {
@@ -1030,7 +1160,7 @@
                 "options"
             ],
             "support": {
-                "source": "https://github.com/symfony/options-resolver/tree/v4.4.18"
+                "source": "https://github.com/symfony/options-resolver/tree/v5.2.1"
             },
             "funding": [
                 {
@@ -1046,7 +1176,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-10-24T11:50:19+00:00"
+            "time": "2020-10-24T12:08:07+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
@@ -1126,6 +1256,171 @@
                 }
             ],
             "time": "2021-01-07T16:49:33+00:00"
+        },
+        {
+            "name": "symfony/polyfill-intl-grapheme",
+            "version": "v1.22.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-intl-grapheme.git",
+                "reference": "267a9adeb8ecb8071040a740930e077cdfb987af"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/267a9adeb8ecb8071040a740930e077cdfb987af",
+                "reference": "267a9adeb8ecb8071040a740930e077cdfb987af",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "suggest": {
+                "ext-intl": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.22-dev"
+                },
+                "thanks": {
+                    "name": "symfony/polyfill",
+                    "url": "https://github.com/symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Intl\\Grapheme\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for intl's grapheme_* functions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "grapheme",
+                "intl",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.22.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-01-07T16:49:33+00:00"
+        },
+        {
+            "name": "symfony/polyfill-intl-normalizer",
+            "version": "v1.22.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-intl-normalizer.git",
+                "reference": "6e971c891537eb617a00bb07a43d182a6915faba"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/6e971c891537eb617a00bb07a43d182a6915faba",
+                "reference": "6e971c891537eb617a00bb07a43d182a6915faba",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "suggest": {
+                "ext-intl": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.22-dev"
+                },
+                "thanks": {
+                    "name": "symfony/polyfill",
+                    "url": "https://github.com/symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Intl\\Normalizer\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ],
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for intl's Normalizer class and related functions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "intl",
+                "normalizer",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.22.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-01-07T17:09:11+00:00"
         },
         {
             "name": "symfony/polyfill-mbstring",
@@ -1515,20 +1810,21 @@
         },
         {
             "name": "symfony/process",
-            "version": "v4.4.18",
+            "version": "v5.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
-                "reference": "075316ff72233ce3d04a9743414292e834f2cb4a"
+                "reference": "bd8815b8b6705298beaa384f04fabd459c10bedd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/075316ff72233ce3d04a9743414292e834f2cb4a",
-                "reference": "075316ff72233ce3d04a9743414292e834f2cb4a",
+                "url": "https://api.github.com/repos/symfony/process/zipball/bd8815b8b6705298beaa384f04fabd459c10bedd",
+                "reference": "bd8815b8b6705298beaa384f04fabd459c10bedd",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.1.3"
+                "php": ">=7.2.5",
+                "symfony/polyfill-php80": "^1.15"
             },
             "type": "library",
             "autoload": {
@@ -1556,7 +1852,7 @@
             "description": "Symfony Process Component",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/process/tree/v4.4.18"
+                "source": "https://github.com/symfony/process/tree/v5.2.1"
             },
             "funding": [
                 {
@@ -1572,24 +1868,24 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-12-08T16:59:59+00:00"
+            "time": "2020-12-08T17:03:37+00:00"
         },
         {
             "name": "symfony/service-contracts",
-            "version": "v1.1.9",
+            "version": "v2.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/service-contracts.git",
-                "reference": "b776d18b303a39f56c63747bcb977ad4b27aca26"
+                "reference": "d15da7ba4957ffb8f1747218be9e1a121fd298a1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/b776d18b303a39f56c63747bcb977ad4b27aca26",
-                "reference": "b776d18b303a39f56c63747bcb977ad4b27aca26",
+                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/d15da7ba4957ffb8f1747218be9e1a121fd298a1",
+                "reference": "d15da7ba4957ffb8f1747218be9e1a121fd298a1",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.1.3",
+                "php": ">=7.2.5",
                 "psr/container": "^1.0"
             },
             "suggest": {
@@ -1598,7 +1894,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.1-dev"
+                    "dev-master": "2.2-dev"
                 },
                 "thanks": {
                     "name": "symfony/contracts",
@@ -1635,7 +1931,7 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/service-contracts/tree/v1.1.9"
+                "source": "https://github.com/symfony/service-contracts/tree/master"
             },
             "funding": [
                 {
@@ -1651,24 +1947,24 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-07-06T13:19:58+00:00"
+            "time": "2020-09-07T11:33:47+00:00"
         },
         {
             "name": "symfony/stopwatch",
-            "version": "v4.4.18",
+            "version": "v5.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/stopwatch.git",
-                "reference": "c7a594108ed01c89555c4e1bb123b4a54aee2595"
+                "reference": "2b105c0354f39a63038a1d8bf776ee92852813af"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/stopwatch/zipball/c7a594108ed01c89555c4e1bb123b4a54aee2595",
-                "reference": "c7a594108ed01c89555c4e1bb123b4a54aee2595",
+                "url": "https://api.github.com/repos/symfony/stopwatch/zipball/2b105c0354f39a63038a1d8bf776ee92852813af",
+                "reference": "2b105c0354f39a63038a1d8bf776ee92852813af",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.1.3",
+                "php": ">=7.2.5",
                 "symfony/service-contracts": "^1.0|^2"
             },
             "type": "library",
@@ -1697,7 +1993,7 @@
             "description": "Symfony Stopwatch Component",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/stopwatch/tree/v4.4.18"
+                "source": "https://github.com/symfony/stopwatch/tree/v5.2.1"
             },
             "funding": [
                 {
@@ -1713,66 +2009,114 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-10-31T22:44:29+00:00"
+            "time": "2020-11-01T16:14:45+00:00"
+        },
+        {
+            "name": "symfony/string",
+            "version": "v5.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/string.git",
+                "reference": "5bd67751d2e3f7d6f770c9154b8fbcb2aa05f7ed"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/string/zipball/5bd67751d2e3f7d6f770c9154b8fbcb2aa05f7ed",
+                "reference": "5bd67751d2e3f7d6f770c9154b8fbcb2aa05f7ed",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2.5",
+                "symfony/polyfill-ctype": "~1.8",
+                "symfony/polyfill-intl-grapheme": "~1.0",
+                "symfony/polyfill-intl-normalizer": "~1.0",
+                "symfony/polyfill-mbstring": "~1.0",
+                "symfony/polyfill-php80": "~1.15"
+            },
+            "require-dev": {
+                "symfony/error-handler": "^4.4|^5.0",
+                "symfony/http-client": "^4.4|^5.0",
+                "symfony/translation-contracts": "^1.1|^2",
+                "symfony/var-exporter": "^4.4|^5.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\String\\": ""
+                },
+                "files": [
+                    "Resources/functions.php"
+                ],
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony String component",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "grapheme",
+                "i18n",
+                "string",
+                "unicode",
+                "utf-8",
+                "utf8"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/string/tree/v5.2.1"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-12-05T07:33:16+00:00"
         }
     ],
     "packages-dev": [
         {
-            "name": "christophwurst/nextcloud",
-            "version": "v20.0.4",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/ChristophWurst/nextcloud_composer.git",
-                "reference": "a207b55848d1ac4c83a954eac90c07714bbdaaed"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/ChristophWurst/nextcloud_composer/zipball/a207b55848d1ac4c83a954eac90c07714bbdaaed",
-                "reference": "a207b55848d1ac4c83a954eac90c07714bbdaaed",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.2"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "20.0.0-dev"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "AGPL-3.0-or-later"
-            ],
-            "authors": [
-                {
-                    "name": "Christoph Wurst",
-                    "email": "christoph@winzerhof-wurst.at"
-                }
-            ],
-            "description": "Composer package containing Nextcloud's public API (classes, interfaces)",
-            "time": "2020-12-23T12:42:07+00:00"
-        },
-        {
             "name": "christophwurst/nextcloud_testing",
-            "version": "0.10.0",
+            "version": "v0.12.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ChristophWurst/nextcloud_testing.git",
-                "reference": "a5b30f95ef199b2fa80ff51b0e5bad48bfd0501c"
+                "reference": "3cbba15c75b7442e21d661e16e84a549eec93f3f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ChristophWurst/nextcloud_testing/zipball/a5b30f95ef199b2fa80ff51b0e5bad48bfd0501c",
-                "reference": "a5b30f95ef199b2fa80ff51b0e5bad48bfd0501c",
+                "url": "https://api.github.com/repos/ChristophWurst/nextcloud_testing/zipball/3cbba15c75b7442e21d661e16e84a549eec93f3f",
+                "reference": "3cbba15c75b7442e21d661e16e84a549eec93f3f",
                 "shasum": ""
             },
             "require": {
-                "php-webdriver/webdriver": "^1.7",
-                "phpunit/phpunit": "^8.0"
+                "php": "^7.2|^8.0",
+                "php-webdriver/webdriver": "^1.9",
+                "phpunit/phpunit": "^8.0|^9.0"
             },
             "require-dev": {
-                "christophwurst/nextcloud": "^15.0"
+                "christophwurst/nextcloud": "^17.0"
             },
             "type": "library",
             "autoload": {
@@ -1791,40 +2135,39 @@
                 }
             ],
             "description": "Simple and fast unit and integration testing framework for Nextcloud, based on PHPUnit",
-            "time": "2020-01-20T13:20:58+00:00"
+            "support": {
+                "issues": "https://github.com/ChristophWurst/nextcloud_testing/issues",
+                "source": "https://github.com/ChristophWurst/nextcloud_testing/tree/v0.12.1"
+            },
+            "time": "2021-01-13T10:05:18+00:00"
         },
         {
             "name": "doctrine/instantiator",
-            "version": "1.3.0",
+            "version": "1.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/instantiator.git",
-                "reference": "ae466f726242e637cebdd526a7d991b9433bacf1"
+                "reference": "d56bf6102915de5702778fe20f2de3b2fe570b5b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/ae466f726242e637cebdd526a7d991b9433bacf1",
-                "reference": "ae466f726242e637cebdd526a7d991b9433bacf1",
+                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/d56bf6102915de5702778fe20f2de3b2fe570b5b",
+                "reference": "d56bf6102915de5702778fe20f2de3b2fe570b5b",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.1"
+                "php": "^7.1 || ^8.0"
             },
             "require-dev": {
-                "doctrine/coding-standard": "^6.0",
+                "doctrine/coding-standard": "^8.0",
                 "ext-pdo": "*",
                 "ext-phar": "*",
-                "phpbench/phpbench": "^0.13",
-                "phpstan/phpstan-phpunit": "^0.11",
-                "phpstan/phpstan-shim": "^0.11",
-                "phpunit/phpunit": "^7.0"
+                "phpbench/phpbench": "^0.13 || 1.0.0-alpha2",
+                "phpstan/phpstan": "^0.12",
+                "phpstan/phpstan-phpunit": "^0.12",
+                "phpunit/phpunit": "^7.0 || ^8.0 || ^9.0"
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.2.x-dev"
-                }
-            },
             "autoload": {
                 "psr-4": {
                     "Doctrine\\Instantiator\\": "src/Doctrine/Instantiator/"
@@ -1838,7 +2181,7 @@
                 {
                     "name": "Marco Pivetta",
                     "email": "ocramius@gmail.com",
-                    "homepage": "http://ocramius.github.com/"
+                    "homepage": "https://ocramius.github.io/"
                 }
             ],
             "description": "A small, lightweight utility to instantiate objects in PHP without invoking their constructors",
@@ -1847,24 +2190,42 @@
                 "constructor",
                 "instantiate"
             ],
-            "time": "2019-10-21T16:45:58+00:00"
+            "support": {
+                "issues": "https://github.com/doctrine/instantiator/issues",
+                "source": "https://github.com/doctrine/instantiator/tree/1.4.0"
+            },
+            "funding": [
+                {
+                    "url": "https://www.doctrine-project.org/sponsorship.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://www.patreon.com/phpdoctrine",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/doctrine%2Finstantiator",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-11-10T18:47:58+00:00"
         },
         {
             "name": "myclabs/deep-copy",
-            "version": "1.9.5",
+            "version": "1.10.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/myclabs/DeepCopy.git",
-                "reference": "b2c28789e80a97badd14145fda39b545d83ca3ef"
+                "reference": "776f831124e9c62e1a2c601ecc52e776d8bb7220"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/b2c28789e80a97badd14145fda39b545d83ca3ef",
-                "reference": "b2c28789e80a97badd14145fda39b545d83ca3ef",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/776f831124e9c62e1a2c601ecc52e776d8bb7220",
+                "reference": "776f831124e9c62e1a2c601ecc52e776d8bb7220",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.1"
+                "php": "^7.1 || ^8.0"
             },
             "replace": {
                 "myclabs/deep-copy": "self.version"
@@ -1895,32 +2256,99 @@
                 "object",
                 "object graph"
             ],
-            "time": "2020-01-17T21:11:47+00:00"
+            "support": {
+                "issues": "https://github.com/myclabs/DeepCopy/issues",
+                "source": "https://github.com/myclabs/DeepCopy/tree/1.10.2"
+            },
+            "funding": [
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/myclabs/deep-copy",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-11-13T09:40:50+00:00"
         },
         {
-            "name": "phar-io/manifest",
-            "version": "1.0.3",
+            "name": "nikic/php-parser",
+            "version": "v4.10.4",
             "source": {
                 "type": "git",
-                "url": "https://github.com/phar-io/manifest.git",
-                "reference": "7761fcacf03b4d4f16e7ccb606d4879ca431fcf4"
+                "url": "https://github.com/nikic/PHP-Parser.git",
+                "reference": "c6d052fc58cb876152f89f532b95a8d7907e7f0e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phar-io/manifest/zipball/7761fcacf03b4d4f16e7ccb606d4879ca431fcf4",
-                "reference": "7761fcacf03b4d4f16e7ccb606d4879ca431fcf4",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/c6d052fc58cb876152f89f532b95a8d7907e7f0e",
+                "reference": "c6d052fc58cb876152f89f532b95a8d7907e7f0e",
+                "shasum": ""
+            },
+            "require": {
+                "ext-tokenizer": "*",
+                "php": ">=7.0"
+            },
+            "require-dev": {
+                "ircmaxell/php-yacc": "^0.0.7",
+                "phpunit/phpunit": "^6.5 || ^7.0 || ^8.0 || ^9.0"
+            },
+            "bin": [
+                "bin/php-parse"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.9-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PhpParser\\": "lib/PhpParser"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Nikita Popov"
+                }
+            ],
+            "description": "A PHP parser written in PHP",
+            "keywords": [
+                "parser",
+                "php"
+            ],
+            "support": {
+                "issues": "https://github.com/nikic/PHP-Parser/issues",
+                "source": "https://github.com/nikic/PHP-Parser/tree/v4.10.4"
+            },
+            "time": "2020-12-20T10:01:03+00:00"
+        },
+        {
+            "name": "phar-io/manifest",
+            "version": "2.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phar-io/manifest.git",
+                "reference": "85265efd3af7ba3ca4b2a2c34dbfc5788dd29133"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phar-io/manifest/zipball/85265efd3af7ba3ca4b2a2c34dbfc5788dd29133",
+                "reference": "85265efd3af7ba3ca4b2a2c34dbfc5788dd29133",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
                 "ext-phar": "*",
-                "phar-io/version": "^2.0",
-                "php": "^5.6 || ^7.0"
+                "ext-xmlwriter": "*",
+                "phar-io/version": "^3.0.1",
+                "php": "^7.2 || ^8.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0.x-dev"
+                    "dev-master": "2.0.x-dev"
                 }
             },
             "autoload": {
@@ -1950,24 +2378,28 @@
                 }
             ],
             "description": "Component for reading phar.io manifest information from a PHP Archive (PHAR)",
-            "time": "2018-07-08T19:23:20+00:00"
+            "support": {
+                "issues": "https://github.com/phar-io/manifest/issues",
+                "source": "https://github.com/phar-io/manifest/tree/master"
+            },
+            "time": "2020-06-27T14:33:11+00:00"
         },
         {
             "name": "phar-io/version",
-            "version": "2.0.1",
+            "version": "3.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phar-io/version.git",
-                "reference": "45a2ec53a73c70ce41d55cedef9063630abaf1b6"
+                "reference": "e4782611070e50613683d2b9a57730e9a3ba5451"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phar-io/version/zipball/45a2ec53a73c70ce41d55cedef9063630abaf1b6",
-                "reference": "45a2ec53a73c70ce41d55cedef9063630abaf1b6",
+                "url": "https://api.github.com/repos/phar-io/version/zipball/e4782611070e50613683d2b9a57730e9a3ba5451",
+                "reference": "e4782611070e50613683d2b9a57730e9a3ba5451",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.6 || ^7.0"
+                "php": "^7.2 || ^8.0"
             },
             "type": "library",
             "autoload": {
@@ -1997,38 +2429,44 @@
                 }
             ],
             "description": "Library for handling version information and constraints",
-            "time": "2018-07-08T19:19:57+00:00"
+            "support": {
+                "issues": "https://github.com/phar-io/version/issues",
+                "source": "https://github.com/phar-io/version/tree/3.0.4"
+            },
+            "time": "2020-12-13T23:18:30+00:00"
         },
         {
             "name": "php-webdriver/webdriver",
-            "version": "1.8.2",
+            "version": "1.9.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-webdriver/php-webdriver.git",
-                "reference": "3308a70be084d6d7fd1ee5787b4c2e6eb4b70aab"
+                "reference": "e3633154554605274cc9d59837f55a7427d72003"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-webdriver/php-webdriver/zipball/3308a70be084d6d7fd1ee5787b4c2e6eb4b70aab",
-                "reference": "3308a70be084d6d7fd1ee5787b4c2e6eb4b70aab",
+                "url": "https://api.github.com/repos/php-webdriver/php-webdriver/zipball/e3633154554605274cc9d59837f55a7427d72003",
+                "reference": "e3633154554605274cc9d59837f55a7427d72003",
                 "shasum": ""
             },
             "require": {
                 "ext-curl": "*",
                 "ext-json": "*",
                 "ext-zip": "*",
-                "php": "^5.6 || ~7.0",
+                "php": "^5.6 || ~7.0 || ^8.0",
                 "symfony/polyfill-mbstring": "^1.12",
                 "symfony/process": "^2.8 || ^3.1 || ^4.0 || ^5.0"
             },
+            "replace": {
+                "facebook/webdriver": "*"
+            },
             "require-dev": {
                 "friendsofphp/php-cs-fixer": "^2.0",
-                "jakub-onderka/php-parallel-lint": "^1.0",
-                "php-coveralls/php-coveralls": "^2.0",
-                "php-mock/php-mock-phpunit": "^1.1",
-                "phpunit/phpunit": "^5.7",
-                "sebastian/environment": "^1.3.4 || ^2.0 || ^3.0",
-                "sminnee/phpunit-mock-objects": "^3.4",
+                "ondram/ci-detector": "^2.1 || ^3.5",
+                "php-coveralls/php-coveralls": "^2.4",
+                "php-mock/php-mock-phpunit": "^1.1 || ^2.0",
+                "php-parallel-lint/php-parallel-lint": "^1.2",
+                "phpunit/phpunit": "^5.7 || ^7 || ^8 || ^9",
                 "squizlabs/php_codesniffer": "^3.5",
                 "symfony/var-dumper": "^3.3 || ^4.0 || ^5.0"
             },
@@ -2038,7 +2476,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.8.x-dev"
+                    "dev-main": "1.8.x-dev"
                 }
             },
             "autoload": {
@@ -2062,7 +2500,11 @@
                 "selenium",
                 "webdriver"
             ],
-            "time": "2020-03-04T14:40:12+00:00"
+            "support": {
+                "issues": "https://github.com/php-webdriver/php-webdriver/issues",
+                "source": "https://github.com/php-webdriver/php-webdriver/tree/1.9.0"
+            },
+            "time": "2020-11-19T15:21:05+00:00"
         },
         {
             "name": "phpdocumentor/reflection-common",
@@ -2111,6 +2553,10 @@
                 "reflection",
                 "static analysis"
             ],
+            "support": {
+                "issues": "https://github.com/phpDocumentor/ReflectionCommon/issues",
+                "source": "https://github.com/phpDocumentor/ReflectionCommon/tree/2.x"
+            },
             "time": "2020-06-27T09:03:43+00:00"
         },
         {
@@ -2163,6 +2609,10 @@
                 }
             ],
             "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
+            "support": {
+                "issues": "https://github.com/phpDocumentor/ReflectionDocBlock/issues",
+                "source": "https://github.com/phpDocumentor/ReflectionDocBlock/tree/master"
+            },
             "time": "2020-09-03T19:13:55+00:00"
         },
         {
@@ -2208,37 +2658,41 @@
                 }
             ],
             "description": "A PSR-5 based resolver of Class names, Types and Structural Element Names",
+            "support": {
+                "issues": "https://github.com/phpDocumentor/TypeResolver/issues",
+                "source": "https://github.com/phpDocumentor/TypeResolver/tree/1.4.0"
+            },
             "time": "2020-09-17T18:55:26+00:00"
         },
         {
             "name": "phpspec/prophecy",
-            "version": "v1.10.3",
+            "version": "1.12.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpspec/prophecy.git",
-                "reference": "451c3cd1418cf640de218914901e51b064abb093"
+                "reference": "245710e971a030f42e08f4912863805570f23d39"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/451c3cd1418cf640de218914901e51b064abb093",
-                "reference": "451c3cd1418cf640de218914901e51b064abb093",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/245710e971a030f42e08f4912863805570f23d39",
+                "reference": "245710e971a030f42e08f4912863805570f23d39",
                 "shasum": ""
             },
             "require": {
-                "doctrine/instantiator": "^1.0.2",
-                "php": "^5.3|^7.0",
-                "phpdocumentor/reflection-docblock": "^2.0|^3.0.2|^4.0|^5.0",
-                "sebastian/comparator": "^1.2.3|^2.0|^3.0|^4.0",
-                "sebastian/recursion-context": "^1.0|^2.0|^3.0|^4.0"
+                "doctrine/instantiator": "^1.2",
+                "php": "^7.2 || ~8.0, <8.1",
+                "phpdocumentor/reflection-docblock": "^5.2",
+                "sebastian/comparator": "^3.0 || ^4.0",
+                "sebastian/recursion-context": "^3.0 || ^4.0"
             },
             "require-dev": {
-                "phpspec/phpspec": "^2.5 || ^3.2",
-                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.5 || ^7.1"
+                "phpspec/phpspec": "^6.0",
+                "phpunit/phpunit": "^8.0 || ^9.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.10.x-dev"
+                    "dev-master": "1.11.x-dev"
                 }
             },
             "autoload": {
@@ -2271,44 +2725,52 @@
                 "spy",
                 "stub"
             ],
-            "time": "2020-03-05T15:02:03+00:00"
+            "support": {
+                "issues": "https://github.com/phpspec/prophecy/issues",
+                "source": "https://github.com/phpspec/prophecy/tree/1.12.2"
+            },
+            "time": "2020-12-19T10:15:11+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "7.0.10",
+            "version": "9.2.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "f1884187926fbb755a9aaf0b3836ad3165b478bf"
+                "reference": "f3e026641cc91909d421802dd3ac7827ebfd97e1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/f1884187926fbb755a9aaf0b3836ad3165b478bf",
-                "reference": "f1884187926fbb755a9aaf0b3836ad3165b478bf",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/f3e026641cc91909d421802dd3ac7827ebfd97e1",
+                "reference": "f3e026641cc91909d421802dd3ac7827ebfd97e1",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
+                "ext-libxml": "*",
                 "ext-xmlwriter": "*",
-                "php": "^7.2",
-                "phpunit/php-file-iterator": "^2.0.2",
-                "phpunit/php-text-template": "^1.2.1",
-                "phpunit/php-token-stream": "^3.1.1",
-                "sebastian/code-unit-reverse-lookup": "^1.0.1",
-                "sebastian/environment": "^4.2.2",
-                "sebastian/version": "^2.0.1",
-                "theseer/tokenizer": "^1.1.3"
+                "nikic/php-parser": "^4.10.2",
+                "php": ">=7.3",
+                "phpunit/php-file-iterator": "^3.0.3",
+                "phpunit/php-text-template": "^2.0.2",
+                "sebastian/code-unit-reverse-lookup": "^2.0.2",
+                "sebastian/complexity": "^2.0",
+                "sebastian/environment": "^5.1.2",
+                "sebastian/lines-of-code": "^1.0.3",
+                "sebastian/version": "^3.0.1",
+                "theseer/tokenizer": "^1.2.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^8.2.2"
+                "phpunit/phpunit": "^9.3"
             },
             "suggest": {
-                "ext-xdebug": "^2.7.2"
+                "ext-pcov": "*",
+                "ext-xdebug": "*"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "7.0-dev"
+                    "dev-master": "9.2-dev"
                 }
             },
             "autoload": {
@@ -2334,32 +2796,42 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2019-11-20T13:55:58+00:00"
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.5"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-11-28T06:44:49+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
-            "version": "2.0.2",
+            "version": "3.0.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
-                "reference": "050bedf145a257b1ff02746c31894800e5122946"
+                "reference": "aa4be8575f26070b100fccb67faabb28f21f66f8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/050bedf145a257b1ff02746c31894800e5122946",
-                "reference": "050bedf145a257b1ff02746c31894800e5122946",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/aa4be8575f26070b100fccb67faabb28f21f66f8",
+                "reference": "aa4be8575f26070b100fccb67faabb28f21f66f8",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.1"
+                "php": ">=7.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^7.1"
+                "phpunit/phpunit": "^9.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0.x-dev"
+                    "dev-master": "3.0-dev"
                 }
             },
             "autoload": {
@@ -2384,26 +2856,107 @@
                 "filesystem",
                 "iterator"
             ],
-            "time": "2018-09-13T20:33:42+00:00"
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-file-iterator/issues",
+                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/3.0.5"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-09-28T05:57:25+00:00"
         },
         {
-            "name": "phpunit/php-text-template",
-            "version": "1.2.1",
+            "name": "phpunit/php-invoker",
+            "version": "3.1.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/sebastianbergmann/php-text-template.git",
-                "reference": "31f8b717e51d9a2afca6c9f046f5d69fc27c8686"
+                "url": "https://github.com/sebastianbergmann/php-invoker.git",
+                "reference": "5a10147d0aaf65b58940a0b72f71c9ac0423cc67"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/31f8b717e51d9a2afca6c9f046f5d69fc27c8686",
-                "reference": "31f8b717e51d9a2afca6c9f046f5d69fc27c8686",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-invoker/zipball/5a10147d0aaf65b58940a0b72f71c9ac0423cc67",
+                "reference": "5a10147d0aaf65b58940a0b72f71c9ac0423cc67",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "ext-pcntl": "*",
+                "phpunit/phpunit": "^9.3"
+            },
+            "suggest": {
+                "ext-pcntl": "*"
             },
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Invoke callables with a timeout",
+            "homepage": "https://github.com/sebastianbergmann/php-invoker/",
+            "keywords": [
+                "process"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-invoker/issues",
+                "source": "https://github.com/sebastianbergmann/php-invoker/tree/3.1.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-09-28T05:58:55+00:00"
+        },
+        {
+            "name": "phpunit/php-text-template",
+            "version": "2.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-text-template.git",
+                "reference": "5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28",
+                "reference": "5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
             "autoload": {
                 "classmap": [
                     "src/"
@@ -2425,32 +2978,42 @@
             "keywords": [
                 "template"
             ],
-            "time": "2015-06-21T13:50:34+00:00"
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-text-template/issues",
+                "source": "https://github.com/sebastianbergmann/php-text-template/tree/2.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T05:33:50+00:00"
         },
         {
             "name": "phpunit/php-timer",
-            "version": "2.1.2",
+            "version": "5.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-timer.git",
-                "reference": "1038454804406b0b5f5f520358e78c1c2f71501e"
+                "reference": "5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/1038454804406b0b5f5f520358e78c1c2f71501e",
-                "reference": "1038454804406b0b5f5f520358e78c1c2f71501e",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2",
+                "reference": "5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.1"
+                "php": ">=7.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^7.0"
+                "phpunit/phpunit": "^9.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.1-dev"
+                    "dev-master": "5.0-dev"
                 }
             },
             "autoload": {
@@ -2474,106 +3037,69 @@
             "keywords": [
                 "timer"
             ],
-            "time": "2019-06-07T04:22:29+00:00"
-        },
-        {
-            "name": "phpunit/php-token-stream",
-            "version": "3.1.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/php-token-stream.git",
-                "reference": "995192df77f63a59e47f025390d2d1fdf8f425ff"
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-timer/issues",
+                "source": "https://github.com/sebastianbergmann/php-timer/tree/5.0.3"
             },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/995192df77f63a59e47f025390d2d1fdf8f425ff",
-                "reference": "995192df77f63a59e47f025390d2d1fdf8f425ff",
-                "shasum": ""
-            },
-            "require": {
-                "ext-tokenizer": "*",
-                "php": "^7.1"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^7.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.1-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
+            "funding": [
                 {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de"
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
                 }
             ],
-            "description": "Wrapper around PHP's tokenizer extension.",
-            "homepage": "https://github.com/sebastianbergmann/php-token-stream/",
-            "keywords": [
-                "tokenizer"
-            ],
-            "abandoned": true,
-            "time": "2019-09-17T06:23:10+00:00"
+            "time": "2020-10-26T13:16:10+00:00"
         },
         {
             "name": "phpunit/phpunit",
-            "version": "8.5.3",
+            "version": "9.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "67750516bc02f300e2742fed2f50177f8f37bedf"
+                "reference": "8e16c225d57c3d6808014df6b1dd7598d0a5bbbe"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/67750516bc02f300e2742fed2f50177f8f37bedf",
-                "reference": "67750516bc02f300e2742fed2f50177f8f37bedf",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/8e16c225d57c3d6808014df6b1dd7598d0a5bbbe",
+                "reference": "8e16c225d57c3d6808014df6b1dd7598d0a5bbbe",
                 "shasum": ""
             },
             "require": {
-                "doctrine/instantiator": "^1.2.0",
+                "doctrine/instantiator": "^1.3.1",
                 "ext-dom": "*",
                 "ext-json": "*",
                 "ext-libxml": "*",
                 "ext-mbstring": "*",
                 "ext-xml": "*",
                 "ext-xmlwriter": "*",
-                "myclabs/deep-copy": "^1.9.1",
-                "phar-io/manifest": "^1.0.3",
-                "phar-io/version": "^2.0.1",
-                "php": "^7.2",
-                "phpspec/prophecy": "^1.8.1",
-                "phpunit/php-code-coverage": "^7.0.7",
-                "phpunit/php-file-iterator": "^2.0.2",
-                "phpunit/php-text-template": "^1.2.1",
-                "phpunit/php-timer": "^2.1.2",
-                "sebastian/comparator": "^3.0.2",
-                "sebastian/diff": "^3.0.2",
-                "sebastian/environment": "^4.2.2",
-                "sebastian/exporter": "^3.1.1",
-                "sebastian/global-state": "^3.0.0",
-                "sebastian/object-enumerator": "^3.0.3",
-                "sebastian/resource-operations": "^2.0.1",
-                "sebastian/type": "^1.1.3",
-                "sebastian/version": "^2.0.1"
+                "myclabs/deep-copy": "^1.10.1",
+                "phar-io/manifest": "^2.0.1",
+                "phar-io/version": "^3.0.2",
+                "php": ">=7.3",
+                "phpspec/prophecy": "^1.12.1",
+                "phpunit/php-code-coverage": "^9.2.3",
+                "phpunit/php-file-iterator": "^3.0.5",
+                "phpunit/php-invoker": "^3.1.1",
+                "phpunit/php-text-template": "^2.0.3",
+                "phpunit/php-timer": "^5.0.2",
+                "sebastian/cli-parser": "^1.0.1",
+                "sebastian/code-unit": "^1.0.6",
+                "sebastian/comparator": "^4.0.5",
+                "sebastian/diff": "^4.0.3",
+                "sebastian/environment": "^5.1.3",
+                "sebastian/exporter": "^4.0.3",
+                "sebastian/global-state": "^5.0.1",
+                "sebastian/object-enumerator": "^4.0.3",
+                "sebastian/resource-operations": "^3.0.3",
+                "sebastian/type": "^2.3",
+                "sebastian/version": "^3.0.2"
             },
             "require-dev": {
-                "ext-pdo": "*"
+                "ext-pdo": "*",
+                "phpspec/prophecy-phpunit": "^2.0.1"
             },
             "suggest": {
                 "ext-soap": "*",
-                "ext-xdebug": "*",
-                "phpunit/php-invoker": "^2.0.0"
+                "ext-xdebug": "*"
             },
             "bin": [
                 "phpunit"
@@ -2581,12 +3107,15 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "8.5-dev"
+                    "dev-master": "9.5-dev"
                 }
             },
             "autoload": {
                 "classmap": [
                     "src/"
+                ],
+                "files": [
+                    "src/Framework/Assert/Functions.php"
                 ]
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -2607,6 +3136,10 @@
                 "testing",
                 "xunit"
             ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/phpunit/issues",
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.5.0"
+            },
             "funding": [
                 {
                     "url": "https://phpunit.de/donate.html",
@@ -2617,32 +3150,144 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-03-31T08:52:04+00:00"
+            "time": "2020-12-04T05:05:53+00:00"
         },
         {
-            "name": "sebastian/code-unit-reverse-lookup",
+            "name": "sebastian/cli-parser",
             "version": "1.0.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/sebastianbergmann/code-unit-reverse-lookup.git",
-                "reference": "4419fcdb5eabb9caa61a27c7a1db532a6b55dd18"
+                "url": "https://github.com/sebastianbergmann/cli-parser.git",
+                "reference": "442e7c7e687e42adc03470c7b668bc4b2402c0b2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/4419fcdb5eabb9caa61a27c7a1db532a6b55dd18",
-                "reference": "4419fcdb5eabb9caa61a27c7a1db532a6b55dd18",
+                "url": "https://api.github.com/repos/sebastianbergmann/cli-parser/zipball/442e7c7e687e42adc03470c7b668bc4b2402c0b2",
+                "reference": "442e7c7e687e42adc03470c7b668bc4b2402c0b2",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.6 || ^7.0"
+                "php": ">=7.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^5.7 || ^6.0"
+                "phpunit/phpunit": "^9.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0.x-dev"
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for parsing CLI options",
+            "homepage": "https://github.com/sebastianbergmann/cli-parser",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/cli-parser/issues",
+                "source": "https://github.com/sebastianbergmann/cli-parser/tree/1.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-09-28T06:08:49+00:00"
+        },
+        {
+            "name": "sebastian/code-unit",
+            "version": "1.0.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/code-unit.git",
+                "reference": "1fc9f64c0927627ef78ba436c9b17d967e68e120"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit/zipball/1fc9f64c0927627ef78ba436c9b17d967e68e120",
+                "reference": "1fc9f64c0927627ef78ba436c9b17d967e68e120",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Collection of value objects that represent the PHP code units",
+            "homepage": "https://github.com/sebastianbergmann/code-unit",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/code-unit/issues",
+                "source": "https://github.com/sebastianbergmann/code-unit/tree/1.0.8"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T13:08:54+00:00"
+        },
+        {
+            "name": "sebastian/code-unit-reverse-lookup",
+            "version": "2.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/code-unit-reverse-lookup.git",
+                "reference": "ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5",
+                "reference": "ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
                 }
             },
             "autoload": {
@@ -2662,34 +3307,44 @@
             ],
             "description": "Looks up which function or method a line of code belongs to",
             "homepage": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/",
-            "time": "2017-03-04T06:30:41+00:00"
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/issues",
+                "source": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/tree/2.0.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-09-28T05:30:19+00:00"
         },
         {
             "name": "sebastian/comparator",
-            "version": "3.0.2",
+            "version": "4.0.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "5de4fc177adf9bce8df98d8d141a7559d7ccf6da"
+                "reference": "55f4261989e546dc112258c7a75935a81a7ce382"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/5de4fc177adf9bce8df98d8d141a7559d7ccf6da",
-                "reference": "5de4fc177adf9bce8df98d8d141a7559d7ccf6da",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/55f4261989e546dc112258c7a75935a81a7ce382",
+                "reference": "55f4261989e546dc112258c7a75935a81a7ce382",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.1",
-                "sebastian/diff": "^3.0",
-                "sebastian/exporter": "^3.1"
+                "php": ">=7.3",
+                "sebastian/diff": "^4.0",
+                "sebastian/exporter": "^4.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^7.1"
+                "phpunit/phpunit": "^9.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.0-dev"
+                    "dev-master": "4.0-dev"
                 }
             },
             "autoload": {
@@ -2702,6 +3357,10 @@
                 "BSD-3-Clause"
             ],
             "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
                 {
                     "name": "Jeff Welch",
                     "email": "whatthejeff@gmail.com"
@@ -2713,10 +3372,6 @@
                 {
                     "name": "Bernhard Schussek",
                     "email": "bschussek@2bepublished.at"
-                },
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de"
                 }
             ],
             "description": "Provides the functionality to compare PHP values for equality",
@@ -2726,33 +3381,43 @@
                 "compare",
                 "equality"
             ],
-            "time": "2018-07-12T15:12:46+00:00"
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/comparator/issues",
+                "source": "https://github.com/sebastianbergmann/comparator/tree/4.0.6"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T15:49:45+00:00"
         },
         {
-            "name": "sebastian/diff",
-            "version": "3.0.2",
+            "name": "sebastian/complexity",
+            "version": "2.0.2",
             "source": {
                 "type": "git",
-                "url": "https://github.com/sebastianbergmann/diff.git",
-                "reference": "720fcc7e9b5cf384ea68d9d930d480907a0c1a29"
+                "url": "https://github.com/sebastianbergmann/complexity.git",
+                "reference": "739b35e53379900cc9ac327b2147867b8b6efd88"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/720fcc7e9b5cf384ea68d9d930d480907a0c1a29",
-                "reference": "720fcc7e9b5cf384ea68d9d930d480907a0c1a29",
+                "url": "https://api.github.com/repos/sebastianbergmann/complexity/zipball/739b35e53379900cc9ac327b2147867b8b6efd88",
+                "reference": "739b35e53379900cc9ac327b2147867b8b6efd88",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.1"
+                "nikic/php-parser": "^4.7",
+                "php": ">=7.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^7.5 || ^8.0",
-                "symfony/process": "^2 || ^3.3 || ^4"
+                "phpunit/phpunit": "^9.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.0-dev"
+                    "dev-master": "2.0-dev"
                 }
             },
             "autoload": {
@@ -2766,12 +3431,69 @@
             ],
             "authors": [
                 {
-                    "name": "Kore Nordmann",
-                    "email": "mail@kore-nordmann.de"
-                },
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for calculating the complexity of PHP code units",
+            "homepage": "https://github.com/sebastianbergmann/complexity",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/complexity/issues",
+                "source": "https://github.com/sebastianbergmann/complexity/tree/2.0.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T15:52:27+00:00"
+        },
+        {
+            "name": "sebastian/diff",
+            "version": "4.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/diff.git",
+                "reference": "3461e3fccc7cfdfc2720be910d3bd73c69be590d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/3461e3fccc7cfdfc2720be910d3bd73c69be590d",
+                "reference": "3461e3fccc7cfdfc2720be910d3bd73c69be590d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3",
+                "symfony/process": "^4.2 || ^5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
                 {
                     "name": "Sebastian Bergmann",
                     "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Kore Nordmann",
+                    "email": "mail@kore-nordmann.de"
                 }
             ],
             "description": "Diff implementation",
@@ -2782,27 +3504,37 @@
                 "unidiff",
                 "unified diff"
             ],
-            "time": "2019-02-04T06:01:07+00:00"
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/diff/issues",
+                "source": "https://github.com/sebastianbergmann/diff/tree/4.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T13:10:38+00:00"
         },
         {
             "name": "sebastian/environment",
-            "version": "4.2.3",
+            "version": "5.1.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/environment.git",
-                "reference": "464c90d7bdf5ad4e8a6aea15c091fec0603d4368"
+                "reference": "388b6ced16caa751030f6a69e588299fa09200ac"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/464c90d7bdf5ad4e8a6aea15c091fec0603d4368",
-                "reference": "464c90d7bdf5ad4e8a6aea15c091fec0603d4368",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/388b6ced16caa751030f6a69e588299fa09200ac",
+                "reference": "388b6ced16caa751030f6a69e588299fa09200ac",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.1"
+                "php": ">=7.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^7.5"
+                "phpunit/phpunit": "^9.3"
             },
             "suggest": {
                 "ext-posix": "*"
@@ -2810,7 +3542,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.2-dev"
+                    "dev-master": "5.1-dev"
                 }
             },
             "autoload": {
@@ -2835,34 +3567,44 @@
                 "environment",
                 "hhvm"
             ],
-            "time": "2019-11-20T08:46:58+00:00"
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/environment/issues",
+                "source": "https://github.com/sebastianbergmann/environment/tree/5.1.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-09-28T05:52:38+00:00"
         },
         {
             "name": "sebastian/exporter",
-            "version": "3.1.2",
+            "version": "4.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/exporter.git",
-                "reference": "68609e1261d215ea5b21b7987539cbfbe156ec3e"
+                "reference": "d89cc98761b8cb5a1a235a6b703ae50d34080e65"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/68609e1261d215ea5b21b7987539cbfbe156ec3e",
-                "reference": "68609e1261d215ea5b21b7987539cbfbe156ec3e",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/d89cc98761b8cb5a1a235a6b703ae50d34080e65",
+                "reference": "d89cc98761b8cb5a1a235a6b703ae50d34080e65",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.0",
-                "sebastian/recursion-context": "^3.0"
+                "php": ">=7.3",
+                "sebastian/recursion-context": "^4.0"
             },
             "require-dev": {
                 "ext-mbstring": "*",
-                "phpunit/phpunit": "^6.0"
+                "phpunit/phpunit": "^9.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.1.x-dev"
+                    "dev-master": "4.0-dev"
                 }
             },
             "autoload": {
@@ -2902,30 +3644,40 @@
                 "export",
                 "exporter"
             ],
-            "time": "2019-09-14T09:02:43+00:00"
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/exporter/issues",
+                "source": "https://github.com/sebastianbergmann/exporter/tree/4.0.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-09-28T05:24:23+00:00"
         },
         {
             "name": "sebastian/global-state",
-            "version": "3.0.0",
+            "version": "5.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/global-state.git",
-                "reference": "edf8a461cf1d4005f19fb0b6b8b95a9f7fa0adc4"
+                "reference": "a90ccbddffa067b51f574dea6eb25d5680839455"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/edf8a461cf1d4005f19fb0b6b8b95a9f7fa0adc4",
-                "reference": "edf8a461cf1d4005f19fb0b6b8b95a9f7fa0adc4",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/a90ccbddffa067b51f574dea6eb25d5680839455",
+                "reference": "a90ccbddffa067b51f574dea6eb25d5680839455",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.2",
-                "sebastian/object-reflector": "^1.1.1",
-                "sebastian/recursion-context": "^3.0"
+                "php": ">=7.3",
+                "sebastian/object-reflector": "^2.0",
+                "sebastian/recursion-context": "^4.0"
             },
             "require-dev": {
                 "ext-dom": "*",
-                "phpunit/phpunit": "^8.0"
+                "phpunit/phpunit": "^9.3"
             },
             "suggest": {
                 "ext-uopz": "*"
@@ -2933,7 +3685,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.0-dev"
+                    "dev-master": "5.0-dev"
                 }
             },
             "autoload": {
@@ -2956,34 +3708,101 @@
             "keywords": [
                 "global state"
             ],
-            "time": "2019-02-01T05:30:01+00:00"
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/global-state/issues",
+                "source": "https://github.com/sebastianbergmann/global-state/tree/5.0.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T15:55:19+00:00"
         },
         {
-            "name": "sebastian/object-enumerator",
-            "version": "3.0.3",
+            "name": "sebastian/lines-of-code",
+            "version": "1.0.3",
             "source": {
                 "type": "git",
-                "url": "https://github.com/sebastianbergmann/object-enumerator.git",
-                "reference": "7cfd9e65d11ffb5af41198476395774d4c8a84c5"
+                "url": "https://github.com/sebastianbergmann/lines-of-code.git",
+                "reference": "c1c2e997aa3146983ed888ad08b15470a2e22ecc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/7cfd9e65d11ffb5af41198476395774d4c8a84c5",
-                "reference": "7cfd9e65d11ffb5af41198476395774d4c8a84c5",
+                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/c1c2e997aa3146983ed888ad08b15470a2e22ecc",
+                "reference": "c1c2e997aa3146983ed888ad08b15470a2e22ecc",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.0",
-                "sebastian/object-reflector": "^1.1.1",
-                "sebastian/recursion-context": "^3.0"
+                "nikic/php-parser": "^4.6",
+                "php": ">=7.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^6.0"
+                "phpunit/phpunit": "^9.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.0.x-dev"
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for counting the lines of code in PHP source code",
+            "homepage": "https://github.com/sebastianbergmann/lines-of-code",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/lines-of-code/issues",
+                "source": "https://github.com/sebastianbergmann/lines-of-code/tree/1.0.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-11-28T06:42:11+00:00"
+        },
+        {
+            "name": "sebastian/object-enumerator",
+            "version": "4.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/object-enumerator.git",
+                "reference": "5c9eeac41b290a3712d88851518825ad78f45c71"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/5c9eeac41b290a3712d88851518825ad78f45c71",
+                "reference": "5c9eeac41b290a3712d88851518825ad78f45c71",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3",
+                "sebastian/object-reflector": "^2.0",
+                "sebastian/recursion-context": "^4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
                 }
             },
             "autoload": {
@@ -3003,122 +3822,37 @@
             ],
             "description": "Traverses array structures and object graphs to enumerate all referenced objects",
             "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
-            "time": "2017-08-03T12:35:26+00:00"
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/object-enumerator/issues",
+                "source": "https://github.com/sebastianbergmann/object-enumerator/tree/4.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T13:12:34+00:00"
         },
         {
             "name": "sebastian/object-reflector",
-            "version": "1.1.1",
+            "version": "2.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/object-reflector.git",
-                "reference": "773f97c67f28de00d397be301821b06708fca0be"
+                "reference": "b4f479ebdbf63ac605d183ece17d8d7fe49c15c7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/773f97c67f28de00d397be301821b06708fca0be",
-                "reference": "773f97c67f28de00d397be301821b06708fca0be",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/b4f479ebdbf63ac605d183ece17d8d7fe49c15c7",
+                "reference": "b4f479ebdbf63ac605d183ece17d8d7fe49c15c7",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.0"
+                "php": ">=7.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^6.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.1-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de"
-                }
-            ],
-            "description": "Allows reflection of object attributes, including inherited and non-public ones",
-            "homepage": "https://github.com/sebastianbergmann/object-reflector/",
-            "time": "2017-03-29T09:07:27+00:00"
-        },
-        {
-            "name": "sebastian/recursion-context",
-            "version": "3.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/recursion-context.git",
-                "reference": "5b0cd723502bac3b006cbf3dbf7a1e3fcefe4fa8"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/5b0cd723502bac3b006cbf3dbf7a1e3fcefe4fa8",
-                "reference": "5b0cd723502bac3b006cbf3dbf7a1e3fcefe4fa8",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^6.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.0.x-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Jeff Welch",
-                    "email": "whatthejeff@gmail.com"
-                },
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de"
-                },
-                {
-                    "name": "Adam Harvey",
-                    "email": "aharvey@php.net"
-                }
-            ],
-            "description": "Provides functionality to recursively process PHP variables",
-            "homepage": "http://www.github.com/sebastianbergmann/recursion-context",
-            "time": "2017-03-03T06:23:57+00:00"
-        },
-        {
-            "name": "sebastian/resource-operations",
-            "version": "2.0.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/resource-operations.git",
-                "reference": "4d7a795d35b889bf80a0cc04e08d77cedfa917a9"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/4d7a795d35b889bf80a0cc04e08d77cedfa917a9",
-                "reference": "4d7a795d35b889bf80a0cc04e08d77cedfa917a9",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.1"
+                "phpunit/phpunit": "^9.3"
             },
             "type": "library",
             "extra": {
@@ -3141,34 +3875,162 @@
                     "email": "sebastian@phpunit.de"
                 }
             ],
-            "description": "Provides a list of PHP built-in functions that operate on resources",
-            "homepage": "https://www.github.com/sebastianbergmann/resource-operations",
-            "time": "2018-10-04T04:07:39+00:00"
+            "description": "Allows reflection of object attributes, including inherited and non-public ones",
+            "homepage": "https://github.com/sebastianbergmann/object-reflector/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/object-reflector/issues",
+                "source": "https://github.com/sebastianbergmann/object-reflector/tree/2.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T13:14:26+00:00"
         },
         {
-            "name": "sebastian/type",
-            "version": "1.1.3",
+            "name": "sebastian/recursion-context",
+            "version": "4.0.4",
             "source": {
                 "type": "git",
-                "url": "https://github.com/sebastianbergmann/type.git",
-                "reference": "3aaaa15fa71d27650d62a948be022fe3b48541a3"
+                "url": "https://github.com/sebastianbergmann/recursion-context.git",
+                "reference": "cd9d8cf3c5804de4341c283ed787f099f5506172"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/3aaaa15fa71d27650d62a948be022fe3b48541a3",
-                "reference": "3aaaa15fa71d27650d62a948be022fe3b48541a3",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/cd9d8cf3c5804de4341c283ed787f099f5506172",
+                "reference": "cd9d8cf3c5804de4341c283ed787f099f5506172",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.2"
+                "php": ">=7.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^8.2"
+                "phpunit/phpunit": "^9.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.1-dev"
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Adam Harvey",
+                    "email": "aharvey@php.net"
+                }
+            ],
+            "description": "Provides functionality to recursively process PHP variables",
+            "homepage": "http://www.github.com/sebastianbergmann/recursion-context",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/recursion-context/issues",
+                "source": "https://github.com/sebastianbergmann/recursion-context/tree/4.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T13:17:30+00:00"
+        },
+        {
+            "name": "sebastian/resource-operations",
+            "version": "3.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/resource-operations.git",
+                "reference": "0f4443cb3a1d92ce809899753bc0d5d5a8dd19a8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/0f4443cb3a1d92ce809899753bc0d5d5a8dd19a8",
+                "reference": "0f4443cb3a1d92ce809899753bc0d5d5a8dd19a8",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Provides a list of PHP built-in functions that operate on resources",
+            "homepage": "https://www.github.com/sebastianbergmann/resource-operations",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/resource-operations/issues",
+                "source": "https://github.com/sebastianbergmann/resource-operations/tree/3.0.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-09-28T06:45:17+00:00"
+        },
+        {
+            "name": "sebastian/type",
+            "version": "2.3.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/type.git",
+                "reference": "81cd61ab7bbf2de744aba0ea61fae32f721df3d2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/81cd61ab7bbf2de744aba0ea61fae32f721df3d2",
+                "reference": "81cd61ab7bbf2de744aba0ea61fae32f721df3d2",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.3-dev"
                 }
             },
             "autoload": {
@@ -3189,29 +4051,39 @@
             ],
             "description": "Collection of value objects that represent the types of the PHP type system",
             "homepage": "https://github.com/sebastianbergmann/type",
-            "time": "2019-07-02T08:10:15+00:00"
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/type/issues",
+                "source": "https://github.com/sebastianbergmann/type/tree/2.3.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T13:18:59+00:00"
         },
         {
             "name": "sebastian/version",
-            "version": "2.0.1",
+            "version": "3.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/version.git",
-                "reference": "99732be0ddb3361e16ad77b68ba41efc8e979019"
+                "reference": "c6c1022351a901512170118436c764e473f6de8c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/99732be0ddb3361e16ad77b68ba41efc8e979019",
-                "reference": "99732be0ddb3361e16ad77b68ba41efc8e979019",
+                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/c6c1022351a901512170118436c764e473f6de8c",
+                "reference": "c6c1022351a901512170118436c764e473f6de8c",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.6"
+                "php": ">=7.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0.x-dev"
+                    "dev-master": "3.0-dev"
                 }
             },
             "autoload": {
@@ -3232,27 +4104,37 @@
             ],
             "description": "Library that helps with managing the version number of Git-hosted PHP projects",
             "homepage": "https://github.com/sebastianbergmann/version",
-            "time": "2016-10-03T07:35:21+00:00"
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/version/issues",
+                "source": "https://github.com/sebastianbergmann/version/tree/3.0.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-09-28T06:39:44+00:00"
         },
         {
             "name": "theseer/tokenizer",
-            "version": "1.1.3",
+            "version": "1.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/theseer/tokenizer.git",
-                "reference": "11336f6f84e16a720dae9d8e6ed5019efa85a0f9"
+                "reference": "75a63c33a8577608444246075ea0af0d052e452a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/11336f6f84e16a720dae9d8e6ed5019efa85a0f9",
-                "reference": "11336f6f84e16a720dae9d8e6ed5019efa85a0f9",
+                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/75a63c33a8577608444246075ea0af0d052e452a",
+                "reference": "75a63c33a8577608444246075ea0af0d052e452a",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
                 "ext-tokenizer": "*",
                 "ext-xmlwriter": "*",
-                "php": "^7.0"
+                "php": "^7.2 || ^8.0"
             },
             "type": "library",
             "autoload": {
@@ -3272,7 +4154,17 @@
                 }
             ],
             "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
-            "time": "2019-06-13T22:48:21+00:00"
+            "support": {
+                "issues": "https://github.com/theseer/tokenizer/issues",
+                "source": "https://github.com/theseer/tokenizer/tree/master"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/theseer",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-07-12T23:59:07+00:00"
         },
         {
             "name": "webmozart/assert",
@@ -3321,6 +4213,10 @@
                 "check",
                 "validate"
             ],
+            "support": {
+                "issues": "https://github.com/webmozart/assert/issues",
+                "source": "https://github.com/webmozart/assert/tree/master"
+            },
             "time": "2020-07-08T17:02:28+00:00"
         }
     ],
@@ -3330,7 +4226,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=7.2"
+        "php": "^7.2|^8.0"
     },
     "platform-dev": [],
     "plugin-api-version": "2.0.0"

--- a/lib/Controller/PublicViewController.php
+++ b/lib/Controller/PublicViewController.php
@@ -122,7 +122,7 @@ class PublicViewController extends Controller {
 		$defaultSlotDuration = $this->config->getAppValue($this->appName, 'slotDuration', '00:30:00');
 		$defaultShowTasks = $this->config->getAppValue($this->appName, 'showTasks', 'yes');
 
-		$appVersion = $this->config->getAppValue($this->appName, 'installed_version');
+		$appVersion = $this->config->getAppValue($this->appName, 'installed_version', null);
 
 		$this->initialStateService->provideInitialState($this->appName, 'app_version', $appVersion);
 		$this->initialStateService->provideInitialState($this->appName, 'event_limit', ($defaultEventLimit === 'yes'));

--- a/lib/Controller/ViewController.php
+++ b/lib/Controller/ViewController.php
@@ -96,7 +96,7 @@ class ViewController extends Controller {
 		$defaultSlotDuration = $this->config->getAppValue($this->appName, 'slotDuration', '00:30:00');
 		$defaultShowTasks = $this->config->getAppValue($this->appName, 'showTasks', 'yes');
 
-		$appVersion = $this->config->getAppValue($this->appName, 'installed_version');
+		$appVersion = $this->config->getAppValue($this->appName, 'installed_version', null);
 		$eventLimit = $this->config->getUserValue($this->userId, $this->appName, 'eventLimit', $defaultEventLimit) === 'yes';
 		$firstRun = $this->config->getUserValue($this->userId, $this->appName, 'firstRun', 'yes') === 'yes';
 		$initialView = $this->getView($this->config->getUserValue($this->userId, $this->appName, 'currentView', $defaultInitialView));

--- a/phpunit.unit.xml
+++ b/phpunit.unit.xml
@@ -1,28 +1,17 @@
-<?xml version="1.0" encoding="utf-8" ?>
-<phpunit bootstrap="tests/php/unit/bootstrap.php"
+<?xml version="1.0" encoding="utf-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         bootstrap="tests/php/unit/bootstrap.php"
          verbose="true"
-         timeoutForSmallTests="900"
-         timeoutForMediumTests="900"
-         timeoutForLargeTests="900"
->
-    <testsuite name='Calendar app tests'>
-        <directory suffix='test.php'>./tests/php/unit</directory>
-        <directory suffix='Test.php'>./tests/php/unit</directory>
-    </testsuite>
-    <!-- filters for code coverage -->
-    <filter>
-        <whitelist>
-            <directory suffix=".php">./</directory>
-            <exclude>
-                <directory suffix=".php">./appinfo</directory>
-                <directory suffix=".php">./l10n</directory>
-                <directory suffix=".php">./templates</directory>
-                <directory suffix=".php">./tests</directory>
-            </exclude>
-        </whitelist>
-    </filter>
-    <logging>
-        <!-- and this is where your report will be written -->
-        <log type="coverage-clover" target="./clover.unit.xml"/>
-    </logging>
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/8.5/phpunit.xsd">
+  <testsuite name="unit">
+    <directory suffix="Test.php">./tests/php/unit</directory>
+  </testsuite>
+  <coverage>
+    <include>
+      <directory suffix=".php">./lib</directory>
+    </include>
+    <report>
+      <clover outputFile="./clover.unit.xml"/>
+    </report>
+  </coverage>
 </phpunit>

--- a/tests/php/unit/Controller/ContactControllerTest.php
+++ b/tests/php/unit/Controller/ContactControllerTest.php
@@ -27,16 +27,17 @@ use OCP\AppFramework\Http\JSONResponse;
 use OCP\Contacts\IManager;
 use OCP\IRequest;
 use ChristophWurst\Nextcloud\Testing\TestCase;
+use PHPUnit\Framework\MockObject\MockObject;
 
 class ContactControllerTest extends TestCase {
 
 	/** @var string */
 	protected $appName;
 
-	/** @var IRequest|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var IRequest|MockObject */
 	protected $request;
 
-	/** @var IManager|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var IManager|MockObject */
 	protected $manager;
 
 	/** @var ContactController */
@@ -69,12 +70,12 @@ class ContactControllerTest extends TestCase {
 	}
 
 	public function testSearchLocation():void {
-		$this->manager->expects($this->at(0))
+		$this->manager->expects(self::once())
 			->method('isEnabled')
 			->with()
 			->willReturn(true);
 
-		$this->manager->expects($this->at(1))
+		$this->manager->expects(self::once())
 			->method('search')
 			->with('search 123', ['FN', 'ADR'])
 			->willReturn([
@@ -161,12 +162,12 @@ class ContactControllerTest extends TestCase {
 	}
 
 	public function testSearchAttendee():void {
-		$this->manager->expects($this->at(0))
+		$this->manager->expects(self::once())
 			->method('isEnabled')
 			->with()
 			->willReturn(true);
 
-		$this->manager->expects($this->at(1))
+		$this->manager->expects(self::once())
 			->method('search')
 			->with('search 123', ['FN', 'EMAIL'])
 			->willReturn([
@@ -257,12 +258,12 @@ class ContactControllerTest extends TestCase {
 	}
 
 	public function testSearchPhoto():void {
-		$this->manager->expects($this->at(0))
+		$this->manager->expects(self::once())
 			->method('isEnabled')
 			->with()
 			->willReturn(true);
 
-		$this->manager->expects($this->at(1))
+		$this->manager->expects(self::once())
 			->method('search')
 			->with('foo3@example.com', ['EMAIL'])
 			->willReturn([

--- a/tests/php/unit/Controller/EmailControllerTest.php
+++ b/tests/php/unit/Controller/EmailControllerTest.php
@@ -35,34 +35,35 @@ use OCP\Mail\IEMailTemplate;
 use OCP\Mail\IMailer;
 use OCP\Mail\IMessage;
 use ChristophWurst\Nextcloud\Testing\TestCase;
+use PHPUnit\Framework\MockObject\MockObject;
 
 class EmailControllerTest extends TestCase {
 
 	/** @var string */
 	private $appName;
 
-	/** @var IRequest|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var IRequest|MockObject */
 	private $request;
 
-	/** @var IConfig|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var IConfig|MockObject */
 	private $config;
 
-	/** @var Defaults|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var Defaults|MockObject */
 	private $defaults;
 
-	/** @var IL10N|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var IL10N|MockObject */
 	private $l10n;
 
-	/** @var IMailer|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var IMailer|MockObject */
 	private $mailer;
 
-	/** @var IUserSession|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var IUserSession|MockObject */
 	private $userSession;
 
-	/** @var IURLGenerator|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var IURLGenerator|MockObject */
 	private $urlGenerator;
 
-	/** @var IUser|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var IUser|MockObject */
 	private $user;
 
 	/** @var EmailController */
@@ -96,7 +97,7 @@ class EmailControllerTest extends TestCase {
 	}
 
 	public function testSendUserSessionExpired():void {
-		$this->userSession->expects($this->at(0))
+		$this->userSession->expects(self::once(0))
 			->method('getUser')
 			->with()
 			->willReturn(null);
@@ -116,12 +117,12 @@ class EmailControllerTest extends TestCase {
 	}
 
 	public function testSendInvalidEmailAddress():void {
-		$this->userSession->expects($this->at(0))
+		$this->userSession->expects(self::once())
 			->method('getUser')
 			->with()
 			->willReturn($this->user);
 
-		$this->mailer->expects($this->at(0))
+		$this->mailer->expects(self::once())
 			->method('validateMailAddress')
 			->with('foo@bar.com')
 			->willReturn(false);
@@ -139,31 +140,28 @@ class EmailControllerTest extends TestCase {
 	}
 
 	public function testSendWithMailerError() {
-		$this->userSession->expects($this->at(0))
+		$this->userSession->expects(self::once())
 			->method('getUser')
-			->with()
 			->willReturn($this->user);
 
-		$this->mailer->expects($this->at(0))
+		$this->mailer->expects(self::once())
 			->method('validateMailAddress')
 			->with('foo@bar.com')
 			->willReturn(true);
 
-		$this->config->expects($this->at(0))
+		$this->config->expects(self::exactly(2))
 			->method('getSystemValue')
-			->with('mail_domain', 'domain.org')
-			->willReturn('testdomain.org');
-		$this->config->expects($this->at(1))
-			->method('getSystemValue')
-			->with('mail_from_address', 'nextcloud')
-			->willReturn('nextcloud123');
+			->willReturnMap([
+				['mail_domain', 'domain.org', 'testdomain.org'],
+				['mail_from_address', 'nextcloud', 'nextcloud123'],
+			]);
 
-		$this->defaults->expects($this->at(0))
+		$this->defaults->expects(self::once())
 			->method('getName')
 			->with()
 			->willReturn('Example Cloud Inc.');
 
-		$this->urlGenerator->expects($this->at(0))
+		$this->urlGenerator->expects(self::once())
 			->method('linkToRouteAbsolute')
 			->with('calendar.publicView.public_index_with_branding', [
 				'token' => 'token123'
@@ -171,54 +169,50 @@ class EmailControllerTest extends TestCase {
 			->willReturn('http://publicURL123');
 
 		$template = $this->createMock(IEMailTemplate::class);
-		$template->expects($this->at(0))
+		$template->expects(self::once())
 			->method('setSubject')
 			->with('TRANSLATED: User Displayname 123 has published the calendar »calendar name 456«')
 			->willReturn($template);
-		$template->expects($this->at(1))
+		$template->expects(self::once())
 			->method('addHeader')
 			->with()
 			->willReturn($template);
-		$template->expects($this->at(2))
+		$template->expects(self::once())
 			->method('addHeading')
 			->with('TRANSLATED: User Displayname 123 has published the calendar »calendar name 456«')
 			->willReturn($template);
-		$template->expects($this->at(3))
+		$template->expects(self::exactly(3))
 			->method('addBodyText')
-			->with('TRANSLATED: Hello,')
-			->willReturn($template);
-		$template->expects($this->at(4))
-			->method('addBodyText')
-			->with('TRANSLATED: We wanted to inform you that User Displayname 123 has published the calendar »calendar name 456«.')
-			->willReturn($template);
-		$template->expects($this->at(5))
+			->withConsecutive(
+				['TRANSLATED: Hello,'],
+				['TRANSLATED: We wanted to inform you that User Displayname 123 has published the calendar »calendar name 456«.'],
+				['TRANSLATED: Cheers!']
+			)
+			->willReturnSelf();
+		$template->expects(self::once())
 			->method('addBodyButton')
 			->with('TRANSLATED: Open »calendar name 456«', 'http://publicURL123')
-			->willReturn($template);
-		$template->expects($this->at(6))
-			->method('addBodyText')
-			->with('TRANSLATED: Cheers!')
-			->willReturn($template);
-		$template->expects($this->at(7))
+			->willReturnSelf();
+		$template->expects(self::once())
 			->method('addFooter')
 			->with()
-			->willReturn($template);
+			->willReturnSelf();
 
 		$message = $this->createMock(IMessage::class);
-		$message->expects($this->at(0))
+		$message->expects(self::once())
 			->method('setFrom')
 			->with(['nextcloud123@testdomain.org' => 'Example Cloud Inc.'])
 			->willReturn($message);
-		$message->expects($this->at(1))
+		$message->expects(self::once())
 			->method('setTo')
 			->with(['foo@bar.com' => 'foo@bar.com'])
 			->willReturn($message);
-		$message->expects($this->at(2))
+		$message->expects(self::once())
 			->method('useTemplate')
 			->with($template)
 			->willReturn($message);
 
-		$this->mailer->expects($this->at(1))
+		$this->mailer->expects(self::once())
 			->method('createEMailTemplate')
 			->with('calendar.PublicShareNotification', [
 				'displayname' => 'User Displayname 123',
@@ -226,11 +220,11 @@ class EmailControllerTest extends TestCase {
 				'calendar_url' => 'http://publicURL123',
 			])
 			->willReturn($template);
-		$this->mailer->expects($this->at(2))
+		$this->mailer->expects(self::once())
 			->method('createMessage')
 			->with()
 			->willReturn($message);
-		$this->mailer->expects($this->at(3))
+		$this->mailer->expects(self::once())
 			->method('send')
 			->with($message)
 			->willThrowException(new \Exception('123'));
@@ -245,31 +239,29 @@ class EmailControllerTest extends TestCase {
 	}
 
 	public function testSendMailerSuccess() {
-		$this->userSession->expects($this->at(0))
+		$this->userSession->expects(self::once())
 			->method('getUser')
 			->with()
 			->willReturn($this->user);
 
-		$this->mailer->expects($this->at(0))
+		$this->mailer->expects(self::once())
 			->method('validateMailAddress')
 			->with('foo@bar.com')
 			->willReturn(true);
 
-		$this->config->expects($this->at(0))
+		$this->config->expects(self::exactly(2))
 			->method('getSystemValue')
-			->with('mail_domain', 'domain.org')
-			->willReturn('testdomain.org');
-		$this->config->expects($this->at(1))
-			->method('getSystemValue')
-			->with('mail_from_address', 'nextcloud')
-			->willReturn('nextcloud123');
+			->willReturnMap([
+				['mail_domain', 'domain.org', 'testdomain.org'],
+				['mail_from_address', 'nextcloud', 'nextcloud123'],
+			]);
 
-		$this->defaults->expects($this->at(0))
+		$this->defaults->expects(self::once())
 			->method('getName')
 			->with()
 			->willReturn('Example Cloud Inc.');
 
-		$this->urlGenerator->expects($this->at(0))
+		$this->urlGenerator->expects(self::once())
 			->method('linkToRouteAbsolute')
 			->with('calendar.publicView.public_index_with_branding', [
 				'token' => 'token123'
@@ -277,54 +269,50 @@ class EmailControllerTest extends TestCase {
 			->willReturn('http://publicURL123');
 
 		$template = $this->createMock(IEMailTemplate::class);
-		$template->expects($this->at(0))
+		$template->expects(self::once())
 			->method('setSubject')
 			->with('TRANSLATED: User Displayname 123 has published the calendar »calendar name 456«')
 			->willReturn($template);
-		$template->expects($this->at(1))
+		$template->expects(self::once())
 			->method('addHeader')
 			->with()
 			->willReturn($template);
-		$template->expects($this->at(2))
+		$template->expects(self::once())
 			->method('addHeading')
 			->with('TRANSLATED: User Displayname 123 has published the calendar »calendar name 456«')
 			->willReturn($template);
-		$template->expects($this->at(3))
+		$template->expects(self::exactly(3))
 			->method('addBodyText')
-			->with('TRANSLATED: Hello,')
-			->willReturn($template);
-		$template->expects($this->at(4))
-			->method('addBodyText')
-			->with('TRANSLATED: We wanted to inform you that User Displayname 123 has published the calendar »calendar name 456«.')
-			->willReturn($template);
-		$template->expects($this->at(5))
+			->withConsecutive(
+				['TRANSLATED: Hello,'],
+				['TRANSLATED: We wanted to inform you that User Displayname 123 has published the calendar »calendar name 456«.'],
+				['TRANSLATED: Cheers!']
+			)
+			->willReturnSelf();
+		$template->expects(self::once())
 			->method('addBodyButton')
 			->with('TRANSLATED: Open »calendar name 456«', 'http://publicURL123')
 			->willReturn($template);
-		$template->expects($this->at(6))
-			->method('addBodyText')
-			->with('TRANSLATED: Cheers!')
-			->willReturn($template);
-		$template->expects($this->at(7))
+		$template->expects(self::once())
 			->method('addFooter')
 			->with()
 			->willReturn($template);
 
 		$message = $this->createMock(IMessage::class);
-		$message->expects($this->at(0))
+		$message->expects(self::once())
 			->method('setFrom')
 			->with(['nextcloud123@testdomain.org' => 'Example Cloud Inc.'])
 			->willReturn($message);
-		$message->expects($this->at(1))
+		$message->expects(self::once())
 			->method('setTo')
 			->with(['foo@bar.com' => 'foo@bar.com'])
 			->willReturn($message);
-		$message->expects($this->at(2))
+		$message->expects(self::once())
 			->method('useTemplate')
 			->with($template)
 			->willReturn($message);
 
-		$this->mailer->expects($this->at(1))
+		$this->mailer->expects(self::once())
 			->method('createEMailTemplate')
 			->with('calendar.PublicShareNotification', [
 				'displayname' => 'User Displayname 123',
@@ -332,11 +320,11 @@ class EmailControllerTest extends TestCase {
 				'calendar_url' => 'http://publicURL123',
 			])
 			->willReturn($template);
-		$this->mailer->expects($this->at(2))
+		$this->mailer->expects(self::once())
 			->method('createMessage')
 			->with()
 			->willReturn($message);
-		$this->mailer->expects($this->at(3))
+		$this->mailer->expects(self::once())
 			->method('send')
 			->with($message);
 

--- a/tests/php/unit/Controller/PublicViewControllerTest.php
+++ b/tests/php/unit/Controller/PublicViewControllerTest.php
@@ -29,22 +29,23 @@ use OCP\IInitialStateService;
 use OCP\IRequest;
 use OCP\IURLGenerator;
 use ChristophWurst\Nextcloud\Testing\TestCase;
+use PHPUnit\Framework\MockObject\MockObject;
 
 class PublicViewControllerTest extends TestCase {
 
 	/** @var string */
 	private $appName;
 
-	/** @var IRequest|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var IRequest|MockObject */
 	private $request;
 
-	/** @var IConfig|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var IConfig|MockObject */
 	private $config;
 
-	/** @var IInitialStateService|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var IInitialStateService|MockObject */
 	private $initialStateService;
 
-	/** @var IURLGenerator|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var IURLGenerator|MockObject */
 	private $urlGenerator;
 
 	/** @var ViewController */
@@ -62,101 +63,58 @@ class PublicViewControllerTest extends TestCase {
 	}
 
 	public function testPublicIndexWithBranding():void {
-		$this->config->expects($this->at(0))
+		$this->config->expects(self::exactly(9))
 			->method('getAppValue')
-			->with('calendar', 'eventLimit', 'yes')
-			->willReturn('no');
-		$this->config->expects($this->at(1))
-			->method('getAppValue')
-			->with('calendar', 'currentView', 'dayGridMonth')
-			->willReturn('defaultCurrentView');
-		$this->config->expects($this->at(2))
-			->method('getAppValue')
-			->with('calendar', 'showWeekends', 'yes')
-			->willReturn('no');
-		$this->config->expects($this->at(3))
-			->method('getAppValue')
-			->with('calendar', 'showWeekNr', 'no')
-			->willReturn('yes');
-		$this->config->expects($this->at(4))
-			->method('getAppValue')
-			->with('calendar', 'skipPopover', 'yes')
-			->willReturn('yes');
-		$this->config->expects($this->at(5))
-			->method('getAppValue')
-			->with('calendar', 'timezone', 'automatic')
-			->willReturn('defaultTimezone');
-		$this->config->expects($this->at(6))
-			->method('getAppValue')
-			->with('calendar', 'slotDuration', '00:30:00')
-			->willReturn('defaultSlotDuration');
-		$this->config->expects($this->at(7))
-			->method('getAppValue')
-			->with('calendar', 'showTasks')
-			->willReturn('yes');
-		$this->config->expects($this->at(8))
-			->method('getAppValue')
-			->with('calendar', 'installed_version')
-			->willReturn('1.0.0');
+			->willReturnMap([
+				['calendar', 'eventLimit', 'yes', 'no'],
+				['calendar', 'currentView', 'dayGridMonth', 'defaultCurrentView'],
+				['calendar', 'showWeekends', 'yes', 'no'],
+				['calendar', 'showWeekNr', 'no', 'yes'],
+				['calendar', 'skipPopover', 'yes', 'yes'],
+				['calendar', 'timezone', 'automatic', 'defaultTimezone'],
+				['calendar', 'slotDuration', '00:30:00', 'defaultSlotDuration'],
+				['calendar', 'showTasks', 'yes', 'yes'],
+				['calendar', 'installed_version', null, '1.0.0']
+			]);
 
-		$this->request->expects($this->at(0))
+		$this->request->expects(self::once())
 			->method('getServerProtocol')
 			->with()
 			->willReturn('protocol');
-		$this->request->expects($this->at(1))
+		$this->request->expects(self::once())
 			->method('getServerHost')
 			->with()
 			->willReturn('host123');
-		$this->request->expects($this->at(2))
+		$this->request->expects(self::once())
 			->method('getRequestUri')
 			->with()
 			->willReturn('/456');
 
-		$this->urlGenerator->expects($this->at(0))
+		$this->urlGenerator->expects(self::once())
 			->method('imagePath')
 			->with('core', 'favicon-touch.png')
 			->willReturn('imagePath456');
-		$this->urlGenerator->expects($this->at(1))
+		$this->urlGenerator->expects(self::once())
 			->method('getAbsoluteURL')
 			->with('imagePath456')
 			->willReturn('absoluteImagePath456');
 
-		$this->initialStateService->expects($this->at(0))
+		$this->initialStateService->expects(self::exactly(12))
 			->method('provideInitialState')
-			->with('calendar', 'app_version', '1.0.0');
-		$this->initialStateService->expects($this->at(1))
-			->method('provideInitialState')
-			->with('calendar', 'event_limit', false);
-		$this->initialStateService->expects($this->at(2))
-			->method('provideInitialState')
-			->with('calendar', 'first_run', false);
-		$this->initialStateService->expects($this->at(3))
-			->method('provideInitialState')
-			->with('calendar', 'initial_view', 'defaultCurrentView');
-		$this->initialStateService->expects($this->at(4))
-			->method('provideInitialState')
-			->with('calendar', 'show_weekends', false);
-		$this->initialStateService->expects($this->at(5))
-			->method('provideInitialState')
-			->with('calendar', 'show_week_numbers', true);
-		$this->initialStateService->expects($this->at(6))
-			->method('provideInitialState')
-			->with('calendar', 'skip_popover', true);
-		$this->initialStateService->expects($this->at(7))
-			->method('provideInitialState')
-			->with('calendar', 'talk_enabled', false);
-		$this->initialStateService->expects($this->at(8))
-			->method('provideInitialState')
-			->with('calendar', 'timezone', 'defaultTimezone');
-		$this->initialStateService->expects($this->at(9))
-			->method('provideInitialState')
-			->with('calendar', 'slot_duration', 'defaultSlotDuration');
-		$this->initialStateService->expects($this->at(10))
-			->method('provideInitialState')
-			->with('calendar', 'show_tasks', true);
-		$this->initialStateService->expects($this->at(11))
-			->method('provideInitialState')
-			->with('calendar', 'tasks_enabled', false);
+			->withConsecutive(
+				['calendar', 'app_version', '1.0.0'],
+				['calendar', 'event_limit', false],
+				['calendar', 'first_run', false],
+				['calendar', 'initial_view', 'defaultCurrentView'],
+				['calendar', 'show_weekends', false],
+				['calendar', 'show_week_numbers', true],
+				['calendar', 'skip_popover', true],
+				['calendar', 'talk_enabled', false],
+				['calendar', 'timezone', 'defaultTimezone'],
+				['calendar', 'slot_duration', 'defaultSlotDuration'],
+				['calendar', 'show_tasks', true],
+				['calendar', 'tasks_enabled', false]
+			);
 
 		$response = $this->controller->publicIndexWithBranding('');
 
@@ -170,101 +128,57 @@ class PublicViewControllerTest extends TestCase {
 	}
 
 	public function testPublicIndexForEmbedding():void {
-		$this->config->expects($this->at(0))
+		$this->config->expects(self::any())
 			->method('getAppValue')
-			->with('calendar', 'eventLimit', 'yes')
-			->willReturn('yes');
-		$this->config->expects($this->at(1))
-			->method('getAppValue')
-			->with('calendar', 'currentView', 'dayGridMonth')
-			->willReturn('defaultCurrentView');
-		$this->config->expects($this->at(2))
-			->method('getAppValue')
-			->with('calendar', 'showWeekends', 'yes')
-			->willReturn('no');
-		$this->config->expects($this->at(3))
-			->method('getAppValue')
-			->with('calendar', 'showWeekNr', 'no')
-			->willReturn('yes');
-		$this->config->expects($this->at(4))
-			->method('getAppValue')
-			->with('calendar', 'skipPopover', 'yes')
-			->willReturn('yes');
-		$this->config->expects($this->at(5))
-			->method('getAppValue')
-			->with('calendar', 'timezone', 'automatic')
-			->willReturn('defaultTimezone');
-		$this->config->expects($this->at(6))
-			->method('getAppValue')
-			->with('calendar', 'slotDuration', '00:30:00')
-			->willReturn('defaultSlotDuration');
-		$this->config->expects($this->at(7))
-			->method('getAppValue')
-			->with('calendar', 'showTasks', 'yes')
-			->willReturn('defaultShowTasks');
-		$this->config->expects($this->at(8))
-			->method('getAppValue')
-			->with('calendar', 'installed_version')
-			->willReturn('1.0.0');
-
-		$this->request->expects($this->at(0))
+			->willReturnMap([
+				['calendar', 'eventLimit', 'yes', 'yes'],
+				['calendar', 'currentView', 'dayGridMonth', 'defaultCurrentView'],
+				['calendar', 'showWeekends', 'yes', 'no'],
+				['calendar', 'showWeekNr', 'no', 'yes'],
+				['calendar', 'skipPopover', 'yes', 'yes'],
+				['calendar', 'timezone', 'automatic', 'defaultTimezone'],
+				['calendar', 'slotDuration', '00:30:00', 'defaultSlotDuration'],
+				['calendar', 'showTasks', 'yes', 'defaultShowTasks'],
+				['calendar', 'installed_version', null, '1.0.0']
+			]);
+		$this->request->expects(self::once())
 			->method('getServerProtocol')
 			->with()
 			->willReturn('protocol');
-		$this->request->expects($this->at(1))
+		$this->request->expects(self::once())
 			->method('getServerHost')
 			->with()
 			->willReturn('host123');
-		$this->request->expects($this->at(2))
+		$this->request->expects(self::once())
 			->method('getRequestUri')
 			->with()
 			->willReturn('/456');
 
-		$this->urlGenerator->expects($this->at(0))
+		$this->urlGenerator->expects(self::once())
 			->method('imagePath')
 			->with('core', 'favicon-touch.png')
 			->willReturn('imagePath456');
-		$this->urlGenerator->expects($this->at(1))
+		$this->urlGenerator->expects(self::once())
 			->method('getAbsoluteURL')
 			->with('imagePath456')
 			->willReturn('absoluteImagePath456');
 
-		$this->initialStateService->expects($this->at(0))
+		$this->initialStateService->expects(self::exactly(12))
 			->method('provideInitialState')
-			->with('calendar', 'app_version', '1.0.0');
-		$this->initialStateService->expects($this->at(1))
-			->method('provideInitialState')
-			->with('calendar', 'event_limit', true);
-		$this->initialStateService->expects($this->at(2))
-			->method('provideInitialState')
-			->with('calendar', 'first_run', false);
-		$this->initialStateService->expects($this->at(3))
-			->method('provideInitialState')
-			->with('calendar', 'initial_view', 'defaultCurrentView');
-		$this->initialStateService->expects($this->at(4))
-			->method('provideInitialState')
-			->with('calendar', 'show_weekends', false);
-		$this->initialStateService->expects($this->at(5))
-			->method('provideInitialState')
-			->with('calendar', 'show_week_numbers', true);
-		$this->initialStateService->expects($this->at(6))
-			->method('provideInitialState')
-			->with('calendar', 'skip_popover', true);
-		$this->initialStateService->expects($this->at(7))
-			->method('provideInitialState')
-			->with('calendar', 'talk_enabled', false);
-		$this->initialStateService->expects($this->at(8))
-			->method('provideInitialState')
-			->with('calendar', 'timezone', 'defaultTimezone');
-		$this->initialStateService->expects($this->at(9))
-			->method('provideInitialState')
-			->with('calendar', 'slot_duration', 'defaultSlotDuration');
-		$this->initialStateService->expects($this->at(10))
-			->method('provideInitialState')
-			->with('calendar', 'show_tasks', false);
-		$this->initialStateService->expects($this->at(11))
-			->method('provideInitialState')
-			->with('calendar', 'tasks_enabled', false);
+			->withConsecutive(
+				['calendar', 'app_version', '1.0.0'],
+				['calendar', 'event_limit', true],
+				['calendar', 'first_run', false],
+				['calendar', 'initial_view', 'defaultCurrentView'],
+				['calendar', 'show_weekends', false],
+				['calendar', 'show_week_numbers', true],
+				['calendar', 'skip_popover', true],
+				['calendar', 'talk_enabled', false],
+				['calendar', 'timezone', 'defaultTimezone'],
+				['calendar', 'slot_duration', 'defaultSlotDuration'],
+				['calendar', 'show_tasks', false],
+				['calendar', 'tasks_enabled', false]
+			);
 
 		$response = $this->controller->publicIndexForEmbedding('');
 

--- a/tests/php/unit/Controller/SettingsControllerTest.php
+++ b/tests/php/unit/Controller/SettingsControllerTest.php
@@ -26,16 +26,17 @@ namespace OCA\Calendar\Controller;
 use OCP\IConfig;
 use OCP\IRequest;
 use ChristophWurst\Nextcloud\Testing\TestCase;
+use PHPUnit\Framework\MockObject\MockObject;
 
 class SettingsControllerTest extends TestCase {
 
 	/** @var string */
 	private $appName;
 
-	/** @var IRequest|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var IRequest|MockObject */
 	private $request;
 
-	/** @var IConfig|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var IConfig|MockObject */
 	private $config;
 
 	/** @var string */

--- a/tests/php/unit/Controller/ViewControllerTest.php
+++ b/tests/php/unit/Controller/ViewControllerTest.php
@@ -21,6 +21,7 @@ declare(strict_types=1);
  * License along with this library.  If not, see <http://www.gnu.org/licenses/>.
  *
  */
+
 namespace OCA\Calendar\Controller;
 
 use OCP\App\IAppManager;
@@ -29,22 +30,23 @@ use OCP\IConfig;
 use OCP\IInitialStateService;
 use OCP\IRequest;
 use ChristophWurst\Nextcloud\Testing\TestCase;
+use PHPUnit\Framework\MockObject\MockObject;
 
 class ViewControllerTest extends TestCase {
 
 	/** @var string */
 	private $appName;
 
-	/** @var IRequest|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var IRequest|MockObject */
 	private $request;
 
-	/** @var IAppManager|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var IAppManager|MockObject */
 	private $appManager;
 
-	/** @var IConfig|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var IConfig|MockObject */
 	private $config;
 
-	/** @var IInitialStateService|\PHPUnit_Framework_MockObject_MockObject */
+	/** @var IInitialStateService|MockObject */
 	private $initialStateService;
 
 	/** @var string */
@@ -53,7 +55,7 @@ class ViewControllerTest extends TestCase {
 	/** @var ViewController */
 	private $controller;
 
-	protected function setUp():void {
+	protected function setUp(): void {
 		$this->appName = 'calendar';
 		$this->request = $this->createMock(IRequest::class);
 		$this->appManager = $this->createMock(IAppManager::class);
@@ -65,124 +67,56 @@ class ViewControllerTest extends TestCase {
 			$this->config, $this->initialStateService, $this->appManager, $this->userId);
 	}
 
-	public function testIndex():void {
-		$this->config->expects($this->at(0))
+	public function testIndex(): void {
+		$this->config
 			->method('getAppValue')
-			->with('calendar', 'eventLimit', 'yes')
-			->willReturn('defaultEventLimit');
-		$this->config->expects($this->at(1))
-			->method('getAppValue')
-			->with('calendar', 'currentView', 'dayGridMonth')
-			->willReturn('defaultCurrentView');
-		$this->config->expects($this->at(2))
-			->method('getAppValue')
-			->with('calendar', 'showWeekends', 'yes')
-			->willReturn('defaultShowWeekends');
-		$this->config->expects($this->at(3))
-			->method('getAppValue')
-			->with('calendar', 'showWeekNr', 'no')
-			->willReturn('defaultShowWeekNr');
-		$this->config->expects($this->at(4))
-			->method('getAppValue')
-			->with('calendar', 'skipPopover', 'no')
-			->willReturn('defaultSkipPopover');
-		$this->config->expects($this->at(5))
-			->method('getAppValue')
-			->with('calendar', 'timezone', 'automatic')
-			->willReturn('defaultTimezone');
-		$this->config->expects($this->at(6))
-			->method('getAppValue')
-			->with('calendar', 'slotDuration', '00:30:00')
-			->willReturn('defaultSlotDuration');
-		$this->config->expects($this->at(7))
-			->method('getAppValue')
-			->with('calendar', 'showTasks', 'yes')
-			->willReturn('defaultShowTasks');
-		$this->config->expects($this->at(8))
-			->method('getAppValue')
-			->with('calendar', 'installed_version')
-			->willReturn('1.0.0');
-		$this->config->expects($this->at(9))
+			->willReturnMap([
+				['calendar', 'eventLimit', 'yes', 'defaultEventLimit'],
+				['calendar', 'currentView', 'dayGridMonth', 'defaultCurrentView'],
+				['calendar', 'showWeekends', 'yes', 'defaultShowWeekends'],
+				['calendar', 'showWeekNr', 'no', 'defaultShowWeekNr'],
+				['calendar', 'skipPopover', 'no', 'defaultSkipPopover'],
+				['calendar', 'timezone', 'automatic', 'defaultTimezone'],
+				['calendar', 'slotDuration', '00:30:00', 'defaultSlotDuration'],
+				['calendar', 'showTasks', 'yes', 'defaultShowTasks'],
+				['calendar', 'installed_version', null, '1.0.0'],
+			]);
+		$this->config
 			->method('getUserValue')
-			->with('user123', 'calendar', 'eventLimit', 'defaultEventLimit')
-			->willReturn('yes');
-		$this->config->expects($this->at(10))
-			->method('getUserValue')
-			->with('user123', 'calendar', 'firstRun', 'yes')
-			->willReturn('yes');
-		$this->config->expects($this->at(11))
-			->method('getUserValue')
-			->with('user123', 'calendar', 'currentView', 'defaultCurrentView')
-			->willReturn('timeGridWeek');
-		$this->config->expects($this->at(12))
-			->method('getUserValue')
-			->with('user123', 'calendar', 'showWeekends', 'defaultShowWeekends')
-			->willReturn('yes');
-		$this->config->expects($this->at(13))
-			->method('getUserValue')
-			->with('user123', 'calendar', 'showWeekNr', 'defaultShowWeekNr')
-			->willReturn('yes');
-		$this->config->expects($this->at(14))
-			->method('getUserValue')
-			->with('user123', 'calendar', 'skipPopover', 'defaultSkipPopover')
-			->willReturn('yes');
-		$this->config->expects($this->at(15))
-			->method('getUserValue')
-			->with('user123', 'calendar', 'timezone', 'defaultTimezone')
-			->willReturn('Europe/Berlin');
-		$this->config->expects($this->at(16))
-			->method('getUserValue')
-			->with('user123', 'calendar', 'slotDuration', 'defaultSlotDuration')
-			->willReturn('00:15:00');
-		$this->config->expects($this->at(17))
-			->method('getUserValue')
-			->with('user123', 'calendar', 'showTasks', 'defaultShowTasks')
-			->willReturn('00:15:00');
-		$this->appManager->expects($this->at(0))
+			->willReturnMap([
+				['user123', 'calendar', 'eventLimit', 'defaultEventLimit', 'yes'],
+				['user123', 'calendar', 'firstRun', 'yes', 'yes'],
+				['user123', 'calendar', 'currentView', 'defaultCurrentView', 'timeGridWeek'],
+				['user123', 'calendar', 'showWeekends', 'defaultShowWeekends', 'yes'],
+				['user123', 'calendar', 'showWeekNr', 'defaultShowWeekNr', 'yes'],
+				['user123', 'calendar', 'skipPopover', 'defaultSkipPopover', 'yes'],
+				['user123', 'calendar', 'timezone', 'defaultTimezone', 'Europe/Berlin'],
+				['user123', 'calendar', 'slotDuration', 'defaultSlotDuration', '00:15:00'],
+				['user123', 'calendar', 'showTasks', 'defaultShowTasks', '00:15:00'],
+			]);
+		$this->appManager
 			->method('isEnabledForUser')
-			->with('spreed')
-			->willReturn(true);
-		$this->appManager->expects($this->at(1))
-			->method('isEnabledForUser')
-			->with('tasks')
-			->willReturn(true);
+			->willReturnMap([
+				['spreed', null, true],
+				['tasks', null, true]
+			]);
 
-		$this->initialStateService->expects($this->at(0))
+		$this->initialStateService
 			->method('provideInitialState')
-			->with('calendar', 'app_version', '1.0.0');
-		$this->initialStateService->expects($this->at(1))
-			->method('provideInitialState')
-			->with('calendar', 'event_limit', true);
-		$this->initialStateService->expects($this->at(2))
-			->method('provideInitialState')
-			->with('calendar', 'first_run', true);
-		$this->initialStateService->expects($this->at(3))
-			->method('provideInitialState')
-			->with('calendar', 'initial_view', 'timeGridWeek');
-		$this->initialStateService->expects($this->at(4))
-			->method('provideInitialState')
-			->with('calendar', 'show_weekends', true);
-		$this->initialStateService->expects($this->at(5))
-			->method('provideInitialState')
-			->with('calendar', 'show_week_numbers', true);
-		$this->initialStateService->expects($this->at(6))
-			->method('provideInitialState')
-			->with('calendar', 'skip_popover', true);
-		$this->initialStateService->expects($this->at(7))
-			->method('provideInitialState')
-			->with('calendar', 'talk_enabled', true);
-		$this->initialStateService->expects($this->at(8))
-			->method('provideInitialState')
-			->with('calendar', 'timezone', 'Europe/Berlin');
-		$this->initialStateService->expects($this->at(9))
-			->method('provideInitialState')
-			->with('calendar', 'slot_duration', '00:15:00');
-		$this->initialStateService->expects($this->at(10))
-			->method('provideInitialState')
-			->with('calendar', 'show_tasks', false);
-		$this->initialStateService->expects($this->at(11))
-			->method('provideInitialState')
-			->with('calendar', 'tasks_enabled', true);
+			->withConsecutive(
+				['calendar', 'app_version', '1.0.0'],
+				['calendar', 'event_limit', true],
+				['calendar', 'first_run', true],
+				['calendar', 'initial_view', 'timeGridWeek'],
+				['calendar', 'show_weekends', true],
+				['calendar', 'show_week_numbers', true],
+				['calendar', 'skip_popover', true],
+				['calendar', 'talk_enabled', true],
+				['calendar', 'timezone', 'Europe/Berlin'],
+				['calendar', 'slot_duration', '00:15:00'],
+				['calendar', 'show_tasks', false],
+				['calendar', 'tasks_enabled', true]
+			);
 
 		$response = $this->controller->index();
 
@@ -198,124 +132,56 @@ class ViewControllerTest extends TestCase {
 	 * @param string $savedView
 	 * @param string $expectedView
 	 */
-	public function testIndexViewFix(string $savedView, string $expectedView):void {
-		$this->config->expects($this->at(0))
+	public function testIndexViewFix(string $savedView, string $expectedView): void {
+		$this->config
 			->method('getAppValue')
-			->with('calendar', 'eventLimit', 'yes')
-			->willReturn('defaultEventLimit');
-		$this->config->expects($this->at(1))
-			->method('getAppValue')
-			->with('calendar', 'currentView', 'dayGridMonth')
-			->willReturn('defaultCurrentView');
-		$this->config->expects($this->at(2))
-			->method('getAppValue')
-			->with('calendar', 'showWeekends', 'yes')
-			->willReturn('defaultShowWeekends');
-		$this->config->expects($this->at(3))
-			->method('getAppValue')
-			->with('calendar', 'showWeekNr', 'no')
-			->willReturn('defaultShowWeekNr');
-		$this->config->expects($this->at(4))
-			->method('getAppValue')
-			->with('calendar', 'skipPopover', 'no')
-			->willReturn('defaultSkipPopover');
-		$this->config->expects($this->at(5))
-			->method('getAppValue')
-			->with('calendar', 'timezone', 'automatic')
-			->willReturn('defaultTimezone');
-		$this->config->expects($this->at(6))
-			->method('getAppValue')
-			->with('calendar', 'slotDuration', '00:30:00')
-			->willReturn('defaultSlotDuration');
-		$this->config->expects($this->at(7))
-			->method('getAppValue')
-			->with('calendar', 'showTasks', 'yes')
-			->willReturn('defaultShowTasks');
-		$this->config->expects($this->at(8))
-			->method('getAppValue')
-			->with('calendar', 'installed_version')
-			->willReturn('1.0.0');
-		$this->config->expects($this->at(9))
+			->willReturnMap([
+				['calendar', 'eventLimit', 'yes', 'defaultEventLimit'],
+				['calendar', 'currentView', 'dayGridMonth', 'defaultCurrentView'],
+				['calendar', 'showWeekends', 'yes', 'defaultShowWeekends'],
+				['calendar', 'showWeekNr', 'no', 'defaultShowWeekNr'],
+				['calendar', 'skipPopover', 'no', 'defaultSkipPopover'],
+				['calendar', 'timezone', 'automatic', 'defaultTimezone'],
+				['calendar', 'slotDuration', '00:30:00', 'defaultSlotDuration'],
+				['calendar', 'showTasks', 'yes', 'defaultShowTasks'],
+				['calendar', 'installed_version', null, '1.0.0'],
+			]);
+		$this->config
 			->method('getUserValue')
-			->with('user123', 'calendar', 'eventLimit', 'defaultEventLimit')
-			->willReturn('yes');
-		$this->config->expects($this->at(10))
-			->method('getUserValue')
-			->with('user123', 'calendar', 'firstRun', 'yes')
-			->willReturn('yes');
-		$this->config->expects($this->at(11))
-			->method('getUserValue')
-			->with('user123', 'calendar', 'currentView', 'defaultCurrentView')
-			->willReturn($savedView);
-		$this->config->expects($this->at(12))
-			->method('getUserValue')
-			->with('user123', 'calendar', 'showWeekends', 'defaultShowWeekends')
-			->willReturn('yes');
-		$this->config->expects($this->at(13))
-			->method('getUserValue')
-			->with('user123', 'calendar', 'showWeekNr', 'defaultShowWeekNr')
-			->willReturn('yes');
-		$this->config->expects($this->at(14))
-			->method('getUserValue')
-			->with('user123', 'calendar', 'skipPopover', 'defaultSkipPopover')
-			->willReturn('yes');
-		$this->config->expects($this->at(15))
-			->method('getUserValue')
-			->with('user123', 'calendar', 'timezone', 'defaultTimezone')
-			->willReturn('Europe/Berlin');
-		$this->config->expects($this->at(16))
-			->method('getUserValue')
-			->with('user123', 'calendar', 'slotDuration', 'defaultSlotDuration')
-			->willReturn('00:15:00');
-		$this->config->expects($this->at(17))
-			->method('getUserValue')
-			->with('user123', 'calendar', 'showTasks', 'defaultShowTasks')
-			->willReturn('00:15:00');
-		$this->appManager->expects($this->at(0))
+			->willReturnMap([
+				['user123', 'calendar', 'eventLimit', 'defaultEventLimit', 'yes'],
+				['user123', 'calendar', 'firstRun', 'yes', 'yes'],
+				['user123', 'calendar', 'currentView', 'defaultCurrentView', $savedView],
+				['user123', 'calendar', 'showWeekends', 'defaultShowWeekends', 'yes'],
+				['user123', 'calendar', 'showWeekNr', 'defaultShowWeekNr', 'yes'],
+				['user123', 'calendar', 'skipPopover', 'defaultSkipPopover', 'yes'],
+				['user123', 'calendar', 'timezone', 'defaultTimezone', 'Europe/Berlin'],
+				['user123', 'calendar', 'slotDuration', 'defaultSlotDuration', '00:15:00'],
+				['user123', 'calendar', 'showTasks', 'defaultShowTasks', '00:15:00'],
+			]);
+		$this->appManager
 			->method('isEnabledForUser')
-			->with('spreed')
-			->willReturn(true);
-		$this->appManager->expects($this->at(1))
-			->method('isEnabledForUser')
-			->with('tasks')
-			->willReturn(false);
+			->willReturnMap([
+				['spreed', null, true],
+				['tasks', null, false]
+			]);
 
-		$this->initialStateService->expects($this->at(0))
+		$this->initialStateService
 			->method('provideInitialState')
-			->with('calendar', 'app_version', '1.0.0');
-		$this->initialStateService->expects($this->at(1))
-			->method('provideInitialState')
-			->with('calendar', 'event_limit', true);
-		$this->initialStateService->expects($this->at(2))
-			->method('provideInitialState')
-			->with('calendar', 'first_run', true);
-		$this->initialStateService->expects($this->at(3))
-			->method('provideInitialState')
-			->with('calendar', 'initial_view', $expectedView);
-		$this->initialStateService->expects($this->at(4))
-			->method('provideInitialState')
-			->with('calendar', 'show_weekends', true);
-		$this->initialStateService->expects($this->at(5))
-			->method('provideInitialState')
-			->with('calendar', 'show_week_numbers', true);
-		$this->initialStateService->expects($this->at(6))
-			->method('provideInitialState')
-			->with('calendar', 'skip_popover', true);
-		$this->initialStateService->expects($this->at(7))
-			->method('provideInitialState')
-			->with('calendar', 'talk_enabled', true);
-		$this->initialStateService->expects($this->at(8))
-			->method('provideInitialState')
-			->with('calendar', 'timezone', 'Europe/Berlin');
-		$this->initialStateService->expects($this->at(9))
-			->method('provideInitialState')
-			->with('calendar', 'slot_duration', '00:15:00');
-		$this->initialStateService->expects($this->at(10))
-			->method('provideInitialState')
-			->with('calendar', 'show_tasks', false);
-		$this->initialStateService->expects($this->at(11))
-			->method('provideInitialState')
-			->with('calendar', 'tasks_enabled', false);
+			->withConsecutive(
+				['calendar', 'app_version', '1.0.0'],
+				['calendar', 'event_limit', true],
+				['calendar', 'first_run', true],
+				['calendar', 'initial_view', $expectedView],
+				['calendar', 'show_weekends', true],
+				['calendar', 'show_week_numbers', true],
+				['calendar', 'skip_popover', true],
+				['calendar', 'talk_enabled', true],
+				['calendar', 'timezone', 'Europe/Berlin'],
+				['calendar', 'slot_duration', '00:15:00'],
+				['calendar', 'show_tasks', false],
+				['calendar', 'tasks_enabled', false]
+			);
 
 		$response = $this->controller->index();
 

--- a/tests/php/unit/RepairSteps/CurrentViewNameRepairStepTest.php
+++ b/tests/php/unit/RepairSteps/CurrentViewNameRepairStepTest.php
@@ -94,57 +94,26 @@ class CurrentViewNameRepairStepTest extends TestCase {
 				return true;
 			}));
 
-		$this->config->expects($this->at(0))
+		$this->config
 			->method('getUserValue')
-			->with('user1', 'calendar', 'currentView', null)
-			->willReturn('agendaDay');
-		$this->config->expects($this->at(1))
+			->willReturnMap([
+				['user1', 'calendar', 'currentView', null, 'agendaDay'],
+				['user2', 'calendar', 'currentView', null, 'agendaWeek'],
+				['user3', 'calendar', 'currentView', null, 'month'],
+				['user4', 'calendar', 'currentView', null, 'otherView'],
+				['user5', 'calendar', 'currentView', null, null],
+				['user7', 'calendar', 'currentView', null, 'timeGridWeek'],
+			]);
+		$this->config
 			->method('setUserValue')
-			->with('user1', 'calendar', 'currentView', 'timeGridDay');
-
-		$this->config->expects($this->at(2))
-			->method('getUserValue')
-			->with('user2', 'calendar', 'currentView', null)
-			->willReturn('agendaWeek');
-		$this->config->expects($this->at(3))
-			->method('setUserValue')
-			->with('user2', 'calendar', 'currentView', 'timeGridWeek');
-
-		$this->config->expects($this->at(4))
-			->method('getUserValue')
-			->with('user3', 'calendar', 'currentView', null)
-			->willReturn('month');
-		$this->config->expects($this->at(5))
-			->method('setUserValue')
-			->with('user3', 'calendar', 'currentView', 'dayGridMonth');
-
-		$this->config->expects($this->at(6))
-			->method('getUserValue')
-			->with('user4', 'calendar', 'currentView', null)
-			->willReturn('otherView');
-		$this->config->expects($this->at(7))
-			->method('setUserValue')
-			->with('user4', 'calendar', 'currentView', 'dayGridMonth');
-
-		$this->config->expects($this->at(8))
-			->method('getUserValue')
-			->with('user5', 'calendar', 'currentView', null)
-			->willReturn(null);
-
-		$this->config->expects($this->at(9))
-			->method('getUserValue')
-			->with('user6', 'calendar', 'currentView', null)
-			->willReturn('timeGridDay');
-
-		$this->config->expects($this->at(10))
-			->method('getUserValue')
-			->with('user7', 'calendar', 'currentView', null)
-			->willReturn('timeGridWeek');
-
-		$this->config->expects($this->at(11))
-			->method('getUserValue')
-			->with('user8', 'calendar', 'currentView', null)
-			->willReturn('dayGridMonth');
+			->withConsecutive(
+				['user1', 'calendar', 'currentView', 'timeGridDay'],
+				['user2', 'calendar', 'currentView', 'timeGridWeek'],
+				['user3', 'calendar', 'currentView', 'dayGridMonth'],
+				['user4', 'calendar', 'currentView', 'dayGridMonth'],
+				['user6', 'calendar', 'currentView', null],
+				['user8', 'calendar', 'currentView', null, 'dayGridMonth']
+			);
 
 		$output = $this->createMock(IOutput::class);
 		$output->expects($this->never())

--- a/tests/php/unit/Service/JsDataServiceTest.php
+++ b/tests/php/unit/Service/JsDataServiceTest.php
@@ -27,13 +27,14 @@ use ChristophWurst\Nextcloud\Testing\TestCase;
 use OCP\IConfig;
 use OCP\IUser;
 use OCP\IUserSession;
+use PHPUnit\Framework\MockObject\MockObject;
 
 class JsDataServiceTest extends TestCase {
 
-	/** @var IConfig|\PHPUnit\Framework\MockObject\MockObject */
+	/** @var IConfig|MockObject */
 	private $config;
 
-	/** @var IUserSession|\PHPUnit\Framework\MockObject\MockObject */
+	/** @var IUserSession|MockObject */
 	private $userSession;
 
 	/** @var JSDataService */
@@ -55,22 +56,18 @@ class JsDataServiceTest extends TestCase {
 			->method('getUser')
 			->willReturn($user);
 
-		$this->config->expects($this->at(0))
+		$this->config
 			->method('getAppValue')
-			->with('calendar', 'timezone', 'automatic')
-			->willReturn('default-app-value-timezone');
-		$this->config->expects($this->at(1))
-			->method('getAppValue')
-			->with('calendar', 'showTasks', 'yes')
-			->willReturn('default-app-value-showTasks');
-		$this->config->expects($this->at(2))
+			->willReturnMap([
+				['calendar', 'timezone', 'automatic', 'default-app-value-timezone'],
+				['calendar', 'showTasks', 'yes', 'default-app-value-showTasks']
+			]);
+		$this->config
 			->method('getUserValue')
-			->with('john.doe', 'calendar', 'timezone', 'default-app-value-timezone')
-			->willReturn('timezone-config-value');
-		$this->config->expects($this->at(3))
-			->method('getUserValue')
-			->with('john.doe', 'calendar', 'showTasks', 'default-app-value-showTasks')
-			->willReturn('yes');
+			->willReturnMap([
+				['john.doe', 'calendar', 'timezone', 'default-app-value-timezone', 'timezone-config-value'],
+				['john.doe', 'calendar', 'showTasks', 'default-app-value-showTasks', 'yes']
+			]);
 
 		$this->assertEquals([
 			'timezone' => 'timezone-config-value',


### PR DESCRIPTION
* Drops `christophwurst/nextcloud` as that is only required for static analysis, which there is none here at the moment
* Updates phpunit to the lastest available version (through `christophwurst/nextcloud_testing` and adjust the test code for this, mainly the deprecated `$this->at(...)` usage that throws warnings now
* Downgrades phpunit dynamically for php7.2 as the latest phpunit support php8 but not 7.2, there is no release that supports 7.2-8.0 unfortunately
* Does a weird move on `nextcloud/3rdparty`: the php-parser conflicts with the one from phpunit, hence for the stable20 tests we update that package there. This is super ugly, but I don't know any other way to resolve that. Phpunit throws errors otherwise. AFAIK the php-parser is not really used in Nextcloud except for unit tests in server, so that update should not have any negative influence and the result of Calendar tests
* Migrate the phpunti config for the latest phpunit. Starting with 9.0 they have a new XML format. Unfortunately that isn't compatible with the older phpunit for 7.2, hence I now exclude stable20 for coverage. But there really shouldn't be any difference because we care about coverage in *Calendar* and not anything outside it.