### PR TITLE
Replace timezoneselect with timezonepicker

### DIFF
--- a/src/components/AppNavigation/Settings/SettingsTimezoneSelect.vue
+++ b/src/components/AppNavigation/Settings/SettingsTimezoneSelect.vue
@@ -21,10 +21,10 @@
 
 <template>
 	<li class="settings-fieldset-interior-item settings-fieldset-interior-item--timezone">
-		<TimezoneSelect
+		<TimezonePicker
 			:additional-timezones="additionalTimezones"
 			:value="timezone"
-			@change="setTimezoneValue" />
+			@input="setTimezoneValue" />
 	</li>
 </template>
 
@@ -33,7 +33,7 @@ import {
 	mapState,
 } from 'vuex'
 
-import TimezoneSelect from '../../Shared/TimezoneSelect.vue'
+import TimezonePicker from '@nextcloud/vue/dist/Components/TimezonePicker'
 import { detectTimezone } from '../../../services/timezoneDetectionService.js'
 import {
 	showInfo,
@@ -42,7 +42,7 @@ import {
 export default {
 	name: 'SettingsTimezoneSelect',
 	components: {
-		TimezoneSelect,
+		TimezonePicker,
 	},
 	props: {
 		isDisabled: {

--- a/src/components/Shared/DatePicker.vue
+++ b/src/components/Shared/DatePicker.vue
@@ -55,10 +55,10 @@
 						{{ $t('calendar', 'Please select a time zone:') }}
 					</strong>
 				</div>
-				<TimezoneSelect
+				<TimezonePicker
 					class="timezone-popover-wrapper__timezone-select"
 					:value="timezoneId"
-					@change="changeTimezone" />
+					@input="changeTimezone" />
 			</Popover>
 		</template>
 		<template
@@ -92,7 +92,7 @@ import {
 	showError,
 } from '@nextcloud/dialogs'
 
-import TimezoneSelect from './TimezoneSelect'
+import TimezonePicker from '@nextcloud/vue/dist/Components/TimezonePicker'
 import { getLangConfigForVue2DatePicker } from '../../utils/localization.js'
 
 export default {
@@ -100,7 +100,7 @@ export default {
 	components: {
 		DatetimePicker,
 		Popover,
-		TimezoneSelect,
+		TimezonePicker,
 	},
 	props: {
 		date: {


### PR DESCRIPTION
After moving the TimezoneSelect to vue, and renamed it TimezonePicker, we need to replace it on calendar accordingly 

- [x] Requires https://github.com/nextcloud/nextcloud-vue/pull/2095