### PR TITLE
Hide the trash bin if it's disabled

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5930,7 +5930,7 @@
 			"dev": true
 		},
 		"cdav-library": {
-			"version": "git+https://github.com/nextcloud/cdav-library.git#00e0479f545cd9d9fc445e70596ec154c106d3c7",
+			"version": "git+https://github.com/nextcloud/cdav-library.git#3170b21e9dccf8b95bbc23c29927734099ba3cc0",
 			"from": "git+https://github.com/nextcloud/cdav-library.git",
 			"requires": {
 				"core-js": "^3.13.0",

--- a/src/components/AppNavigation/CalendarList/Trashbin.vue
+++ b/src/components/AppNavigation/CalendarList/Trashbin.vue
@@ -132,7 +132,7 @@ export default {
 		},
 		retentionDuration() {
 			return Math.ceil(
-				this.trashBin._props['{http://nextcloud.com/ns}trash-bin-retention-duration'] / (60 * 60 * 24)
+				this.trashBin.retentionDuration / (60 * 60 * 24)
 			)
 		},
 	},

--- a/src/store/calendars.js
+++ b/src/store/calendars.js
@@ -401,7 +401,7 @@ const getters = {
 	},
 
 	hasTrashBin(state) {
-		return state.trashBin !== undefined
+		return state.trashBin !== undefined && state.trashBin.retentionDuration !== 0
 	},
 
 	trashBin(state) {


### PR DESCRIPTION
If an admin sets the retention duration to 0 then deletions will drop
data right away and remaining deleted items will be killed in the next
cron job. So there is nothing for the user to restore and we can safely
hide the item from the sidebar.
