### PR TITLE
Fix sorting of free/busy resources

### DIFF
--- a/src/components/Editor/FreeBusy/FreeBusy.vue
+++ b/src/components/Editor/FreeBusy/FreeBusy.vue
@@ -162,6 +162,10 @@ export default {
 					title: attendee.commonName || attendee.uri.substr(7),
 				})
 			}
+			// Sort the resources by ID, just like fullcalendar does. This ensures that
+			// the fake blocking event can know the first and last resource reliably
+			// ref https://fullcalendar.io/docs/resourceOrder
+			resources.sort((a, b) => (a.id > b.id) - (a.id < b.id))
 
 			return resources
 		},


### PR DESCRIPTION
Fullcalendar sorts resources by their ID. In our app that is the
attendee's email address. For the fake blocking event that shows the
current time slot we need to know the first and last resource to show a
special border on top/bottom. In some scenarios that didn't work before,
now it seems more reliable.

### How to test / use your changes?

* Create an event
* Add user A with email b@domain.tld
* Add user B with email a@domain.tld

Master: borders don't make any sense

![Bildschirmfoto vom 2021-02-26 08-56-33](https://user-images.githubusercontent.com/1374172/109272544-502f8200-7811-11eb-8e73-e11b57bb568c.png)


This branch: smooth borders that show an actual box

![Bildschirmfoto vom 2021-02-26 08-57-14](https://user-images.githubusercontent.com/1374172/109272564-56256300-7811-11eb-9486-d184f9c1a2da.png)


