### PR TITLE
Redirect public view to public calendar ics endpoint if requested with Accept: 'text/calendar'

### DIFF
--- a/lib/Controller/PublicViewController.php
+++ b/lib/Controller/PublicViewController.php
@@ -25,6 +25,8 @@ namespace OCA\Calendar\Controller;
 
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http\ContentSecurityPolicy;
+use OCP\AppFramework\Http\RedirectResponse;
+use OCP\AppFramework\Http\Response;
 use OCP\AppFramework\Http\TemplateResponse;
 use OCP\IConfig;
 use OCP\IInitialStateService;
@@ -79,9 +81,13 @@ class PublicViewController extends Controller {
 	 * @NoCSRFRequired
 	 *
 	 * @param string $token
-	 * @return TemplateResponse
+	 * @return Response
 	 */
-	public function publicIndexWithBranding(string $token):TemplateResponse {
+	public function publicIndexWithBranding(string $token):Response {
+		$acceptHeader = $this->request->getHeader('Accept');
+		if (strpos($acceptHeader, 'text/calendar') !== false) {
+			return new RedirectResponse($this->urlGenerator->linkTo('', 'remote.php') . '/dav/public-calendars/' . $token . '/?export');
+		}
 		return $this->publicIndex($token, 'public');
 	}
 

--- a/tests/php/unit/Controller/PublicViewControllerTest.php
+++ b/tests/php/unit/Controller/PublicViewControllerTest.php
@@ -23,6 +23,7 @@ declare(strict_types=1);
  */
 namespace OCA\Calendar\Controller;
 
+use OCP\AppFramework\Http\RedirectResponse;
 use OCP\AppFramework\Http\TemplateResponse;
 use OCP\IConfig;
 use OCP\IInitialStateService;
@@ -127,6 +128,16 @@ class PublicViewControllerTest extends TestCase {
 		], $response->getParams());
 		$this->assertEquals('public', $response->getRenderAs());
 		$this->assertEquals('main', $response->getTemplateName());
+	}
+
+	public function testRedirectionIfRequestedWithAcceptCalendarHeader(): void {
+		$endpoint = 'https://somewhere.net/remote.php';
+
+		$this->request->expects(self::once())->method('getHeader')->with('Accept')->willReturn('text/calendar');
+		$this->urlGenerator->expects(self::once())->method('linkTo')->with('', 'remote.php')->willReturn($endpoint);
+		$response = $this->controller->publicIndexWithBranding('some-token');
+		self::assertInstanceOf(RedirectResponse::class, $response);
+		self::assertEquals($endpoint . '/dav/public-calendars/some-token/?export', $response->getRedirectURL());
 	}
 
 	public function testPublicIndexForEmbedding():void {


### PR DESCRIPTION
The server [already does the request](https://github.com/nextcloud/server/blob/master/apps/dav/lib/CalDAV/WebcalCaching/RefreshWebcalService.php#L202) with the following header `Accept: 'text/calendar, application/calendar+json, application/calendar+xml'`. `text/calendar` isn't a MIME type requested by common browsers.

Closes https://github.com/nextcloud/server/issues/17746
