### PR TITLE
make shared calendars visible/enabled by default

### DIFF
--- a/src/models/calendar.js
+++ b/src/models/calendar.js
@@ -123,9 +123,9 @@ const mapDavCollectionToCalendar = (calendar, currentUserPrincipal) => {
 		enabled = calendar.enabled
 	} else {
 		// If there is no calendar-enabled,
-		// we will display the calendar by default if it's owned by the user
-		// or hide it by default it it's just shared with them
-		enabled = !isSharedWithMe
+		// we will display the calendar by default and set enabled
+		enabled = true
+		calendar.enabled = true
 	}
 
 	const shares = []

--- a/tests/javascript/unit/models/calendar.test.js
+++ b/tests/javascript/unit/models/calendar.test.js
@@ -245,7 +245,7 @@ describe('Test suite: Calendar model (models/calendar.js)', () => {
 			color: '#FF00FF',
 			dav: cdavObject,
 			displayName: 'Displayname of calendar 123',
-			enabled: false,
+			enabled: true,
 			id: 'L2Zvby9iYXI=',
 			order: 0,
 			owner: '/remote.php/dav/principals/users/admin/',


### PR DESCRIPTION
replacement for PR https://github.com/nextcloud/calendar/pull/3159
Tested on my local machine with 2 users

Signed-off-by: Andreas Demmelbauer <git@notice.at>