### PR TITLE
Hide title arrow button in sidebar

### DIFF
--- a/css/app-sidebar.scss
+++ b/css/app-sidebar.scss
@@ -38,7 +38,7 @@
 
 	/** Hide the submit button for the title, because it does not trigger a save */
 	.app-sidebar-header__desc {
-		.rename-form {
+		.app-sidebar-header__maintitle-form {
 			button {
 				display: none;
 			}


### PR DESCRIPTION
Fixes #3160

The button was hidden before but the sidebar structure changed so the CSS rule did not apply.

![Screenshot 2021-06-11 at 10-58-35 June 2021 - Calendar - Nextcloud](https://user-images.githubusercontent.com/1479486/121660961-0149e780-caa4-11eb-9a87-e6c74f9313df.png)