### PR TITLE
Fix missing slashes in generated urls

### DIFF
--- a/src/components/AppNavigation/CalendarList/CalendarListItemSharingSearch.vue
+++ b/src/components/AppNavigation/CalendarList/CalendarListItemSharingSearch.vue
@@ -186,7 +186,7 @@ export default {
 		async findShareesFromCircles(query, hiddenPrincipals, hiddenUrls) {
 			let results
 			try {
-				results = await HttpClient.get(generateOcsUrl('apps/files_sharing/api/v1') + 'sharees', {
+				results = await HttpClient.get(generateOcsUrl('apps/files_sharing/api/v1/') + 'sharees', {
 					params: {
 						format: 'json',
 						search: query,

--- a/src/services/talkService.js
+++ b/src/services/talkService.js
@@ -33,7 +33,7 @@ import { generateUrl, generateOcsUrl } from '@nextcloud/router'
 export async function createTalkRoom(eventTitle = null) {
 	let response
 	try {
-		response = await HTTPClient.post(generateOcsUrl('apps/spreed/api/v1', 2) + 'room', {
+		response = await HTTPClient.post(generateOcsUrl('apps/spreed/api/v1/', 2) + 'room', {
 			roomType: 3,
 			roomName: eventTitle || t('calendar', 'Chat room for event'),
 		})
@@ -44,6 +44,7 @@ export async function createTalkRoom(eventTitle = null) {
 		return generateURLForToken(token)
 	} catch (error) {
 		console.debug(error)
+		throw error
 	}
 }
 


### PR DESCRIPTION
Fixes #3262 

The trailing slash is only added if the given url has one too. I also fixed talk room creation always reporting success even if it fails.

## Testing

Those 2 things should work again:

1. Share calendars with circles
2. Create talk rooms from events (Sidebar -> Attendees)