### PR TITLE
Fix event repeat multiselect width and position on low resolutions

### DIFF
--- a/css/app-sidebar.scss
+++ b/css/app-sidebar.scss
@@ -128,7 +128,7 @@
 
 				.multiselect {
 					width: 100%;
-					min-width: 75px !important; // Set a lower min-width
+					min-width: 100px !important; // Set a lower min-width
 				}
 			}
 
@@ -173,7 +173,7 @@
 
 			.multiselect,
 			input[type=number] {
-				min-width: 75px;
+				min-width: 100px;
 				width: 25%;
 			}
 		}

--- a/src/components/Editor/Repeat/RepeatFreqSelect.vue
+++ b/src/components/Editor/Repeat/RepeatFreqSelect.vue
@@ -25,6 +25,7 @@
 		:allow-empty="false"
 		:options="options"
 		:value="selected"
+		open-direction="bottom"
 		track-by="freq"
 		label="label"
 		@select="select" />


### PR DESCRIPTION
Vue-Multiselect [*should* calculate the multi-select position automatically](https://github.com/shentao/vue-multiselect/blob/master/src/multiselectMixin.js#L696-L715), but that fails for some reason on small screen sizes. We can force the position on the bottom.

On small screen sizes as well the input is too small to view the placeholder fully, increasing that a bit.
Before | After
--------|------
![image](https://user-images.githubusercontent.com/2197836/124082695-4df26400-da4d-11eb-96d6-6dfc5095a656.png) | ![image](https://user-images.githubusercontent.com/2197836/124084506-577ccb80-da4f-11eb-97fe-ecf29c7bfc1f.png)

Maybe @nextcloud/vuejs has better knowledge of this kind of Vue-Multiselect issues.