### PR TITLE
Search DAV for principal as display name OR email

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4970,7 +4970,7 @@
 			"dev": true
 		},
 		"cdav-library": {
-			"version": "github:nextcloud/cdav-library#9260de57f978774ba3db515f5a17aa28be543a56",
+			"version": "github:nextcloud/cdav-library#0e508a5a9bdfd36197d562abfd0423c7bfbb3cb0",
 			"from": "github:nextcloud/cdav-library",
 			"requires": {
 				"core-js": "^3.6.5",
@@ -7561,7 +7561,8 @@
 		"fsevents": {
 			"version": "2.3.1",
 			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.1.tgz",
-			"integrity": "sha512-YR47Eg4hChJGAB1O3yEAOkGO+rlzutoICGqGo9EZ4lKWokzZRSyIW1QmTzqjtw8MJdj9srP869CuWw/hyzSiBw=="
+			"integrity": "sha512-YR47Eg4hChJGAB1O3yEAOkGO+rlzutoICGqGo9EZ4lKWokzZRSyIW1QmTzqjtw8MJdj9srP869CuWw/hyzSiBw==",
+			"optional": true
 		},
 		"function-bind": {
 			"version": "1.1.1",

--- a/src/components/AppNavigation/CalendarList/CalendarListItemSharingSearch.vue
+++ b/src/components/AppNavigation/CalendarList/CalendarListItemSharingSearch.vue
@@ -45,7 +45,7 @@
 
 <script>
 import Multiselect from '@nextcloud/vue/dist/Components/Multiselect'
-import { findPrincipalsByDisplayName } from '../../../services/caldavService.js'
+import { principalPropertySearchByDisplaynameOrEmail } from '../../../services/caldavService.js'
 import HttpClient from '@nextcloud/axios'
 import debounce from 'debounce'
 import { generateOcsUrl } from '@nextcloud/router'
@@ -140,7 +140,7 @@ export default {
 		async findShareesFromDav(query, hiddenPrincipals, hiddenUrls) {
 			let results
 			try {
-				results = await findPrincipalsByDisplayName(query)
+				results = await principalPropertySearchByDisplaynameOrEmail(query)
 			} catch (error) {
 				return []
 			}

--- a/src/components/Editor/Invitees/InviteesListSearch.vue
+++ b/src/components/Editor/Invitees/InviteesListSearch.vue
@@ -81,7 +81,7 @@
 <script>
 import Avatar from '@nextcloud/vue/dist/Components/Avatar'
 import Multiselect from '@nextcloud/vue/dist/Components/Multiselect'
-import { findPrincipalsByDisplayName } from '../../../services/caldavService.js'
+import { principalPropertySearchByDisplaynameOrEmail } from '../../../services/caldavService.js'
 import HttpClient from '@nextcloud/axios'
 import debounce from 'debounce'
 import { linkTo } from '@nextcloud/router'
@@ -209,7 +209,7 @@ export default {
 		async findAttendeesFromDAV(query) {
 			let results
 			try {
-				results = await findPrincipalsByDisplayName(query)
+				results = await principalPropertySearchByDisplaynameOrEmail(query)
 			} catch (error) {
 				console.debug(error)
 				return []

--- a/src/services/caldavService.js
+++ b/src/services/caldavService.js
@@ -198,11 +198,11 @@ const getCurrentUserPrincipal = () => {
 /**
  * Finds calendar principals by displayname
  *
- * @param {String} query The search-term
+ * @param {String} term The search-term
  * @returns {Promise<void>}
  */
-const findPrincipalsByDisplayName = async(query) => {
-	return getClient().principalPropertySearchByDisplayname(query)
+const principalPropertySearchByDisplaynameOrEmail = async(term) => {
+	return getClient().principalPropertySearchByDisplaynameOrEmail(term)
 }
 
 /**
@@ -227,6 +227,6 @@ export {
 	enableBirthdayCalendar,
 	getBirthdayCalendar,
 	getCurrentUserPrincipal,
-	findPrincipalsByDisplayName,
+	principalPropertySearchByDisplaynameOrEmail,
 	findPrincipalByUrl,
 }


### PR DESCRIPTION
- [x] Requires https://github.com/nextcloud/cdav-library/pull/399

This allows searching for exact matches of email addresses when sharee enumeration is off. Otherwise the server will always filter out the entries where the display name is not identical to the search string.

So to test you create a system user with an email address, disable sharee enumeration and try to share a calendar with that user. On master you won't get a result, here you will.