### PR TITLE
Make the sidebar usable on mobile again

### DIFF
--- a/css/app-sidebar.scss
+++ b/css/app-sidebar.scss
@@ -83,21 +83,29 @@
 		display: flex;
 		flex-direction: column;
 		justify-content: space-between;
+		overflow: unset !important;
+		max-height: unset !important;
 
 		&__buttons {
 			padding-top: 14px;
-			position: absolute;
+			position: fixed;
 			bottom: 0px;
 			z-index: 2;
-			width: 97%;
-			left: 0px;
+			width: calc(27vw - 11px);
+			min-width: 300px - 11px;
+			max-width: 500px - 11px;
+			right: 10px;
 			background-color: var(--color-main-background);
 			padding-left: 22px;
 			padding-right: 22px;
 
 			button {
 				width: 100%;
+				height: 44px;
 			}
+		}
+		&__content {
+			margin-bottom: 120px;
 		}
 	}
 

--- a/src/views/EditSidebar.vue
+++ b/src/views/EditSidebar.vue
@@ -398,8 +398,4 @@ export default {
 ::v-deep .app-sidebar-header__description {
 	flex-direction: column;
 }
-
-::v-deep .app-sidebar-tab__content {
-	margin-bottom: 100px;
-}
 </style>


### PR DESCRIPTION
Fix https://github.com/nextcloud/calendar/issues/3289
| Before | After |
|---|---|
| ![image](https://user-images.githubusercontent.com/42591237/127004799-a90c96c1-cede-4fcf-b0a9-fcaab09f98d2.png) | ![image](https://user-images.githubusercontent.com/42591237/127004442-902e3f33-3f95-47a9-85fc-e9dc7a27a37e.png) |

Signed-off-by: szaimen <szaimen@e.mail.de>