### PR TITLE
Show organizer in free busy modal

### DIFF
--- a/src/components/Editor/FreeBusy/FreeBusy.vue
+++ b/src/components/Editor/FreeBusy/FreeBusy.vue
@@ -168,8 +168,7 @@ export default {
 		resources() {
 			const resources = []
 
-			// for (const attendee of [this.organizer, ...this.attendees]) {
-			for (const attendee of this.attendees) {
+			for (const attendee of [this.organizer, ...this.attendees]) {
 				resources.push({
 					id: attendee.attendeeProperty.email,
 					title: attendee.commonName || attendee.uri.substr(7),

--- a/src/fullcalendar/eventSources/freeBusyBlockedForAllEventSource.js
+++ b/src/fullcalendar/eventSources/freeBusyBlockedForAllEventSource.js
@@ -23,7 +23,7 @@ import { createFreeBusyRequest, getParserManager } from 'calendar-js'
 import DateTimeValue from 'calendar-js/src/values/dateTimeValue.js'
 import { findSchedulingOutbox } from '../../services/caldavService.js'
 import logger from '../../utils/logger.js'
-// import AttendeeProperty from 'calendar-js/src/properties/attendeeProperty.js'
+import AttendeeProperty from 'calendar-js/src/properties/attendeeProperty.js'
 
 /**
  * Returns an event source for free-busy
@@ -58,8 +58,8 @@ export default function(organizer, attendees, resources) {
 			const startDateTime = DateTimeValue.fromJSDate(start, true)
 			const endDateTime = DateTimeValue.fromJSDate(end, true)
 
-			// const organizerAsAttendee = new AttendeeProperty('ATTENDEE', organizer.email)
-			const freeBusyComponent = createFreeBusyRequest(startDateTime, endDateTime, organizer, attendees)
+			const organizerAsAttendee = new AttendeeProperty('ATTENDEE', organizer.email)
+			const freeBusyComponent = createFreeBusyRequest(startDateTime, endDateTime, organizer, [organizerAsAttendee, ...attendees])
 			const freeBusyICS = freeBusyComponent.toICS()
 
 			let outbox

--- a/src/fullcalendar/eventSources/freeBusyResourceEventSource.js
+++ b/src/fullcalendar/eventSources/freeBusyResourceEventSource.js
@@ -25,7 +25,7 @@ import DateTimeValue from 'calendar-js/src/values/dateTimeValue.js'
 import { findSchedulingOutbox } from '../../services/caldavService.js'
 import freeBusyResourceEventSourceFunction from './freeBusyResourceEventSourceFunction.js'
 import logger from '../../utils/logger.js'
-// import AttendeeProperty from 'calendar-js/src/properties/attendeeProperty.js'
+import AttendeeProperty from 'calendar-js/src/properties/attendeeProperty.js'
 
 /**
  * Returns an event source for free-busy
@@ -54,8 +54,8 @@ export default function(id, organizer, attendees) {
 			const startDateTime = DateTimeValue.fromJSDate(start, true)
 			const endDateTime = DateTimeValue.fromJSDate(end, true)
 
-			// const organizerAsAttendee = new AttendeeProperty('ATTENDEE', organizer.email)
-			const freeBusyComponent = createFreeBusyRequest(startDateTime, endDateTime, organizer, attendees)
+			const organizerAsAttendee = new AttendeeProperty('ATTENDEE', organizer.email)
+			const freeBusyComponent = createFreeBusyRequest(startDateTime, endDateTime, organizer, [organizerAsAttendee, ...attendees])
 			const freeBusyICS = freeBusyComponent.toICS()
 
 			let outbox


### PR DESCRIPTION
Fixes #3112 

Show the organizer of an event in the free/busy modal.

The required changes were already in the code but commented out :thinking: 