### PR TITLE
Use Codecov without tokens

### DIFF
--- a/.github/workflows/npm-test.yml
+++ b/.github/workflows/npm-test.yml
@@ -32,7 +32,6 @@ jobs:
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v1
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
           file: ./coverage/coverage-final.json
           flags: javascript
           fail_ci_if_error: true

--- a/.github/workflows/php-test.yml
+++ b/.github/workflows/php-test.yml
@@ -55,5 +55,8 @@ jobs:
       run: composer run test
     - name: Upload coverage to Codecov
       if: ${{ matrix.nextcloud-versions == 'master' }}
-      working-directory: nextcloud/apps/calendar
-      run: curl -s https://codecov.io/bash | bash -s - -t ${{ secrets.CODECOV_TOKEN }} -F php -f clover.unit.xml -Z
+      uses: codecov/codecov-action@v1
+      with:
+        file: nextcloud/apps/calendar/clover.unit.xml
+        flags: php
+        fail_ci_if_error: true


### PR DESCRIPTION
They are only required for private repos.

Ref https://github.com/codecov/codecov-action#usage