### PR TITLE
Increase size of dot on timed events in month view for visibility

### DIFF
--- a/css/fullcalendar.scss
+++ b/css/fullcalendar.scss
@@ -28,6 +28,8 @@
 	--fc-neutral-text-color: var(--color-text-lighter) !important;
 	--fc-border-color: var(--color-border) !important;
 
+	--fc-daygrid-event-dot-width: 10px !important;
+
 	--fc-event-bg-color: var(--color-primary);
 	--fc-event-border-color: var(--color-primary-text);
 	--fc-event-text-color: var(--color-primary-text);


### PR DESCRIPTION
This increases the visibility of the calendar color, and fixes half of https://github.com/nextcloud/calendar/issues/2755

Before | After
-|-
![Month view dot before](https://user-images.githubusercontent.com/925062/121712495-15a9d680-cadc-11eb-8f65-6bc2efdbbe50.png)|![Month view dot fixed](https://user-images.githubusercontent.com/925062/121712569-29edd380-cadc-11eb-895f-9bec2d491063.png)

