### PR TITLE
Fix white hover background on events in list view when using dark theme

### DIFF
--- a/css/fullcalendar.scss
+++ b/css/fullcalendar.scss
@@ -43,6 +43,7 @@
 	--fc-highlight-color: rgba(188, 232, 241, 0.3); // TODO - use some color css var from us?
 	--fc-today-bg-color: var(--color-main-background) !important;
 	--fc-now-indicator-color: red;
+	--fc-list-event-hover-bg-color: var(--color-background-hover) !important;
 }
 
 .fc {


### PR DESCRIPTION
Fixes https://github.com/mwalbeck/nextcloud-breeze-dark/issues/232

This doesn't change anything with the default theme as ```--fc-list-event-hover-bg-color``` is normally set to the same colour as the default colour value of ```--color-background-hover```.

Before:
![Screenshot_20210318_215615](https://user-images.githubusercontent.com/19759293/111698339-01d13a00-8837-11eb-8268-6902f9ad843b.png)

After:
![Screenshot_20210318_215709](https://user-images.githubusercontent.com/19759293/111698358-05fd5780-8837-11eb-9999-0d31d951293b.png)

