### PR TITLE
Bundle style sheets using webpack

### DIFF
--- a/css/calendar.scss
+++ b/css/calendar.scss
@@ -25,7 +25,6 @@
 @import 'freebusy.scss';
 @import 'fullcalendar.scss';
 @import 'global.scss';
-@import 'icons.scss';
 @import 'import.scss';
 @import 'print.scss';
 @import 'public.scss';

--- a/css/fullcalendar.scss
+++ b/css/fullcalendar.scss
@@ -135,10 +135,10 @@
 			top: 0;
 			right: 0;
 			&--light {
-				@include icon-color('reminder', 'calendar', '#fffffe', 1);
+				background-image: var(--icon-calendar-reminder-fffffe)
 			}
 			&--dark {
-				@include icon-color('reminder', 'calendar', '#000001', 1);
+				background-image: var(--icon-calendar-reminder-000001)
 			}
 		}
 	}

--- a/css/icons.scss
+++ b/css/icons.scss
@@ -19,6 +19,10 @@
  * License along with this library.  If not, see <http://www.gnu.org/licenses/>.
  *
  */
+
+// TODO: Use icon svg api instead of mixins when the server drops scss compilation.
+// https://docs.nextcloud.com/server/latest/developer_manual/design/icons.html#svg-color-api
+
 @include icon-black-white('briefcase', 'calendar', 5);
 @include icon-black-white('circle', 'calendar', 1);
 @include icon-black-white('color-picker', 'calendar', 1);
@@ -39,3 +43,5 @@
 @include icon-black-white('view-list', 'calendar', 1);
 @include icon-black-white('view-module', 'calendar', 1);
 @include icon-black-white('view-week', 'calendar', 1);
+@include icon-color('reminder', 'calendar', '#fffffe', 1);
+@include icon-color('reminder', 'calendar', '#000001', 1);

--- a/src/main.js
+++ b/src/main.js
@@ -23,6 +23,8 @@
  */
 import 'core-js/stable'
 
+import '../css/calendar.scss'
+
 import Vue from 'vue'
 import App from './App'
 import router from './router'

--- a/templates/main.php
+++ b/templates/main.php
@@ -20,4 +20,4 @@
  *
  */
 script('calendar', 'calendar-main');
-style('calendar', 'calendar');
+style('calendar', 'icons');


### PR DESCRIPTION
Ref #3178

Nearly all style sheets are now bundled by webpack and automatically rebuilt by the watcher. This should make developing more pleasant because we don't have to deal with the server cache anymore when scss style sheets are modified.

Now, the server compiles only one last style sheet: `css/icons.scss`. The icons are still compiled through the `icon-*()` scss mixins. Those could be migrated to the icon svg api but I suggest postponing the refactoring until its necessary (e.g. the server drops scss compilation).