### PR TITLE
Show the trash bin retention only if one is available

### DIFF
--- a/src/components/AppNavigation/CalendarList/Trashbin.vue
+++ b/src/components/AppNavigation/CalendarList/Trashbin.vue
@@ -50,7 +50,7 @@
 							</td>
 						</tr>
 					</table>
-					<p class="footer">
+					<p v-if="retentionDuration" class="footer">
 						{{ n('calendar', 'Elements in the trash bin are deleted after {numDays} day', 'Elements in the trash bin are deleted after {numDays} days', retentionDuration, { numDays: retentionDuration }) }}
 					</p>
 				</div>


### PR DESCRIPTION
Ref https://github.com/nextcloud/calendar/pull/3130#issuecomment-854421937

This also hides the footer if the retention is set to 0.