### PR TITLE
Add missing isResource property to OrganizerListItem

### DIFF
--- a/src/components/Editor/Invitees/OrganizerListItem.vue
+++ b/src/components/Editor/Invitees/OrganizerListItem.vue
@@ -26,6 +26,7 @@
 			:attendee-is-organizer="true"
 			:avatar-link="avatarLink"
 			:is-viewed-by-organizer="isViewedByOrganizer"
+			:is-resource="isResource"
 			:common-name="commonName"
 			:organizer-display-name="commonName"
 			participation-status="ACCEPTED" />
@@ -74,6 +75,10 @@ export default {
 		},
 		isViewedByOrganizer() {
 			return true
+		},
+		isResource() {
+			// The organizer does not have a tooltip
+			return false
 		},
 	},
 }


### PR DESCRIPTION
Follow up to #3132 

I missed a reference to `AvatarParticipationStatus` in `OrganizerListItem`. The organizer does not have a tooltip (and is an individual) so `isResource` can be false all the time.

![713-235-max](https://user-images.githubusercontent.com/1479486/120362692-a1b54480-c30b-11eb-8a9f-7d5709316f43.png)
