### PR TITLE
Set editorconfig for Vue files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -6,7 +6,7 @@ charset = utf-8
 end_of_line = lf
 insert_final_newline = true
 
-[*.{js,php}]
+[*.{js,php,vue}]
 indent_style = tab
 insert_final_newline = true
 


### PR DESCRIPTION
Editors configured to pick up the coding style from .editorconfig should
be told *.vue files use the same configuration as *.js files.