### PR TITLE
Fix fullcalendar v5 options for background events

### DIFF
--- a/src/fullcalendar/eventSources/freeBusyEventSourceFunction.js
+++ b/src/fullcalendar/eventSources/freeBusyEventSourceFunction.js
@@ -41,7 +41,7 @@ export default function(uri, calendarData, success, start, end, timezone) {
 			start: start.getInTimezone(timezone).jsDate.toISOString(),
 			end: end.getInTimezone(timezone).jsDate.toISOString(),
 			resourceId: uri,
-			rendering: 'background',
+			display: 'background',
 			allDay: false,
 			backgroundColor: getColorForFBType('UNKNOWN'),
 			borderColor: getColorForFBType('UNKNOWN'),
@@ -67,7 +67,7 @@ export default function(uri, calendarData, success, start, end, timezone) {
 			start: freeBusyProperty.getFirstValue().start.getInTimezone(timezone).jsDate.toISOString(),
 			end: freeBusyProperty.getFirstValue().end.getInTimezone(timezone).jsDate.toISOString(),
 			resourceId: uri,
-			rendering: 'background',
+			display: 'background',
 			backgroundColor: getColorForFBType(freeBusyProperty.type),
 		})
 	}

--- a/src/fullcalendar/eventSources/freeBusyFakeBlockingEventSource.js
+++ b/src/fullcalendar/eventSources/freeBusyFakeBlockingEventSource.js
@@ -45,7 +45,7 @@ export default function(id, resources, eventStart, eventEnd) {
 					start: eventStart.toISOString(),
 					end: eventEnd.toISOString(),
 					allDay: false,
-					rendering: 'background',
+					display: 'background',
 					classNames: [
 						'blocking-event-free-busy',
 						'blocking-event-free-busy--first-row',
@@ -59,7 +59,7 @@ export default function(id, resources, eventStart, eventEnd) {
 					start: eventStart.toISOString(),
 					end: eventEnd.toISOString(),
 					allDay: false,
-					rendering: 'background',
+					display: 'background',
 					classNames: [
 						'blocking-event-free-busy',
 						'blocking-event-free-busy--first-row',
@@ -70,7 +70,7 @@ export default function(id, resources, eventStart, eventEnd) {
 					start: eventStart.toISOString(),
 					end: eventEnd.toISOString(),
 					allDay: false,
-					rendering: 'background',
+					display: 'background',
 					classNames: [
 						'blocking-event-free-busy',
 						'blocking-event-free-busy--last-row',
@@ -83,7 +83,7 @@ export default function(id, resources, eventStart, eventEnd) {
 					start: eventStart.toISOString(),
 					end: eventEnd.toISOString(),
 					allDay: false,
-					rendering: 'background',
+					display: 'background',
 					classNames: [
 						'blocking-event-free-busy',
 						'blocking-event-free-busy--first-row',
@@ -94,7 +94,7 @@ export default function(id, resources, eventStart, eventEnd) {
 					start: eventStart.toISOString(),
 					end: eventEnd.toISOString(),
 					allDay: false,
-					rendering: 'background',
+					display: 'background',
 					classNames: [
 						'blocking-event-free-busy',
 					],
@@ -104,7 +104,7 @@ export default function(id, resources, eventStart, eventEnd) {
 					start: eventStart.toISOString(),
 					end: eventEnd.toISOString(),
 					allDay: false,
-					rendering: 'background',
+					display: 'background',
 					classNames: [
 						'blocking-event-free-busy',
 						'blocking-event-free-busy--last-row',


### PR DESCRIPTION
## Description

`rendering` was used in v4, in v5 `display` changes the way how events
are rendered. This caused blocks in the UI that then made the free/busy
schedule grow vertically and so became less useful.

Ref https://fullcalendar.io/docs/upgrading-from-v4
Ref https://fullcalendar.io/docs/background-events

Possibly a regression of https://github.com/nextcloud/calendar/pull/2498, for comparison here's the original PR for free/busy with a screenshot: https://github.com/nextcloud/calendar/pull/1731

Fixes # (issue)

### Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### How to test / use your changes?

Please provide instructions how to test your changes

1. Create an event
2. Add at least one attendee
3. View the free/busy UI

### UI Changes

In case you changed, added or removed UI elements, please provide a set of before / after screenshots:

| Before | After |
|:---------:|:------:|
|![Bildschirmfoto von 2021-02-12 12-06-45](https://user-images.githubusercontent.com/1374172/107761223-4e52c280-6d2b-11eb-9ef1-d6d7f2809962.png)|![Bildschirmfoto von 2021-02-12 12-06-05](https://user-images.githubusercontent.com/1374172/107761238-527ee000-6d2b-11eb-9152-08ce4ceb2f3b.png)|
