### PR TITLE
Do not override the php version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,9 +1,4 @@
 {
-    "config": {
-        "platform": {
-            "php": "7.2"
-        }
-    },
     "require": {
         "php": ">=7.2",
         "nextcloud/coding-standard": "^0.3.0"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e8b3324adafdb726d8ff8a0027682b03",
+    "content-hash": "b7fa996863194d22aa03016634893cb2",
     "packages": [
         {
             "name": "composer/semver",
@@ -3277,8 +3277,5 @@
         "php": ">=7.2"
     },
     "platform-dev": [],
-    "platform-overrides": {
-        "php": "7.2"
-    },
     "plugin-api-version": "2.0.0"
 }


### PR DESCRIPTION
I noticed in https://github.com/nextcloud/calendar/pull/2805 that this will blindly install pre-php8 libraries that are otherwise not compatible and thus cause trouble later on. CI already checks against all supported versions of php, there is no need to overwrite this.