### PR TITLE
Fix fetching language from DAV attendee

### DIFF
--- a/src/components/Editor/Invitees/InviteesListSearch.vue
+++ b/src/components/Editor/Invitees/InviteesListSearch.vue
@@ -216,7 +216,7 @@ export default {
 					commonName: principal.displayname,
 					calendarUserType: principal.calendarUserType,
 					email: principal.email,
-					lang: null,
+					language: principal.language,
 					isUser: principal.calendarUserType === 'INDIVIDUAL',
 					avatar: principal.userId,
 					hasMultipleEMails: false,


### PR DESCRIPTION
Closes #3414

* [x] Requires https://github.com/nextcloud/server/pull/28458 in server
* [x] Requires `npm link` to https://github.com/nextcloud/cdav-library/pull/534 via #3423