### PR TITLE
Fix right border on today not being visible in month and week view when using Firefox, again

### DIFF
--- a/css/fullcalendar.scss
+++ b/css/fullcalendar.scss
@@ -96,6 +96,12 @@
 	}
 }
 
+// Fix right border on today not being visible in month and week view when using Firefox
+.fc .fc-daygrid-day.fc-day-today,
+.fc .fc-timegrid-col.fc-day-today {
+	background-color: unset !important;
+}
+
 // ### FullCalendar Event adjustments
 .fc-event {
 	padding-left: 3px;


### PR DESCRIPTION
Alternative fix for #2679 without the regression found with #2939 

Sorry about the previous fix, that regression wasn't great... Hopefully this fix is better.

Unsetting the background colour on today achieves the same result. In Calendar the background colour of today is set to `--color-main-background` which is the same as the parent table, so it isn't necessary to be set again when we want it to be the same colour. I have used `!important` as the original rule from fullcalendar is defined inline. Any change of the background during usage, like background colour change on highlight in monthly view, seems to happen inside the today element and not on the today element itself, so that isn't affected by this fix.

Before:
![Screenshot_20210324_155716](https://user-images.githubusercontent.com/19759293/112332022-b1842d00-8cb9-11eb-80bd-f555faeb829c.png)

After:
![Screenshot_20210324_155726](https://user-images.githubusercontent.com/19759293/112332041-b47f1d80-8cb9-11eb-8110-bf4ced6b2759.png)

cc @ChristophWurst 