### PR TITLE
Change String#replaceAll with String#replace and the g switch

### DIFF
--- a/src/fullcalendar/localization/localeProvider.js
+++ b/src/fullcalendar/localization/localeProvider.js
@@ -33,7 +33,7 @@ import {
  */
 const getFullCalendarLocale = (userLocale, momentLocale) => {
 	return {
-		code: userLocale.replaceAll('_', '-').toLowerCase(),
+		code: userLocale.replace(/_/g, '-').toLowerCase(),
 		week: {
 			dow: getFirstDayOfWeekFromMomentLocale(momentLocale),
 			doy: getFirstDayOfYearFromMomentLocale(momentLocale),


### PR DESCRIPTION
Fixes compatibility up to at least Firefox 60 (well, at least loading the initial screen).

Closes #2757 (and probably a lot of similar issues).