### PR TITLE
Add a date picker to the free/busy UI

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -24,7 +24,13 @@
 		"selector-type-case": null,
 		"selector-list-comma-newline-after": null,
 		"no-descending-specificity": null,
-		"string-quotes": "single"
+		"string-quotes": "single",
+		"selector-pseudo-element-no-unknown": [
+			true,
+			{
+				"ignorePseudoElements": ["v-deep"]
+			}
+		]
 	},
 	"plugins": [
 	  "stylelint-scss"

--- a/src/components/Editor/FreeBusy/FreeBusy.vue
+++ b/src/components/Editor/FreeBusy/FreeBusy.vue
@@ -44,6 +44,10 @@
 				</div>
 			</div>
 		</div>
+		<DatePicker ref="datePicker"
+			:date="currentDate"
+			:is-all-day="true"
+			@change="setCurrentDate" />
 	</Modal>
 </template>
 
@@ -70,6 +74,7 @@ import {
 	mapState,
 } from 'vuex'
 import Modal from '@nextcloud/vue/dist/Components/Modal'
+import DatePicker from '../../Shared/DatePicker'
 import { getColorForFBType } from '../../../utils/freebusy.js'
 import { getLocale } from '@nextcloud/l10n'
 import { getFirstDayOfWeekFromMomentLocale } from '../../../utils/moment.js'
@@ -78,6 +83,7 @@ export default {
 	name: 'FreeBusy',
 	components: {
 		FullCalendar,
+		DatePicker,
 		Modal,
 	},
 	props: {
@@ -115,6 +121,7 @@ export default {
 	data() {
 		return {
 			loadingIndicator: true,
+			currentDate: this.startDate,
 		}
 	},
 	computed: {
@@ -211,6 +218,11 @@ export default {
 				// Data
 				eventSources: this.eventSources,
 				resources: this.resources,
+				// Events
+				datesSet: function({ start }) {
+				  // Keep the current date in sync
+					this.setCurrentDate(start, true)
+				}.bind(this),
 				// Plugins
 				plugins: this.plugins,
 				// Interaction:
@@ -237,9 +249,27 @@ export default {
 			}
 		},
 	},
+	mounted() {
+	  // Move file picker into the right header menu
+		// TODO: make this a slot once fullcalendar support it
+		//       ref https://github.com/fullcalendar/fullcalendar-vue/issues/14
+		//       ref https://github.com/fullcalendar/fullcalendar-vue/issues/126
+		const picker = this.$refs.datePicker
+		// Remove from original position
+		picker.$el.parentNode.removeChild(picker.$el)
+		// Insert into calendar
+		this.$el.querySelector('.fc-toolbar-chunk:last-child').appendChild(picker.$el)
+	},
 	methods: {
 		loading(isLoading) {
 			this.loadingIndicator = isLoading
+		},
+		setCurrentDate(date, updatedViaCalendar) {
+		  this.currentDate = date
+			if (!updatedViaCalendar) {
+				const calendar = this.$refs.freeBusyFullCalendar.getApi()
+				calendar.gotoDate(date)
+			}
 		},
 	},
 }
@@ -248,6 +278,15 @@ export default {
 <style lang='scss' scoped>
 .modal__content {
 	padding: 50px;
+  //when the calendar is open, it's cut at the bottom, adding a margin fixes it
+  margin-bottom: 95px;
+}
+
+::v-deep .mx-input{height: 38px !important;
+}
+
+::v-deep .icon-new-calendar {background-color: var(--color-main-background); border: none; padding: 6px; margin-top: 17px;
+  cursor: default;
 }
 </style>
 

--- a/src/components/Editor/FreeBusy/FreeBusy.vue
+++ b/src/components/Editor/FreeBusy/FreeBusy.vue
@@ -278,24 +278,27 @@ export default {
 <style lang='scss' scoped>
 .modal__content {
 	padding: 50px;
-  //when the calendar is open, it's cut at the bottom, adding a margin fixes it
-  margin-bottom: 95px;
+	//when the calendar is open, it's cut at the bottom, adding a margin fixes it
+	margin-bottom: 95px;
 }
 
-::v-deep .mx-input{height: 38px !important;
+::v-deep .mx-input{
+	height: 38px !important;
 }
 
-::v-deep .icon-new-calendar {background-color: var(--color-main-background); border: none; padding: 6px; margin-top: 17px;
-  cursor: default;
+::v-deep .icon-new-calendar {
+	background-color: var(--color-main-background); border: none; padding: 6px; margin-top: 17px;
+	cursor: default;
 }
 </style>
 
 <style lang="scss">
 .blocking-event-free-busy {
-  // Show the blocking event above any other blocks, especially the *blocked for all* one
-  z-index: 3 !important;
+	// Show the blocking event above any other blocks, especially the *blocked for all* one
+	z-index: 3 !important;
 }
+
 .free-busy-block {
-  opacity: 0.7 !important;
+	opacity: 0.7 !important;
 }
 </style>


### PR DESCRIPTION
## Description

Adds a date picker to the free/busy UI so that you can navigate around more efficient than just prev/next days.

### Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### How to test / use your changes?

Please provide instructions how to test your changes

1. Create an event
2. Add participants
3. Open the free/busy UI

### UI Changes

In case you changed, added or removed UI elements, please provide a set of before / after screenshots:

| Before | After |
|:---------:|:------:|
|![Bildschirmfoto von 2021-02-11 10-17-04](https://user-images.githubusercontent.com/1374172/107618823-7de1cc00-6c52-11eb-80e3-11514ad6baf7.png)|![Bildschirmfoto von 2021-02-11 10-16-14](https://user-images.githubusercontent.com/1374172/107618839-833f1680-6c52-11eb-9850-ba26e6ba616c.png)|

Todo
- [x] Make it work
- [x] Make it pretty

cc @jancborchardt @oparoz as discussed