### PR TITLE
Revert the partial upgrade of fullcalendar to v5.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3016,60 +3016,30 @@
 			}
 		},
 		"@fullcalendar/daygrid": {
-			"version": "5.7.0",
-			"resolved": "https://registry.npmjs.org/@fullcalendar/daygrid/-/daygrid-5.7.0.tgz",
-			"integrity": "sha512-K/0A1XIcf527Q18Hg4eMXCdZwd9AkkfrOqm/rtzULnM5cRkd2oaHOksdrQ5V0kGHAQeV96sp9OCg8PPBrdlBoQ==",
+			"version": "5.6.0",
+			"resolved": "https://registry.npmjs.org/@fullcalendar/daygrid/-/daygrid-5.6.0.tgz",
+			"integrity": "sha512-UaNn6/vKQ3zI4/sDhrMACkIHOSZb/MA0JGlvvw3OTYFULqE5TISuYYnDbo9S1Wdz3AbTBvCzYy5Qk1vZQFsGwg==",
 			"requires": {
-				"@fullcalendar/common": "~5.7.0",
+				"@fullcalendar/common": "~5.6.0",
 				"tslib": "^2.0.3"
-			},
-			"dependencies": {
-				"@fullcalendar/common": {
-					"version": "5.7.0",
-					"resolved": "https://registry.npmjs.org/@fullcalendar/common/-/common-5.7.0.tgz",
-					"integrity": "sha512-8zKa4q9cQ5xjuAyN0d8AlpCrEC9Kmar5Oq3iMcPbPIO2AtNXTvifzCG44VIgm3/skjDBZ/wYvjJyyB+4WdmT6g==",
-					"requires": {
-						"tslib": "^2.0.3"
-					}
-				}
 			}
 		},
 		"@fullcalendar/interaction": {
-			"version": "5.7.0",
-			"resolved": "https://registry.npmjs.org/@fullcalendar/interaction/-/interaction-5.7.0.tgz",
-			"integrity": "sha512-GSIMP+b+fN6DZQ6VFkoZvLX94r3o5MmCMRvHfUVWx4XcOF1T1rytcKtPpLv/7HQJpXwX7LAQXEJnywBcXUTbXQ==",
+			"version": "5.6.0",
+			"resolved": "https://registry.npmjs.org/@fullcalendar/interaction/-/interaction-5.6.0.tgz",
+			"integrity": "sha512-2Jlr3e9hKanctmwXKio84Wv070bJn1Im+ZVWjdzUcF/wtUrsD1Kd5dcPBfl9jfTwl2jX/eCWBU3o6ZCLdgoaDg==",
 			"requires": {
-				"@fullcalendar/common": "~5.7.0",
+				"@fullcalendar/common": "~5.6.0",
 				"tslib": "^2.0.3"
-			},
-			"dependencies": {
-				"@fullcalendar/common": {
-					"version": "5.7.0",
-					"resolved": "https://registry.npmjs.org/@fullcalendar/common/-/common-5.7.0.tgz",
-					"integrity": "sha512-8zKa4q9cQ5xjuAyN0d8AlpCrEC9Kmar5Oq3iMcPbPIO2AtNXTvifzCG44VIgm3/skjDBZ/wYvjJyyB+4WdmT6g==",
-					"requires": {
-						"tslib": "^2.0.3"
-					}
-				}
 			}
 		},
 		"@fullcalendar/list": {
-			"version": "5.7.0",
-			"resolved": "https://registry.npmjs.org/@fullcalendar/list/-/list-5.7.0.tgz",
-			"integrity": "sha512-+EYUnWyjcCYppX52VRD4paaJx9c7ly8aCekGBKDsMbs3+KmgTbMEWNdoQKXJGE8Hn668x7OCo8RRZoT65YjTxQ==",
+			"version": "5.6.0",
+			"resolved": "https://registry.npmjs.org/@fullcalendar/list/-/list-5.6.0.tgz",
+			"integrity": "sha512-cpMjW9yUGrKkkoTWBKgo6MWH5P3MWCs3HjFxZd79oeXUY1/6ltyM2rwlSwbV8cCfEUaO+ovsRWzyh0mvSpaGDA==",
 			"requires": {
-				"@fullcalendar/common": "~5.7.0",
+				"@fullcalendar/common": "~5.6.0",
 				"tslib": "^2.0.3"
-			},
-			"dependencies": {
-				"@fullcalendar/common": {
-					"version": "5.7.0",
-					"resolved": "https://registry.npmjs.org/@fullcalendar/common/-/common-5.7.0.tgz",
-					"integrity": "sha512-8zKa4q9cQ5xjuAyN0d8AlpCrEC9Kmar5Oq3iMcPbPIO2AtNXTvifzCG44VIgm3/skjDBZ/wYvjJyyB+4WdmT6g==",
-					"requires": {
-						"tslib": "^2.0.3"
-					}
-				}
 			}
 		},
 		"@fullcalendar/premium-common": {
@@ -5966,7 +5936,7 @@
 		},
 		"cdav-library": {
 			"version": "git+https://github.com/nextcloud/cdav-library.git#c4f7d8225c2c8cfa5a3d269b3d986698d257dd5d",
-			"from": "git+https://github.com/nextcloud/cdav-library.git#c4f7d8225c2c8cfa5a3d269b3d986698d257dd5d",
+			"from": "git+https://github.com/nextcloud/cdav-library.git",
 			"requires": {
 				"core-js": "^3.12.1",
 				"regenerator-runtime": "^0.13.7"

--- a/package.json
+++ b/package.json
@@ -36,9 +36,9 @@
 	},
 	"dependencies": {
 		"@fullcalendar/core": "5.6.0",
-		"@fullcalendar/daygrid": "5.7.0",
-		"@fullcalendar/interaction": "5.7.0",
-		"@fullcalendar/list": "5.7.0",
+		"@fullcalendar/daygrid": "5.6.0",
+		"@fullcalendar/interaction": "5.6.0",
+		"@fullcalendar/list": "5.6.0",
 		"@fullcalendar/resource-timeline": "5.6.0",
 		"@fullcalendar/timegrid": "5.6.0",
 		"@fullcalendar/vue": "5.6.0",


### PR DESCRIPTION
I was too fast with #3078, #3086 and #3087. They break the main calendar component. I have to upgrade fullcalendar in one go and possibly adjust to some (breaking) changes.