### PR TITLE
Fix free/busy blocking event background and border

### DIFF
--- a/css/freebusy.scss
+++ b/css/freebusy.scss
@@ -32,7 +32,8 @@
 		border-style: solid;
 		border-left-width: 1px;
 		border-right-width: 1px;
-		background-color: transparent;
+		background-color: transparent !important;
+		opacity: 1.0 !important;
 		z-index: 2;
 	}
 


### PR DESCRIPTION
The blocking event (the slot for the selected time frame of the event)
is supposed to show with red border and no background. For some reason
this styling broke (possibly through a fullcalendar upgrade) and
therefore needed some stricter styling rules that turn off FC's default
background and reset the opacity to make the border stand out.

This brings the design back to the original design as done by Georg.
Ref https://github.com/nextcloud/calendar/pull/1731

### Before

![Bildschirmfoto von 2021-02-26 09-19-00](https://user-images.githubusercontent.com/1374172/109274707-19a73680-7814-11eb-9520-34b7d784db26.png)

### After

![Bildschirmfoto von 2021-02-26 09-16-29](https://user-images.githubusercontent.com/1374172/109274732-1f048100-7814-11eb-8a59-b108e14c2bfa.png)
