### PR TITLE
Fix compatibility with latest versions of DateTimePicker not showing time panel

### DIFF
--- a/src/components/Shared/DatePicker.vue
+++ b/src/components/Shared/DatePicker.vue
@@ -24,13 +24,13 @@
 	<DatetimePicker
 		:lang="lang"
 		:first-day-of-week="firstDay"
+		:format="'YYYY-MM-DD HH:mm'"
 		:formatter="formatter"
 		:value="date"
 		:type="type"
 		:clearable="false"
 		:minute-step="5"
-		:not-before="minimumDate"
-		:not-after="maximumDate"
+		:disabled-date="disabledDate"
 		:show-second="false"
 		:show-time-panel="showTimePanel"
 		:show-week-number="showWeekNumbers"
@@ -396,6 +396,15 @@ export default {
 
 				return moment(dateMatches[1] + ' ' + timeMatches[1], 'L LT', this.locale).toDate()
 			}
+		},
+		/**
+		 * Whether or not the date is acceptable
+		 *
+		 * @param {Date} date The date to compare to
+		 * @returns {Boolean}
+		 */
+		disabledDate(date) {
+			return date < this.minimumDate || date > this.maximumDate
 		},
 	},
 }


### PR DESCRIPTION
Was broken in https://github.com/nextcloud/calendar/commit/7d372b32eb6a646c0b649a80f7766bbd882df88e

- Closes #2983
  It seems the `format` prop is required to have `HH:mm` to display the timepanel…for some reason

- Remove obsolete props `not-before` and `not-after` which are replaced by a `disabled-date` function prop in vue2-datepicker 3.0.0

Note: The `first-day-of-week` seems unused in `@nextcloud/vue` or `vue2-datepicker`, it should probably override the setting in `lang` instead of be set as a prop here.
For reference, it should be using the `window.firstDay` instead of raw moment data because of language vs locale issue (see https://github.com/nextcloud/calendar/pull/1583)