### PR TITLE
Add min-height limits for events

### DIFF
--- a/css/fullcalendar.scss
+++ b/css/fullcalendar.scss
@@ -184,3 +184,11 @@
 		margin-top: 0 !important;
 	}
 }
+
+.fc-v-event {
+        min-height: 4em;
+}
+
+.fc-v-event.fc-timegrid-event-condensed {
+        min-height: 2em;
+}


### PR DESCRIPTION
Both condensed (one-line) and normal (2+ lines) events have no minimum height limit, resulting in cut-off event time and/or text.  This change introduces minimum limits for both event styles, guaranteeing that both time and text will be shown.  The trade-off here is that the event height no longer directly correlates exactly to the length of the event.

Before this change:
![image](https://user-images.githubusercontent.com/1738198/119999675-fe2d0280-bf9f-11eb-9cd7-a14c00ec0df6.png)


With this change:
![image](https://user-images.githubusercontent.com/1738198/119999574-e3f32480-bf9f-11eb-9900-707e07b8091e.png)

This addresses #2644 