### PR TITLE
Set task start to allow visualization as regular event

### DIFF
--- a/src/fullcalendar/eventSources/eventSourceFunction.js
+++ b/src/fullcalendar/eventSources/eventSourceFunction.js
@@ -74,9 +74,9 @@ export function eventSourceFunction(calendarObjects, calendar, start, end, timez
 				jsEnd = object.endDate.getInTimezone(timezone).jsDate
 			} else if (object.name === 'VTODO') {
 				jsStart = jsEnd = object.endDate.getInTimezone(timezone).jsDate
-				
+
 				// If available, set task start to allow visualization
-				if (object.startDate){
+				if (object.startDate) {
 					jsStart = object.startDate.getInTimezone(timezone).jsDate
 				}
 			} else {

--- a/src/fullcalendar/eventSources/eventSourceFunction.js
+++ b/src/fullcalendar/eventSources/eventSourceFunction.js
@@ -73,10 +73,12 @@ export function eventSourceFunction(calendarObjects, calendar, start, end, timez
 				jsStart = object.startDate.getInTimezone(timezone).jsDate
 				jsEnd = object.endDate.getInTimezone(timezone).jsDate
 			} else if (object.name === 'VTODO') {
-				// For tasks, we only want to display when it is due,
-				// not for how long it has been in progress already
-				jsStart = object.endDate.getInTimezone(timezone).jsDate
-				jsEnd = object.endDate.getInTimezone(timezone).jsDate
+				jsStart = jsEnd = object.endDate.getInTimezone(timezone).jsDate
+				
+				// If available, set task start to allow visualization
+				if (object.startDate){
+					jsStart = object.startDate.getInTimezone(timezone).jsDate
+				}
 			} else {
 				// We do not want to display anything that's neither
 				// an event nor a task

--- a/tests/javascript/unit/fullcalendar/eventSources/freeBusyResourceEventSourceFunction.test.js
+++ b/tests/javascript/unit/fullcalendar/eventSources/freeBusyResourceEventSourceFunction.test.js
@@ -592,7 +592,7 @@ describe('fullcalendar/freeBusyResourceEventSourceFunction test suite', () => {
 				recurrenceId: 123,
 			},
 			id: '1###1',
-			start: event1End,
+			start: event1Start,
 			title: 'Untitled task',
 		}, {
 			allDay: false,
@@ -613,7 +613,7 @@ describe('fullcalendar/freeBusyResourceEventSourceFunction test suite', () => {
 				recurrenceId: 123,
 			},
 			id: '1###2',
-			start: event2End,
+			start: event2Start,
 			title: 'Untitled task',
 		}, {
 			allDay: false,
@@ -634,7 +634,7 @@ describe('fullcalendar/freeBusyResourceEventSourceFunction test suite', () => {
 				recurrenceId: 123,
 			},
 			id: '1###3',
-			start: event3End,
+			start: event3Start,
 			title: 'Untitled task (99%)',
 		}, {
 			allDay: false,
@@ -655,7 +655,7 @@ describe('fullcalendar/freeBusyResourceEventSourceFunction test suite', () => {
 				recurrenceId: 123,
 			},
 			id: '1###4',
-			start: event4End,
+			start: event4Start,
 			title: 'This task has a title',
 		}, {
 			allDay: false,
@@ -676,30 +676,30 @@ describe('fullcalendar/freeBusyResourceEventSourceFunction test suite', () => {
 				recurrenceId: 123,
 			},
 			id: '1###5',
-			start: event5End,
+			start: event5Start,
 			title: 'This task has a title and percent (99%)',
 		}])
 
-		expect(eventComponentSet[0].startDate.getInTimezone).toHaveBeenCalledTimes(0)
-		expect(eventComponentSet[0].endDate.getInTimezone).toHaveBeenCalledTimes(2)
+		expect(eventComponentSet[0].startDate.getInTimezone).toHaveBeenCalledTimes(1)
+		expect(eventComponentSet[0].startDate.getInTimezone).toHaveBeenNthCalledWith(1, timezone)
+		expect(eventComponentSet[0].endDate.getInTimezone).toHaveBeenCalledTimes(1)
 		expect(eventComponentSet[0].endDate.getInTimezone).toHaveBeenNthCalledWith(1, timezone)
-		expect(eventComponentSet[0].endDate.getInTimezone).toHaveBeenNthCalledWith(2, timezone)
-		expect(eventComponentSet[1].startDate.getInTimezone).toHaveBeenCalledTimes(0)
-		expect(eventComponentSet[1].endDate.getInTimezone).toHaveBeenCalledTimes(2)
+		expect(eventComponentSet[1].startDate.getInTimezone).toHaveBeenCalledTimes(1)
+		expect(eventComponentSet[1].startDate.getInTimezone).toHaveBeenNthCalledWith(1, timezone)
+		expect(eventComponentSet[1].endDate.getInTimezone).toHaveBeenCalledTimes(1)
 		expect(eventComponentSet[1].endDate.getInTimezone).toHaveBeenNthCalledWith(1, timezone)
-		expect(eventComponentSet[1].endDate.getInTimezone).toHaveBeenNthCalledWith(2, timezone)
-		expect(eventComponentSet[2].startDate.getInTimezone).toHaveBeenCalledTimes(0)
-		expect(eventComponentSet[2].endDate.getInTimezone).toHaveBeenCalledTimes(2)
+		expect(eventComponentSet[2].startDate.getInTimezone).toHaveBeenCalledTimes(1)
+		expect(eventComponentSet[2].startDate.getInTimezone).toHaveBeenNthCalledWith(1, timezone)
+		expect(eventComponentSet[2].endDate.getInTimezone).toHaveBeenCalledTimes(1)
 		expect(eventComponentSet[2].endDate.getInTimezone).toHaveBeenNthCalledWith(1, timezone)
-		expect(eventComponentSet[2].endDate.getInTimezone).toHaveBeenNthCalledWith(2, timezone)
-		expect(eventComponentSet[3].startDate.getInTimezone).toHaveBeenCalledTimes(0)
-		expect(eventComponentSet[3].endDate.getInTimezone).toHaveBeenCalledTimes(2)
+		expect(eventComponentSet[3].startDate.getInTimezone).toHaveBeenCalledTimes(1)
+		expect(eventComponentSet[3].startDate.getInTimezone).toHaveBeenNthCalledWith(1, timezone)
+		expect(eventComponentSet[3].endDate.getInTimezone).toHaveBeenCalledTimes(1)
 		expect(eventComponentSet[3].endDate.getInTimezone).toHaveBeenNthCalledWith(1, timezone)
-		expect(eventComponentSet[3].endDate.getInTimezone).toHaveBeenNthCalledWith(2, timezone)
-		expect(eventComponentSet[4].startDate.getInTimezone).toHaveBeenCalledTimes(0)
-		expect(eventComponentSet[4].endDate.getInTimezone).toHaveBeenCalledTimes(2)
+		expect(eventComponentSet[4].startDate.getInTimezone).toHaveBeenCalledTimes(1)
+		expect(eventComponentSet[4].startDate.getInTimezone).toHaveBeenNthCalledWith(1, timezone)
+		expect(eventComponentSet[4].endDate.getInTimezone).toHaveBeenCalledTimes(1)
 		expect(eventComponentSet[4].endDate.getInTimezone).toHaveBeenNthCalledWith(1, timezone)
-		expect(eventComponentSet[4].endDate.getInTimezone).toHaveBeenNthCalledWith(2, timezone)
 
 		expect(translate).toHaveBeenCalledTimes(3)
 		expect(translate).toHaveBeenNthCalledWith(1, 'calendar', 'Untitled task')


### PR DESCRIPTION
This PR enables tasks to be visualized as regular events, when their start date is available. Fixes #2669 and will primarily affect Day and Week views of any calendar. See attached screenshots for reference.

![image](https://user-images.githubusercontent.com/6027890/115356991-04de8380-a171-11eb-895a-32b437663555.png)
