### PR TITLE
Rename fc-timegrid-event-condensed to fc-timegrid-event-short

### DIFF
--- a/css/fullcalendar.scss
+++ b/css/fullcalendar.scss
@@ -197,6 +197,6 @@
         min-height: 4em;
 }
 
-.fc-v-event.fc-timegrid-event-condensed {
+.fc-v-event.fc-timegrid-event-short {
         min-height: 2em;
 }


### PR DESCRIPTION
Matches change in fullcalendar [v5.7.0](https://github.com/fullcalendar/fullcalendar/releases/tag/v5.7.0).

This allows the min-height style that prevents vertical text clipping to be applied to the short-style event (one-line of text).  Without this rename, short events are unnecessarily vertically enlarged.

Related to #3121 and #2644.