### PR TITLE
Show email addresses in attendee search

### DIFF
--- a/src/components/Editor/Invitees/InviteesListSearch.vue
+++ b/src/components/Editor/Invitees/InviteesListSearch.vue
@@ -36,41 +36,16 @@
 		label="dropdownName"
 		@search-change="findAttendees"
 		@select="addAttendee">
-		<!--<template slot="singleLabel" slot-scope="props"><img class="option__image" :src="props.option.img" alt="No Man’s Sky"><span class="option__desc"><span class="option__title">{{ props.option.title }}</span></span></template>-->
-		<template slot="singleLabel" slot-scope="props">
+		<template #option="{ option }">
 			<div class="invitees-search-list-item">
-				<Avatar v-if="props.option.isUser" :user="props.option.avatar" :display-name="props.option.dropdownName" />
-				<Avatar v-if="!props.option.isUser" :url="props.option.avatar" :display-name="props.option.dropdownName" />
-				<div v-if="props.option.hasMultipleEMails" class="invitees-search-list-item__label invitees-search-list-item__label--with-displayname">
+				<Avatar v-if="option.isUser" :user="option.avatar" :display-name="option.dropdownName" />
+				<Avatar v-if="!option.isUser" :url="option.avatar" :display-name="option.dropdownName" />
+				<div class="invitees-search-list-item__label invitees-search-list-item__label--with-multiple-email">
 					<div>
-						{{ props.option.commonName }}
+						{{ option.dropdownName }}
 					</div>
-					<div>
-						{{ props.option.email }}
-					</div>
-				</div>
-				<div v-else class="invitees-search-list-item__label invitees-search-list-item__label--single-email">
-					<div>
-						{{ props.option.dropdownName }}
-					</div>
-				</div>
-			</div>
-		</template>
-		<template slot="option" slot-scope="props">
-			<div class="invitees-search-list-item">
-				<Avatar v-if="props.option.isUser" :user="props.option.avatar" :display-name="props.option.dropdownName" />
-				<Avatar v-if="!props.option.isUser" :url="props.option.avatar" :display-name="props.option.dropdownName" />
-				<div v-if="props.option.hasMultipleEMails" class="invitees-search-list-item__label invitees-search-list-item__label--with-multiple-email">
-					<div>
-						{{ props.option.commonName }}
-					</div>
-					<div>
-						{{ props.option.email }}
-					</div>
-				</div>
-				<div v-else class="invitees-search-list-item__label invitees-search-list-item__label--single-email">
-					<div>
-						{{ props.option.dropdownName }}
+					<div v-if="option.email !== option.dropdownName">
+						{{ option.email }}
 					</div>
 				</div>
 			</div>


### PR DESCRIPTION
Fixes #3189 

Always show the email addresses of user in the attendee search results. 

I also took the liberty to remove the `singleLabel` slot because it is only used when the selected option is displayed inside the multiselect field. This is not the case in our attendee search bar because we instantly clear the multiselect after selecting a new option and instead show all selected options in the list below.

## Colliding user (display) names
![Bildschirmfoto von 2021-07-02 14-48-18](https://user-images.githubusercontent.com/1479486/124277022-de5fa000-db44-11eb-8b30-d8845301b840.png)

## Display name fallback to email address

Show only one row in this case to prevent displaying the email address twice. Works for search results from contacts too.

![Bildschirmfoto von 2021-07-02 14-49-43](https://user-images.githubusercontent.com/1479486/124277023-def83680-db44-11eb-8e1a-4b5443592372.png)
