### PR TITLE
Show the name of the day in the free/busy view

### DIFF
--- a/src/components/Editor/FreeBusy/FreeBusy.vue
+++ b/src/components/Editor/FreeBusy/FreeBusy.vue
@@ -215,6 +215,15 @@ export default {
 				loading: this.loading,
 				// Timezones:
 				timeZone: this.timezoneId,
+				// Formatting of the title
+				// will produce something like "Tuesday, September 18, 2018"
+				// ref https://fullcalendar.io/docs/date-formatting
+				titleFormat: {
+				  month: 'long',
+				  year: 'numeric',
+				  day: 'numeric',
+				  weekday: 'long',
+				},
 			}
 		},
 	},


### PR DESCRIPTION
Signed-off-by: Christoph Wurst <christoph@winzerhof-wurst.at>

## Description

As a user I would like to see the name of the day when I browse the free/busy view, mostly to prevent picking weekend dates for business meetings.

### Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### How to test / use your changes?

Open free/busy

### UI Changes

In case you changed, added or removed UI elements, please provide a set of before / after screenshots:

| Before | After |
|:---------:|:------:|
|![Bildschirmfoto von 2021-02-10 16-05-38](https://user-images.githubusercontent.com/1374172/107528376-0d876c00-6bba-11eb-923d-7275c1000913.png)|![Bildschirmfoto von 2021-02-10 16-04-03](https://user-images.githubusercontent.com/1374172/107528406-12e4b680-6bba-11eb-8bb4-c8d53053a708.png)|

@jancborchardt as discussed
