### PR TITLE
Restrict size of text fields in event pop-up

### DIFF
--- a/css/app-sidebar.scss
+++ b/css/app-sidebar.scss
@@ -522,13 +522,16 @@
 
 			&--readonly {
 				div {
-					width: 100%;
+					width: calc(100% - 8px); /* for typical (thin) scrollbar size */
 					white-space: pre-line;
 					margin: 3px 3px 3px 0;
 					padding: 8px 7px;
 					background-color: var(--color-main-background);
 					color: var(--color-main-text);
 					outline: none;
+					overflow-y: scroll;
+					word-break: break-word; /* allows breaking on long URLs */
+					max-height: 30vh;
 				}
 
 				a.linkified {


### PR DESCRIPTION
This small styling fix prevents the description of an event
to grow uncontrollably in either width (e.g. in the
presence of a long URL that otherwise cannot go to a
newline), or height (by introducing a maximum relative to
the viewport, and scrollbar otherwise).

Signed-off-by: Matteo Settenvini <matteo.settenvini@montecristosoftware.eu>