### PR TITLE
Fix: when a attendee is a second person without email, skip alreadyInvitedEmails check

### DIFF
--- a/src/components/Editor/Invitees/InviteesListSearch.vue
+++ b/src/components/Editor/Invitees/InviteesListSearch.vue
@@ -206,7 +206,7 @@ export default {
 						name = email
 					}
 
-					if (this.alreadyInvitedEmails.includes(email)) {
+					if (email && this.alreadyInvitedEmails.includes(email)) {
 						return
 					}
 


### PR DESCRIPTION
In case if multiple attendees have empty email, the second one won't show in search result by 
block of alreadyInvitedEmails. Add email is not empty check in findAttendeesFromContactsAPI