### PR TITLE
Don't throw error when restoring a task

### DIFF
--- a/src/store/calendars.js
+++ b/src/store/calendars.js
@@ -706,8 +706,8 @@ const actions = {
 		const component = calendarObject.calendarComponent.getFirstComponent(vobject.objectType)
 		const timeRange = getters.getTimeRangeForCalendarCoveringRange(
 			vobject.calendar.id,
-			component.startDate.unixTime,
-			component.endDate.unixTime,
+			component.startDate?.unixTime,
+			component.endDate?.unixTime,
 		)
 		if (timeRange) {
 			commit('deleteFetchedTimeRangeFromCalendar', {


### PR DESCRIPTION
Tasks might not have a startDate or endDate so we need to check for that before trying to reload a time range.

Closes #3331.