### PR TITLE
[stable2.3] Bump calendar-js to 2f550aa99d961c78da9684f11c8f6ed4d5aae7ba

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5719,8 +5719,8 @@
 			}
 		},
 		"calendar-js": {
-			"version": "git+https://github.com/nextcloud/calendar-js.git#05f2eed720ea4191d3f6897b3f280560897d20ee",
-			"from": "git+https://github.com/nextcloud/calendar-js.git",
+			"version": "github:nextcloud/calendar-js#2f550aa99d961c78da9684f11c8f6ed4d5aae7ba",
+			"from": "github:nextcloud/calendar-js",
 			"requires": {
 				"ical.js": "^1.4.0",
 				"uuid": "^8.3.2"
@@ -5768,7 +5768,7 @@
 			"version": "git+https://github.com/nextcloud/cdav-library.git#8a8d42fad2a9bc9567b353c49559438347d110ee",
 			"from": "git+https://github.com/nextcloud/cdav-library.git",
 			"requires": {
-				"core-js": "^3.14.0",
+				"core-js": "^3.15.2",
 				"regenerator-runtime": "^0.13.7"
 			}
 		},

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
 		"@nextcloud/vue": "^3.10.1",
 		"@nextcloud/vue-dashboard": "^2.0.1",
 		"autosize": "^5.0.0",
-		"calendar-js": "git+https://github.com/nextcloud/calendar-js.git",
+		"calendar-js": "github:nextcloud/calendar-js",
 		"cdav-library": "git+https://github.com/nextcloud/cdav-library.git",
 		"closest-css-color": "^1.0.0",
 		"color-convert": "^2.0.1",


### PR DESCRIPTION
Backport of #3323