### PR TITLE
Disable calendar picker for recurrences

### DIFF
--- a/src/views/EditSidebar.vue
+++ b/src/views/EditSidebar.vue
@@ -77,7 +77,7 @@
 				v-if="showCalendarPicker"
 				:calendars="calendars"
 				:calendar="selectedCalendar"
-				:is-read-only="isReadOnly"
+				:is-read-only="isReadOnly || !canModifyCalendar"
 				@selectCalendar="changeCalendar" />
 
 			<PropertyTitleTimePicker
@@ -321,6 +321,17 @@ export default {
 			}
 
 			return moment(this.calendarObjectInstance.startDate).locale(this.locale).fromNow()
+		},
+		/**
+		 * @returns {boolean}
+		 */
+		canModifyCalendar() {
+			const eventComponent = this.calendarObjectInstance.eventComponent
+			if (!eventComponent) {
+				return true
+			}
+
+			return !eventComponent.isPartOfRecurrenceSet() || eventComponent.isExactForkOfPrimary
 		},
 	},
 	methods: {


### PR DESCRIPTION
Fixes #3351 

The calendar picker still works for the first event of a recurrence set because the "Update this and all future" button is working as expected. However, the picker is read only for all recurrences.


## Editing the first/primary event
![Screenshot 2021-07-23 at 12-25-05 April 2021 - Calendar - Nextcloud](https://user-images.githubusercontent.com/1479486/126769668-e972a7cd-a3b1-4711-87b8-6d40245eaf4c.png)

## Editing a recurrence
![Screenshot 2021-07-23 at 12-25-21 April 2021 - Calendar - Nextcloud](https://user-images.githubusercontent.com/1479486/126769670-de1863dc-3ca7-4cda-8e5e-763811f8cd66.png)
