### PR TITLE
Use bundled version of calendar-js

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
 	"requires": true,
 	"packages": {
 		"": {
+			"name": "calendar",
 			"version": "2.3.3",
 			"license": "agpl",
 			"dependencies": {
@@ -17,7 +18,7 @@
 				"@fullcalendar/vue": "5.9.0",
 				"@nextcloud/auth": "^1.3.0",
 				"@nextcloud/axios": "^1.6.0",
-				"@nextcloud/calendar-js": "^1.1.1",
+				"@nextcloud/calendar-js": "^2.0.0",
 				"@nextcloud/dialogs": "^3.1.2",
 				"@nextcloud/event-bus": "^2.0.0",
 				"@nextcloud/initial-state": "^1.2.0",
@@ -2677,9 +2678,9 @@
 			"dev": true
 		},
 		"node_modules/@nextcloud/calendar-js": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/@nextcloud/calendar-js/-/calendar-js-1.1.1.tgz",
-			"integrity": "sha512-Uk0vuLBGkPgqLNLn+ut43MlSNu1FFMT5ke+A/yQXfdhNpriFEVOlQdj9OrJzr9KGZF7snWJvTqJIjOGvfoV6zg==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@nextcloud/calendar-js/-/calendar-js-2.0.0.tgz",
+			"integrity": "sha512-wGDDWjnXaMTJVxK2B31S0BAstN5759fptuddWRVZcFU2gEFXZyiv0iFgcbCOdAni+/Mz9rBbdV8h+TYWbst6Qg==",
 			"dependencies": {
 				"ical.js": "^1.4.0",
 				"uuid": "^8.3.2"
@@ -3035,6 +3036,19 @@
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
 			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+		},
+		"node_modules/@nextcloud/vue/node_modules/@nextcloud/calendar-js": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@nextcloud/calendar-js/-/calendar-js-1.1.1.tgz",
+			"integrity": "sha512-Uk0vuLBGkPgqLNLn+ut43MlSNu1FFMT5ke+A/yQXfdhNpriFEVOlQdj9OrJzr9KGZF7snWJvTqJIjOGvfoV6zg==",
+			"dependencies": {
+				"ical.js": "^1.4.0",
+				"uuid": "^8.3.2"
+			},
+			"engines": {
+				"node": ">=14.0.0",
+				"npm": ">=7.0.0"
+			}
 		},
 		"node_modules/@nextcloud/vue/node_modules/ansi-regex": {
 			"version": "6.0.0",
@@ -21876,9 +21890,9 @@
 			"dev": true
 		},
 		"@nextcloud/calendar-js": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/@nextcloud/calendar-js/-/calendar-js-1.1.1.tgz",
-			"integrity": "sha512-Uk0vuLBGkPgqLNLn+ut43MlSNu1FFMT5ke+A/yQXfdhNpriFEVOlQdj9OrJzr9KGZF7snWJvTqJIjOGvfoV6zg==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@nextcloud/calendar-js/-/calendar-js-2.0.0.tgz",
+			"integrity": "sha512-wGDDWjnXaMTJVxK2B31S0BAstN5759fptuddWRVZcFU2gEFXZyiv0iFgcbCOdAni+/Mz9rBbdV8h+TYWbst6Qg==",
 			"requires": {
 				"ical.js": "^1.4.0",
 				"uuid": "^8.3.2"
@@ -22096,6 +22110,15 @@
 				"vue2-datepicker": "^3.6.3"
 			},
 			"dependencies": {
+				"@nextcloud/calendar-js": {
+					"version": "1.1.1",
+					"resolved": "https://registry.npmjs.org/@nextcloud/calendar-js/-/calendar-js-1.1.1.tgz",
+					"integrity": "sha512-Uk0vuLBGkPgqLNLn+ut43MlSNu1FFMT5ke+A/yQXfdhNpriFEVOlQdj9OrJzr9KGZF7snWJvTqJIjOGvfoV6zg==",
+					"requires": {
+						"ical.js": "^1.4.0",
+						"uuid": "^8.3.2"
+					}
+				},
 				"ansi-regex": {
 					"version": "6.0.0",
 					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
 		"@fullcalendar/vue": "5.9.0",
 		"@nextcloud/auth": "^1.3.0",
 		"@nextcloud/axios": "^1.6.0",
-		"@nextcloud/calendar-js": "^1.1.1",
+		"@nextcloud/calendar-js": "^2.0.0",
 		"@nextcloud/dialogs": "^3.1.2",
 		"@nextcloud/event-bus": "^2.0.0",
 		"@nextcloud/initial-state": "^1.2.0",
@@ -109,7 +109,8 @@
 			"vue"
 		],
 		"moduleNameMapper": {
-			"^@/(.*)$": "<rootDir>/src/$1"
+			"^@/(.*)$": "<rootDir>/src/$1",
+			"^ical.js": "<rootDir>/node_modules/ical.js"
 		},
 		"transform": {
 			".*\\.js$": "<rootDir>/node_modules/babel-jest",
@@ -132,7 +133,7 @@
 			"clover"
 		],
 		"transformIgnorePatterns": [
-			"/node_modules/(?!(@nextcloud/calendar-js)|(@fullcalendar)).+\\.js$"
+			"/node_modules/(?!(@fullcalendar)).+\\.js$"
 		],
 		"setupFilesAfterEnv": [
 			"./tests/javascript/jest.setup.js",

--- a/src/components/Shared/TimezoneSelect.vue
+++ b/src/components/Shared/TimezoneSelect.vue
@@ -14,7 +14,7 @@
 </template>
 
 <script>
-import { getReadableTimezoneName, getSortedTimezoneList } from '@nextcloud/calendar-js/src/timezones/utils'
+import { getReadableTimezoneName, getSortedTimezoneList } from '@nextcloud/calendar-js'
 import Multiselect from '@nextcloud/vue/dist/Components/Multiselect'
 import { translate as t } from '@nextcloud/l10n'
 

--- a/src/fullcalendar/duration.js
+++ b/src/fullcalendar/duration.js
@@ -16,7 +16,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import DurationValue from '@nextcloud/calendar-js/src/values/durationValue'
+import { DurationValue } from '@nextcloud/calendar-js'
 
 /**
  * Gets a calendar-js DurationValue from a FullCalendar Duration object

--- a/src/fullcalendar/eventSources/freeBusyBlockedForAllEventSource.js
+++ b/src/fullcalendar/eventSources/freeBusyBlockedForAllEventSource.js
@@ -19,11 +19,9 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 import getTimezoneManager from '../../services/timezoneDataProviderService.js'
-import { createFreeBusyRequest, getParserManager } from '@nextcloud/calendar-js'
-import DateTimeValue from '@nextcloud/calendar-js/src/values/dateTimeValue.js'
+import { createFreeBusyRequest, getParserManager, AttendeeProperty, DateTimeValue } from '@nextcloud/calendar-js'
 import { findSchedulingOutbox } from '../../services/caldavService.js'
 import logger from '../../utils/logger.js'
-import AttendeeProperty from '@nextcloud/calendar-js/src/properties/attendeeProperty.js'
 
 /**
  * Returns an event source for free-busy

--- a/src/fullcalendar/eventSources/freeBusyResourceEventSource.js
+++ b/src/fullcalendar/eventSources/freeBusyResourceEventSource.js
@@ -17,12 +17,10 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 import getTimezoneManager from '../../services/timezoneDataProviderService.js'
-import { createFreeBusyRequest } from '@nextcloud/calendar-js'
-import DateTimeValue from '@nextcloud/calendar-js/src/values/dateTimeValue.js'
+import { createFreeBusyRequest, AttendeeProperty, DateTimeValue } from '@nextcloud/calendar-js'
 import { findSchedulingOutbox } from '../../services/caldavService.js'
 import freeBusyResourceEventSourceFunction from './freeBusyResourceEventSourceFunction.js'
 import logger from '../../utils/logger.js'
-import AttendeeProperty from '@nextcloud/calendar-js/src/properties/attendeeProperty.js'
 
 /**
  * Returns an event source for free-busy

--- a/src/models/event.js
+++ b/src/models/event.js
@@ -18,7 +18,7 @@
  */
 
 import { getDateFromDateTimeValue } from '../utils/date.js'
-import DurationValue from '@nextcloud/calendar-js/src/values/durationValue.js'
+import { DurationValue } from '@nextcloud/calendar-js'
 import { getHexForColorName } from '../utils/color.js'
 import { mapAlarmComponentToAlarmObject } from './alarm.js'
 import { mapAttendeePropertyToAttendeeObject } from './attendee.js'

--- a/src/store/calendarObjectInstance.js
+++ b/src/store/calendarObjectInstance.js
@@ -21,11 +21,7 @@ import getTimezoneManager from '../services/timezoneDataProviderService'
 import {
 	getDateFromDateTimeValue,
 } from '../utils/date.js'
-import DurationValue from '@nextcloud/calendar-js/src/values/durationValue.js'
-import AttendeeProperty from '@nextcloud/calendar-js/src/properties/attendeeProperty.js'
-import DateTimeValue from '@nextcloud/calendar-js/src/values/dateTimeValue.js'
-import RecurValue from '@nextcloud/calendar-js/src/values/recurValue.js'
-import Property from '@nextcloud/calendar-js/src/properties/property.js'
+import { AttendeeProperty, Property, DateTimeValue, DurationValue, RecurValue } from '@nextcloud/calendar-js'
 import { getBySetPositionAndBySetFromDate, getWeekDayFromDate } from '../utils/recurrence.js'
 import {
 	getDefaultEventObject,

--- a/src/store/calendarObjects.js
+++ b/src/store/calendarObjects.js
@@ -21,11 +21,11 @@
 import Vue from 'vue'
 import { mapCalendarJsToCalendarObject } from '../models/calendarObject'
 import logger from '../utils/logger.js'
-import DateTimeValue from '@nextcloud/calendar-js/src/values/dateTimeValue'
 import {
 	createEvent,
 	getParserManager,
 	getTimezoneManager,
+	DateTimeValue,
 } from '@nextcloud/calendar-js'
 
 const state = {

--- a/src/store/calendars.js
+++ b/src/store/calendars.js
@@ -35,8 +35,7 @@ import pLimit from 'p-limit'
 import { uidToHexColor } from '../utils/color.js'
 import { translate as t } from '@nextcloud/l10n'
 import getTimezoneManager from '../services/timezoneDataProviderService.js'
-import Timezone from '@nextcloud/calendar-js/src/timezones/timezone.js'
-import CalendarComponent from '@nextcloud/calendar-js/src/components/calendarComponent.js'
+import { CalendarComponent, Timezone } from '@nextcloud/calendar-js'
 import {
 	CALDAV_BIRTHDAY_CALENDAR,
 	IMPORT_STAGE_IMPORTING,

--- a/src/utils/calendarObject.js
+++ b/src/utils/calendarObject.js
@@ -16,7 +16,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-import DateTimeValue from '@nextcloud/calendar-js/src/values/dateTimeValue.js'
+import { DateTimeValue } from '@nextcloud/calendar-js'
 
 /**
  * Get all recurrence-items in given range

--- a/tests/assets/loadAsset.js
+++ b/tests/assets/loadAsset.js
@@ -20,10 +20,7 @@
  *
  */
 import ICAL from 'ical.js'
-import AlarmComponent from '@nextcloud/calendar-js/src/components/nested/alarmComponent.js'
-import AttendeeProperty from "@nextcloud/calendar-js/src/properties/attendeeProperty.js";
-import RecurValue from "@nextcloud/calendar-js/src/values/recurValue.js";
-import {getParserManager} from "@nextcloud/calendar-js";
+import { AlarmComponent, AttendeeProperty, RecurValue, getParserManager } from '@nextcloud/calendar-js'
 
 const fs = require('fs')
 

--- a/tests/javascript/unit/models/calendarObject.test.js
+++ b/tests/javascript/unit/models/calendarObject.test.js
@@ -24,9 +24,7 @@ import {
 	mapCalendarJsToCalendarObject,
 	mapCDavObjectToCalendarObject
 } from "../../../../src/models/calendarObject.js";
-import CalendarComponent from '@nextcloud/calendar-js/src/components/calendarComponent.js'
-import FreeBusyComponent from '@nextcloud/calendar-js/src/components/root/freeBusyComponent.js'
-import {getParserManager} from "@nextcloud/calendar-js";
+import {CalendarComponent, FreeBusyComponent, getParserManager} from "@nextcloud/calendar-js";
 
 describe('Test suite: Calendar object model (models/calendarObject.js)', () => {
 

--- a/tests/javascript/unit/models/event.test.js
+++ b/tests/javascript/unit/models/event.test.js
@@ -26,7 +26,7 @@ import { getHexForColorName } from '../../../../src/utils/color.js'
 import { mapAlarmComponentToAlarmObject } from '../../../../src/models/alarm.js'
 import { mapAttendeePropertyToAttendeeObject } from '../../../../src/models/attendee.js'
 import { getDefaultRecurrenceRuleObject, mapRecurrenceRuleValueToRecurrenceRuleObject } from '../../../../src/models/recurrenceRule.js'
-import DateTimeValue from "@nextcloud/calendar-js/src/values/dateTimeValue.js";
+import { DateTimeValue } from "@nextcloud/calendar-js";
 
 jest.mock('../../../../src/utils/date.js')
 jest.mock('../../../../src/utils/color.js')

--- a/tests/javascript/unit/models/recurrenceRule.test.js
+++ b/tests/javascript/unit/models/recurrenceRule.test.js
@@ -25,7 +25,7 @@ import {
 	mapRecurrenceRuleValueToRecurrenceRuleObject
 } from "../../../../src/models/recurrenceRule.js";
 import { getDateFromDateTimeValue } from '../../../../src/utils/date.js'
-import DateTimeValue from "@nextcloud/calendar-js/src/values/dateTimeValue.js";
+import { DateTimeValue } from "@nextcloud/calendar-js";
 
 jest.mock('../../../../src/utils/date.js')
 

--- a/tests/javascript/unit/models/schedulingObject.test.js
+++ b/tests/javascript/unit/models/schedulingObject.test.js
@@ -25,8 +25,7 @@ import {
 	mapCalendarJsToSchedulingObject,
 	mapCDavObjectToSchedulingObject
 } from "../../../../src/models/schedulingObject.js";
-import CalendarComponent from "@nextcloud/calendar-js/src/components/calendarComponent.js";
-import {getParserManager} from "@nextcloud/calendar-js";
+import {CalendarComponent, getParserManager} from "@nextcloud/calendar-js";
 
 describe('Test suite: Scheduling Object model (models/schedulingObject.js)', () => {
 

--- a/webpack.js
+++ b/webpack.js
@@ -20,7 +20,6 @@ webpackRules.RULE_JS.exclude = BabelLoaderExcludeNodeModulesExcept([
 	'p-queue',
 	'p-try',
 	'cdav-library',
-	'calendar-js',
 ])
 
 // Edit SCSS rule


### PR DESCRIPTION
- [x] Requires https://github.com/nextcloud/calendar-js/pull/274

I updated all imports and fixed jest in preparation for the upcoming bundled release of calendar-js.

Until the new version is released on npm, you have to checkout my branch manually and then install it by running `npm install /path/to/cloned/and/built/calendar-js`.