### PR TITLE
Make the sidebar usable on mobile again

### DIFF
--- a/src/views/EditSidebar.vue
+++ b/src/views/EditSidebar.vue
@@ -30,6 +30,7 @@
 		:title-placeholder="$t('calendar', 'Event title')"
 		:subtitle="subTitle"
 		:empty="isLoading || isError"
+		class="calendar-app-sidebar"
 		@close="cancel"
 		@update:title="updateTitle">
 		<template v-if="isLoading">
@@ -397,5 +398,9 @@ export default {
 <style lang="scss" scoped>
 ::v-deep .app-sidebar-header__description {
 	flex-direction: column;
+}
+
+.calendar-app-sidebar {
+	height: unset;
 }
 </style>


### PR DESCRIPTION
Fix https://github.com/nextcloud/calendar/issues/3289
| Before | After |
|---|---|
| ![image](https://user-images.githubusercontent.com/42591237/126970053-1edb8131-1be3-4a4e-a013-7ade6378f967.png) | ![image](https://user-images.githubusercontent.com/42591237/126970107-f64459d7-eb49-4302-bb62-53de6b32a978.png) |

Signed-off-by: szaimen <szaimen@e.mail.de>