### PR TITLE
Fix right border on today not being visible in month and week view when using Firefox

### DIFF
--- a/css/fullcalendar.scss
+++ b/css/fullcalendar.scss
@@ -95,6 +95,12 @@
 	}
 }
 
+// Fix right border on today not being visible in month and week view when using Firefox
+.fc .fc-daygrid-day.fc-day-today,
+.fc .fc-timegrid-col.fc-day-today {
+	z-index: -1;
+}
+
 // ### FullCalendar Event adjustments
 .fc-event {
 	padding-left: 3px;


### PR DESCRIPTION
This fixes #2679 

This pull request makes the right border on "today" visible again in month and week view when using Firefox.

before:
![Screenshot_20210308_222601](https://user-images.githubusercontent.com/19759293/110384081-75b45b00-805d-11eb-933f-03cf53b49ba3.png)
![Screenshot_20210308_222611](https://user-images.githubusercontent.com/19759293/110384093-777e1e80-805d-11eb-9476-e2cba4077db5.png)

after:
![Screenshot_20210308_222519](https://user-images.githubusercontent.com/19759293/110384107-7baa3c00-805d-11eb-9d41-6076c5b70e47.png)
![Screenshot_20210308_222536](https://user-images.githubusercontent.com/19759293/110384118-7cdb6900-805d-11eb-9beb-bbc34d9f4e90.png)
