### PR TITLE
Use npm ci to install front-end dependencies in dev

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,10 +4,10 @@
 all: dev-setup lint build-js-production test test-php
 
 # Dev env management
-dev-setup: clean clean-dev npm-init
+dev-setup: clean npm-init
 
 npm-init:
-	npm install
+	npm ci
 
 composer-init:
 	composer install --prefer-dist
@@ -61,9 +61,6 @@ stylelint-fix:
 # Cleaning
 clean:
 	rm -rf js
-
-clean-dev:
-	rm -rf node_modules
 
 # Builds the source package for the app store, ignores php and js tests
 appstore:


### PR DESCRIPTION
## Description

The ci command is meant for any situation where you want to make sure
you're doing a clean install of your dependencies.

It is significantly faster than npm install. If a node_modules is
already present, it will be automatically removed before npm ci begins
its install.

Matches the GitHub actions to build the package.

The clean-dev rule is now unused and can be removed.

https://docs.npmjs.com/cli/v7/commands/npm-ci

### How to test / use your changes?

1. make dev-setup