### PR TITLE
Remove webcals support

### DIFF
--- a/src/components/AppNavigation/CalendarList/PublicCalendarListItem.vue
+++ b/src/components/AppNavigation/CalendarList/PublicCalendarListItem.vue
@@ -155,12 +155,7 @@ export default {
 			const rootURL = generateRemoteUrl('dav')
 			const url = new URL(this.calendar.url + '?export', rootURL)
 
-			if (url.protocol === 'http:') {
-				url.protocol = 'webcal:'
-			}
-			if (url.protocol === 'https:') {
-				url.protocol = 'webcals:'
-			}
+			url.protocol = 'webcal:'
 
 			// copy link for calendar to clipboard
 			try {

--- a/src/components/AppNavigation/EmbedTopNavigation.vue
+++ b/src/components/AppNavigation/EmbedTopNavigation.vue
@@ -69,12 +69,7 @@ export default {
 			const rootURL = generateRemoteUrl('dav')
 			const url = new URL(calendar.url + '?export', rootURL)
 
-			if (url.protocol === 'http:') {
-				url.protocol = 'webcal:'
-			}
-			if (url.protocol === 'https:') {
-				url.protocol = 'webcals:'
-			}
+			url.protocol = 'webcal:'
 
 			// copy link for calendar to clipboard
 			try {


### PR DESCRIPTION
The webcals is not officially registered (it's only assumed to be webcal over https), and it seems [1] some clients don't support it.

Nowdays everything should be using and redirecting to https anyway (and Nextcloud proxifies it's subscribed calendars). Also it's not possible to register a handler for `webcals`, only `webcal` (see https://developer.mozilla.org/en-US/docs/Web/API/Navigator/registerProtocolHandler).

Closes #2416 and #3050 and also related to #2197

[1] https://github.com/nextcloud/calendar/issues/2416

