### PR TITLE
Show shared calendars by default

### DIFF
--- a/src/models/calendar.js
+++ b/src/models/calendar.js
@@ -122,10 +122,8 @@ const mapDavCollectionToCalendar = (calendar, currentUserPrincipal) => {
 		// If calendar-enabled is set, we will just take that
 		enabled = calendar.enabled
 	} else {
-		// If there is no calendar-enabled,
-		// we will display the calendar by default if it's owned by the user
-		// or hide it by default it it's just shared with them
-		enabled = !isSharedWithMe
+		// If there is no calendar-enabled, show calendar by default
+		enabled = true
 	}
 
 	const shares = []


### PR DESCRIPTION
Changes the `enabled` default behavior. Instead of hiding shared calendars by default, now they are shown and users instead have to manually disable shared calendars in order to hide them. Fixes #3022.