### PR TITLE
Properly decode escaped principal urls

### DIFF
--- a/src/utils/url.js
+++ b/src/utils/url.js
@@ -1,0 +1,32 @@
+/**
+ * @copyright Copyright (c) 2021 Richard Steinmetz <richard@steinmetz.cloud>
+ *
+ * @author Richard Steinmetz <richard@steinmetz.cloud>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+/**
+ * Works like urldecode() from php
+ *
+ * @see https://www.php.net/manual/en/function.urldecode.php
+ * @param {string} url The url to be decoded
+ * @returns {string} The decoded url
+ */
+export function urldecode(url) {
+	return decodeURIComponent(url.replace(/\+/g, ' '))
+}

--- a/tests/javascript/unit/utils/url.test.js
+++ b/tests/javascript/unit/utils/url.test.js
@@ -1,0 +1,38 @@
+/**
+ * @copyright Copyright (c) 2021 Richard Steinmetz <richard@steinmetz.cloud>
+ *
+ * @author Richard Steinmetz <richard@steinmetz.cloud>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+import { urldecode } from '../../../../src/utils/url'
+
+describe('utils/url test suite', () => {
+	it('should decode urls encoded by php', () => {
+		const testData = [
+			['my+group+%2B%26%3F%25', 'my group +&?%'],
+			['my%2520+group', 'my%20 group'],
+			['group%20with%20spaces', 'group with spaces'],
+		]
+
+		for (const [encoded, expected] of testData) {
+			const decoded = urldecode(encoded)
+			expect(decoded).toEqual(expected)
+		}
+	})
+})


### PR DESCRIPTION
Fixes https://github.com/nextcloud/server/issues/25165
Fixes https://github.com/nextcloud/server/issues/17610
Fix https://github.com/nextcloud/server/issues/25459

#1985 introduced decoding of urls by using `decodeUri()` which does not fully reverse `urlencode()` of php. Instead all plus signs have to replaced with spaces manually and then `decodeURIComponent()` has be called. Principals of groups were encoded 2 times in a row because the decode wasn't working correctly which resulted in shares not being created.

I tested a couple exotic group names with spaces and special chars (e.g. `my group &%+`) and they all worked fine. Ideally, you should now be able to create a group containing spaces and then share calendars with those groups again.

## Reminder

Georg pointed out in the linked PR that this should be seen as a hot fix. In one of the mentioned issues a consensus was reached to not escape principals in the backend but as @tcitworld pointed out the standard requires us to escape urls. I'm not experienced enough with DAV to make a call here but we could add the decoding logic to the cdav-library at some point.