### PR TITLE
minor: remove `updateTodayJob` from main Calendar.vue

### DIFF
--- a/src/views/Calendar.vue
+++ b/src/views/Calendar.vue
@@ -111,8 +111,6 @@ export default {
 		return {
 			loadingCalendars: true,
 			timeFrameCacheExpiryJob: null,
-			updateTodayJob: null,
-			updateTodayJobPreviousDate: null,
 			showEmptyCalendarScreen: false,
 		}
 	},


### PR DESCRIPTION
## Description

The calendar grid was moved into its own component in 3a076313a6796db63a538719c3d25bf6f492ce41.

`updateTodayJob` and `updateTodayJobPreviousDate` were moved with it.
This commit just cleans up the left over code.

### Type of change

Please delete options that are not relevant.

- [x] Cleanup (non-breaking change which removes old code)


### How to test / use your changes?

Please provide instructions how to test your changes

1. Take a look at the Calendar.vue file
2. Search for uses of the removed data.
3. Find none 😉 

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I signed off my changes (`git commit -sm "Your commit message"`)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

