### PR TITLE
Fix alignment of events in today cell in month view

### DIFF
--- a/css/fullcalendar.scss
+++ b/css/fullcalendar.scss
@@ -87,12 +87,12 @@
 		background: var(--color-primary);
 		color: var(--color-primary-text);
 		border-radius: 50%;
-		margin: 3px 3px 0 0;
+		margin: 4px;
 		width: 24px;
 		height: 24px;
 		text-align: center;
 		font-weight: bold !important;
-		padding: 1px 0 !important;
+		padding: 0 !important;
 	}
 }
 


### PR DESCRIPTION
You can see the events of the current day be a bit too far up, because the 
![Calendar current day layout current](https://user-images.githubusercontent.com/925062/121701533-489a9d00-cad1-11eb-976e-e49f49e2139d.png)

This is fixed now (24 height + 2*4 padding = 32, like the other numbers), also including properly centering it and vertically aligning the number in it:
![Calendar current day layout fixed](https://user-images.githubusercontent.com/925062/121703004-aaa7d200-cad2-11eb-8542-4cf53b3e6a92.png)

