### PR TITLE
Revert "Fix right border on today not being visible in month and week view when using Firefox"

### DIFF
--- a/css/fullcalendar.scss
+++ b/css/fullcalendar.scss
@@ -96,12 +96,6 @@
 	}
 }
 
-// Fix right border on today not being visible in month and week view when using Firefox
-.fc .fc-daygrid-day.fc-day-today,
-.fc .fc-timegrid-col.fc-day-today {
-	z-index: -1;
-}
-
 // ### FullCalendar Event adjustments
 .fc-event {
 	padding-left: 3px;


### PR DESCRIPTION
![Bildschirmfoto von 2021-03-24 09-55-21](https://user-images.githubusercontent.com/1374172/112287428-a8c93200-8c8c-11eb-9f65-e0b2ab4f49e5.png)
![Bildschirmfoto von 2021-03-24 10-21-17](https://user-images.githubusercontent.com/1374172/112287444-acf54f80-8c8c-11eb-8597-433572ef369b.png)

^ some artifacts of the regression. The today column was shown *above* the actual events and therefore events became impossible to click and some visual regressions with lines above events showed as well.

cc @mwalbeck