### PR TITLE
Catch invalid calendar objects

### DIFF
--- a/src/store/calendars.js
+++ b/src/store/calendars.js
@@ -688,9 +688,13 @@ const actions = {
 		const calendarObjects = []
 		const calendarObjectIds = []
 		for (const r of response.concat(responseTodo)) {
-			const calendarObject = mapCDavObjectToCalendarObject(r, calendar.id)
-			calendarObjects.push(calendarObject)
-			calendarObjectIds.push(calendarObject.id)
+			try {
+				const calendarObject = mapCDavObjectToCalendarObject(r, calendar.id)
+				calendarObjects.push(calendarObject)
+				calendarObjectIds.push(calendarObject.id)
+			} catch (e) {
+				console.error('could not convert calendar object', e)
+			}
 		}
 
 		context.commit('appendCalendarObjects', { calendarObjects })


### PR DESCRIPTION
## Description

Catch single faulty events to prevent a full calendar not showing anything.

### Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### How to test / use your changes?

Please provide instructions how to test your changes

1. Create an event
2. Make the calendar data invalid in the db
3. Load a time range with the faulty calendar object