### PR TITLE
Use material-design-icons

### DIFF
--- a/css/app-navigation.scss
+++ b/css/app-navigation.scss
@@ -171,6 +171,7 @@
 
 		.avatar.published {
 			background-color: var(--color-primary);
+			color: white;
 		}
 	}
 

--- a/css/app-settings.scss
+++ b/css/app-settings.scss
@@ -52,6 +52,11 @@
 			display: block;
 			text-align: center;
 			background-position-x: 8px;
+			position: relative;
+
+			.material-design-icon {
+				position: absolute;
+			}
 		}
 
 		&--slotDuration,

--- a/css/app-sidebar.scss
+++ b/css/app-sidebar.scss
@@ -533,10 +533,11 @@
 		&__info {
 			height: 34px;
 			width: 34px;
-			margin-top: 5px;
 		}
 
 		&__info {
+			display: flex;
+			justify-content: center;
 			opacity: .5;
 		}
 

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
 		"vue": "^2.6.12",
 		"vue-click-outside": "^1.1.0",
 		"vue-clipboard2": "^0.3.2",
+		"vue-material-design-icons": "^4.12.1",
 		"vue-router": "^3.5.2",
 		"vue-shortkey": "^3.1.7",
 		"vuedraggable": "^2.24.3",

--- a/src/components/AppNavigation/AppNavigationHeader/AppNavigationHeaderViewMenu.vue
+++ b/src/components/AppNavigation/AppNavigationHeader/AppNavigationHeaderViewMenu.vue
@@ -22,14 +22,19 @@
 <template>
 	<Actions
 		v-shortkey="shortKeyConf"
-		:default-icon="defaultIcon"
 		menu-align="right"
 		@shortkey.native="selectViewFromShortcut">
+		<template #icon>
+			<component :is="defaultIcon" :size="20" decorative />
+		</template>
 		<ActionButton
 			v-for="view in views"
 			:key="view.id"
 			:icon="view.icon"
 			@click="selectView(view.id)">
+			<template #icon>
+				<component :is="view.icon" :size="20" decorative />
+			</template>
 			{{ view.label }}
 		</ActionButton>
 	</Actions>
@@ -39,29 +44,40 @@
 import Actions from '@nextcloud/vue/dist/Components/Actions'
 import ActionButton from '@nextcloud/vue/dist/Components/ActionButton'
 
+import ViewDay from 'vue-material-design-icons/ViewDay.vue'
+import ViewGrid from 'vue-material-design-icons/ViewGrid.vue'
+import ViewList from 'vue-material-design-icons/ViewList.vue'
+import ViewModule from 'vue-material-design-icons/ViewModule.vue'
+import ViewWeek from 'vue-material-design-icons/ViewWeek.vue'
+
 export default {
 	name: 'AppNavigationHeaderViewMenu',
 	components: {
 		Actions,
 		ActionButton,
+		ViewDay,
+		ViewGrid,
+		ViewList,
+		ViewModule,
+		ViewWeek,
 	},
 	computed: {
 		views() {
 			return [{
 				id: 'timeGridDay',
-				icon: 'icon-view-day',
+				icon: 'ViewDay',
 				label: this.$t('calendar', 'Day'),
 			}, {
 				id: 'timeGridWeek',
-				icon: 'icon-view-week',
+				icon: 'ViewWeek',
 				label: this.$t('calendar', 'Week'),
 			}, {
 				id: 'dayGridMonth',
-				icon: 'icon-view-module',
+				icon: 'ViewModule',
 				label: this.$t('calendar', 'Month'),
 			}, {
 				id: 'listMonth',
-				icon: 'icon-view-list',
+				icon: 'ViewList',
 				label: this.$t('calendar', 'List'),
 			}]
 		},
@@ -84,7 +100,7 @@ export default {
 				}
 			}
 
-			return 'icon-toggle-pictures'
+			return 'ViewGrid'
 		},
 	},
 	methods: {

--- a/src/components/AppNavigation/CalendarList/CalendarListItemSharingPublishItem.vue
+++ b/src/components/AppNavigation/CalendarList/CalendarListItemSharingPublishItem.vue
@@ -24,18 +24,26 @@
 		:title="$t('calendar', 'Share link')"
 		:menu-open.sync="menuOpen">
 		<template slot="icon">
-			<div :class="{published: isPublished, 'icon-public': !isPublished, 'icon-public-white': isPublished}" class="avatar" />
+			<LinkVariant
+				:class="{published: isPublished}"
+				:size="18"
+				decorative
+				class="avatar" />
 		</template>
 
 		<template v-if="!isPublished" slot="actions">
 			<ActionButton
 				v-if="!publishingCalendar"
-				icon="icon-add"
+				key="publish"
 				@click.prevent.stop="publishCalendar">
+				<template #icon>
+					<Plus :size="20" decorative />
+				</template>
 				{{ $t('calendar', 'Publish calendar') }}
 			</ActionButton>
 			<ActionButton
-				v-if="publishingCalendar"
+				v-else
+				key="publishing"
 				icon="icon-loading-small"
 				:disabled="true">
 				{{ $t('calendar', 'Publishing calendar') }}
@@ -45,8 +53,10 @@
 		<template v-if="isPublished" slot="counter">
 			<Actions>
 				<ActionButton
-					icon="icon-clippy"
 					@click.prevent.stop="copyPublicLink">
+					<template #icon>
+						<ClipboardArrowLeftOutline :size="20" decorative />
+					</template>
 					{{ $t('calendar', 'Copy public link') }}
 				</ActionButton>
 			</Actions>
@@ -54,14 +64,18 @@
 		<template v-if="isPublished" slot="actions">
 			<ActionButton
 				v-if="showEMailLabel"
-				icon="icon-mail"
 				@click.prevent.stop="openEMailLinkInput">
+				<template #icon>
+					<Email :size="20" decorative />
+				</template>
 				{{ $t('calendar', 'Send link to calendar via email') }}
 			</ActionButton>
 			<ActionInput
 				v-if="showEMailInput"
-				icon="icon-mail"
 				@submit.prevent.stop="sendLinkViaEMail">
+				<template #icon>
+					<Email :size="20" decorative />
+				</template>
 				{{ $t('calendar', 'Enter one address') }}
 			</ActionInput>
 			<ActionText
@@ -73,8 +87,10 @@
 
 			<ActionButton
 				v-if="showCopySubscriptionLinkLabel"
-				icon="icon-calendar-dark"
 				@click.prevent.stop="copySubscriptionLink">
+				<template #icon>
+					<CalendarBlank :size="20" decorative />
+				</template>
 				{{ $t('calendar', 'Copy subscription link') }}
 			</ActionButton>
 			<ActionText
@@ -86,11 +102,16 @@
 			<ActionText
 				v-if="showCopySubscriptionLinkSuccess"
 				icon="icon-calendar-dark">
+				<template #icon>
+					<CalendarBlank :size="20" decorative />
+				</template>
 				{{ $t('calendar', 'Copied link') }}
 			</ActionText>
 			<ActionText
-				v-if="showCopySubscriptionLinkError"
-				icon="icon-calendar-dark">
+				v-if="showCopySubscriptionLinkError">
+				<template #icon>
+					<CalendarBlank :size="20" decorative />
+				</template>
 				{{ $t('calendar', 'Could not copy link') }}
 			</ActionText>
 
@@ -98,6 +119,9 @@
 				v-if="showCopyEmbedCodeLinkLabel"
 				icon="icon-embed"
 				@click.prevent.stop="copyEmbedCode">
+				<template #icon>
+					<CodeBrackets :size="20" decorative />
+				</template>
 				{{ $t('calendar', 'Copy embedding code') }}
 			</ActionButton>
 			<ActionText
@@ -112,15 +136,19 @@
 				{{ $t('calendar', 'Copied code') }}
 			</ActionText>
 			<ActionText
-				v-if="showCopyEmbedCodeLinkError"
-				icon="icon-embed">
+				v-if="showCopyEmbedCodeLinkError">
+				<template #icon>
+					<CodeBrackets :size="20" decorative />
+				</template>
 				{{ $t('calendar', 'Could not copy code') }}
 			</ActionText>
 
 			<ActionButton
 				v-if="!unpublishingCalendar"
-				icon="icon-delete"
 				@click.prevent.stop="unpublishCalendar">
+				<template #icon>
+					<Delete :size="20" decorative />
+				</template>
 				{{ $t('calendar', 'Delete share link') }}
 			</ActionButton>
 			<ActionText
@@ -151,6 +179,14 @@ import {
 } from '@nextcloud/dialogs'
 import HttpClient from '@nextcloud/axios'
 
+import CalendarBlank from 'vue-material-design-icons/CalendarBlank.vue'
+import ClipboardArrowLeftOutline from 'vue-material-design-icons/ClipboardArrowLeftOutline.vue'
+import CodeBrackets from 'vue-material-design-icons/CodeBrackets.vue'
+import Delete from 'vue-material-design-icons/Delete.vue'
+import Email from 'vue-material-design-icons/Email.vue'
+import LinkVariant from 'vue-material-design-icons/LinkVariant.vue'
+import Plus from 'vue-material-design-icons/Plus.vue'
+
 export default {
 	name: 'CalendarListItemSharingPublishItem',
 	components: {
@@ -159,6 +195,13 @@ export default {
 		ActionInput,
 		ActionText,
 		AppNavigationItem,
+		CalendarBlank,
+		ClipboardArrowLeftOutline,
+		CodeBrackets,
+		Delete,
+		Email,
+		LinkVariant,
+		Plus,
 	},
 	directives: {
 		ClickOutside,

--- a/src/components/AppNavigation/CalendarList/CalendarListItemSharingShareItem.vue
+++ b/src/components/AppNavigation/CalendarList/CalendarListItemSharingShareItem.vue
@@ -23,7 +23,11 @@
 	<AppNavigationItem
 		:title="sharee.displayName">
 		<template slot="icon">
-			<div v-if="sharee.isGroup" class="avatar icon-group" />
+			<AccountMultiple
+				v-if="sharee.isGroup"
+				:size="18"
+				decorative
+				class="avatar" />
 			<div v-else-if="sharee.isCircle" class="avatar icon-circle" />
 			<Avatar v-else :user="sharee.id" :display-name="sharee.displayName" />
 		</template>
@@ -39,9 +43,11 @@
 
 		<template slot="actions">
 			<ActionButton
-				icon="icon-delete"
 				:disabled="updatingSharee"
 				@click.prevent.stop="unshare">
+				<template #icon>
+					<Delete :size="20" decorative />
+				</template>
 				{{ $t('calendar', 'Unshare with {displayName}', { displayName: sharee.displayName }) }}
 			</ActionButton>
 		</template>
@@ -57,6 +63,9 @@ import {
 	showInfo,
 } from '@nextcloud/dialogs'
 
+import AccountMultiple from 'vue-material-design-icons/AccountMultiple.vue'
+import Delete from 'vue-material-design-icons/Delete.vue'
+
 export default {
 	name: 'CalendarListItemSharingShareItem',
 	components: {
@@ -64,6 +73,8 @@ export default {
 		ActionCheckbox,
 		AppNavigationItem,
 		Avatar,
+		AccountMultiple,
+		Delete,
 	},
 	props: {
 		calendar: {

--- a/src/components/AppNavigation/CalendarList/CalendarListNew.vue
+++ b/src/components/AppNavigation/CalendarList/CalendarListNew.vue
@@ -27,17 +27,25 @@
 		:menu-open.sync="isOpen"
 		menu-icon="icon-add"
 		@click.prevent.stop="toggleDialog">
+		<template #menu-icon>
+			<Plus :size="20" decorative />
+		</template>
 		<template slot="actions">
 			<ActionButton
 				v-if="showCreateCalendarLabel"
-				icon="icon-new-calendar"
 				@click.prevent.stop="openCreateCalendarInput">
+				<template #icon>
+					<CalendarBlank :size="20" decorative />
+				</template>
 				{{ $t('calendar', 'New calendar') }}
 			</ActionButton>
 			<ActionInput
 				v-if="showCreateCalendarInput"
-				icon="icon-new-calendar"
-				@submit.prevent.stop="createNewCalendar" />
+				@submit.prevent.stop="createNewCalendar">
+				<template #icon>
+					<CalendarBlank :size="20" decorative />
+				</template>
+			</ActionInput>
 			<ActionText
 				v-if="showCreateCalendarSaving"
 				icon="icon-loading-small">
@@ -47,14 +55,19 @@
 
 			<ActionButton
 				v-if="showCreateCalendarTaskListLabel"
-				icon="icon-new-calendar-with-task-list"
 				@click.prevent.stop="openCreateCalendarTaskListInput">
+				<template #icon>
+					<CalendarCheck :size="20" decorative />
+				</template>
 				{{ $t('calendar', 'New calendar with task list') }}
 			</ActionButton>
 			<ActionInput
 				v-if="showCreateCalendarTaskListInput"
-				icon="icon-new-calendar-with-task-list"
-				@submit.prevent.stop="createNewCalendarTaskList" />
+				@submit.prevent.stop="createNewCalendarTaskList">
+				<template #icon>
+					<CalendarCheck :size="20" decorative />
+				</template>
+			</ActionInput>
 			<ActionText
 				v-if="showCreateCalendarTaskListSaving"
 				icon="icon-loading-small">
@@ -64,14 +77,19 @@
 
 			<ActionButton
 				v-if="showCreateSubscriptionLabel"
-				icon="icon-public"
 				@click.prevent.stop="openCreateSubscriptionInput">
+				<template #icon>
+					<LinkVariant :size="20" decorative />
+				</template>
 				{{ $t('calendar', 'New subscription from link (read-only)') }}
 			</ActionButton>
 			<ActionInput
 				v-if="showCreateSubscriptionInput"
-				icon="icon-public"
-				@submit.prevent.stop="createNewSubscription" />
+				@submit.prevent.stop="createNewSubscription">
+				<template #icon>
+					<LinkVariant :size="20" decorative />
+				</template>
+			</ActionInput>
 			<ActionText
 				v-if="showCreateSubscriptionSaving"
 				icon="icon-loading-small">
@@ -93,6 +111,11 @@ import {
 
 import { uidToHexColor } from '../../../utils/color.js'
 
+import CalendarBlank from 'vue-material-design-icons/CalendarBlank.vue'
+import CalendarCheck from 'vue-material-design-icons/CalendarCheck.vue'
+import LinkVariant from 'vue-material-design-icons/LinkVariant.vue'
+import Plus from 'vue-material-design-icons/Plus.vue'
+
 export default {
 	name: 'CalendarListNew',
 	components: {
@@ -100,6 +123,10 @@ export default {
 		ActionInput,
 		ActionText,
 		AppNavigationItem,
+		CalendarBlank,
+		CalendarCheck,
+		LinkVariant,
+		Plus,
 	},
 	data() {
 		return {

--- a/src/components/AppNavigation/CalendarList/PublicCalendarListItem.vue
+++ b/src/components/AppNavigation/CalendarList/PublicCalendarListItem.vue
@@ -42,8 +42,10 @@
 		<template slot="actions">
 			<ActionButton
 				v-if="showCopySubscriptionLinkLabel"
-				icon="icon-calendar-dark"
 				@click.prevent.stop="copySubscriptionLink">
+				<template #icon>
+					<LinkVariant :size="20" decorative />
+				</template>
 				{{ $t('calendar', 'Copy subscription link') }}
 			</ActionButton>
 			<ActionText
@@ -53,20 +55,26 @@
 				{{ $t('calendar', 'Copying link …') }}
 			</ActionText>
 			<ActionText
-				v-if="showCopySubscriptionLinkSuccess"
-				icon="icon-calendar-dark">
+				v-if="showCopySubscriptionLinkSuccess">
+				<template #icon>
+					<LinkVariant :size="20" decorative />
+				</template>
 				{{ $t('calendar', 'Copied link') }}
 			</ActionText>
 			<ActionText
-				v-if="showCopySubscriptionLinkError"
-				icon="icon-calendar-dark">
+				v-if="showCopySubscriptionLinkError">
+				<template #icon>
+					<LinkVariant :size="20" decorative />
+				</template>
 				{{ $t('calendar', 'Could not copy link') }}
 			</ActionText>
 
 			<ActionLink
-				icon="icon-download"
 				target="_blank"
 				:href="downloadUrl">
+				<template #icon>
+					<Download :size="20" decorative />
+				</template>
 				{{ $t('calendar', 'Download') }}
 			</ActionLink>
 		</template>
@@ -88,6 +96,9 @@ import {
 	showError,
 } from '@nextcloud/dialogs'
 
+import Download from 'vue-material-design-icons/Download.vue'
+import LinkVariant from 'vue-material-design-icons/LinkVariant.vue'
+
 export default {
 	name: 'PublicCalendarListItem',
 	components: {
@@ -97,6 +108,8 @@ export default {
 		ActionText,
 		AppNavigationIconBullet,
 		AppNavigationItem,
+		Download,
+		LinkVariant,
 	},
 	props: {
 		calendar: {

--- a/src/components/AppNavigation/CalendarList/Trashbin.vue
+++ b/src/components/AppNavigation/CalendarList/Trashbin.vue
@@ -22,8 +22,10 @@
 <template>
 	<AppNavigationItem :title="t('calendar', 'Trash bin')"
 		:pinned="true"
-		icon="icon-delete"
 		@click.prevent="onShow">
+		<template #icon>
+			<Delete :size="20" decorative />
+		</template>
 		<template #extra>
 			<Modal v-if="showModal"
 				@close="showModal = false">
@@ -39,8 +41,10 @@
 					</EmptyContent>
 					<EmptyContent
 						v-else-if="!items.length"
-						class="modal__content__empty"
-						icon="icon-delete">
+						class="modal__content__empty">
+						<template #icon>
+							<Delete :size="20" decorative />
+						</template>
 						<template #desc>
 							{{ t('calendar', 'You do not have any deleted elements.') }}
 						</template>
@@ -83,8 +87,10 @@
 
 									<Actions :force-menu="true">
 										<ActionButton
-											icon="icon-delete"
 											@click="onDeletePermanently(item)">
+											<template #icon>
+												<Delete :size="20" decorative />
+											</template>
 											{{ t('calendar','Delete permanently') }}
 										</ActionButton>
 									</Actions>
@@ -114,6 +120,8 @@ import { mapGetters } from 'vuex'
 import Moment from './Moment'
 import { uidToHexColor } from '../../../utils/color'
 
+import Delete from 'vue-material-design-icons/Delete.vue'
+
 export default {
 	name: 'Trashbin',
 	components: {
@@ -123,6 +131,7 @@ export default {
 		Moment,
 		Actions,
 		ActionButton,
+		Delete,
 	},
 	data() {
 		return {

--- a/src/components/AppNavigation/EmbedTopNavigation.vue
+++ b/src/components/AppNavigation/EmbedTopNavigation.vue
@@ -9,22 +9,32 @@
 		</div>
 		<!-- TODO have one button per calendar -->
 		<div class="embed-header__share-section">
-			<Actions default-icon="icon-download">
+			<Actions>
+				<template #icon>
+					<Download :size="20" decorative />
+				</template>
 				<ActionLink
 					v-for="calendar in subscriptions"
 					:key="calendar.id"
-					icon="icon-download"
 					target="_blank"
 					:href="calendar.url + '?export'">
+					<template #icon>
+						<Download :size="20" decorative />
+					</template>
 					{{ $t('calendar', 'Download {name}', { name: calendar.displayName || $t('calendar', 'Untitled calendar') }) }}
 				</ActionLink>
 			</Actions>
-			<Actions default-icon="icon-calendar-dark">
+			<Actions>
+				<template #icon>
+					<CalendarBlank :size="20" decorative />
+				</template>
 				<ActionButton
 					v-for="calendar in subscriptions"
 					:key="calendar.id"
-					icon="icon-calendar-dark"
 					@click.prevent.stop="copySubscriptionLink(calendar)">
+					<template #icon>
+						<CalendarBlank :size="20" decorative />
+					</template>
 					{{ $t('calendar', 'Subscribe to {name}', { name: calendar.displayName || $t('calendar', 'Untitled calendar') }) }}
 				</ActionButton>
 			</Actions>
@@ -49,6 +59,9 @@ import AppNavigationHeaderDatePicker from './AppNavigationHeader/AppNavigationHe
 import AppNavigationHeaderTodayButton from './EmbedHeader/EmbedHeaderTodayButton.vue'
 import AppNavigationHeaderViewButtons from './EmbedHeader/EmbedHeaderViewButtons.vue'
 
+import CalendarBlank from 'vue-material-design-icons/CalendarBlank.vue'
+import Download from 'vue-material-design-icons/Download.vue'
+
 export default {
 	name: 'EmbedTopNavigation',
 	components: {
@@ -58,6 +71,8 @@ export default {
 		Actions,
 		ActionButton,
 		ActionLink,
+		CalendarBlank,
+		Download,
 	},
 	computed: {
 		...mapGetters({

--- a/src/components/AppNavigation/Settings.vue
+++ b/src/components/AppNavigation/Settings.vue
@@ -90,18 +90,25 @@
 					@select="changeDefaultReminder" />
 			</li>
 			<SettingsTimezoneSelect :is-disabled="loadingCalendars" />
-			<ActionButton class="settings-fieldset-interior-item" icon="icon-clippy" @click.prevent.stop="copyPrimaryCalDAV">
+			<ActionButton @click.prevent.stop="copyPrimaryCalDAV">
+				<template #icon>
+					<ClipboardArrowLeftOutline :size="20" decorative />
+				</template>
 				{{ $t('calendar', 'Copy primary CalDAV address') }}
 			</ActionButton>
-			<ActionButton class="settings-fieldset-interior-item" icon="icon-clippy" @click.prevent.stop="copyAppleCalDAV">
+			<ActionButton @click.prevent.stop="copyAppleCalDAV">
+				<template #icon>
+					<ClipboardArrowLeftOutline :size="20" decorative />
+				</template>
 				{{ $t('calendar', 'Copy iOS/macOS CalDAV address') }}
 			</ActionButton>
 			<ActionButton
 				v-shortkey.propagate="['h']"
-				class="settings-fieldset-interior-item"
-				icon="icon-info"
 				@click.prevent.stop="showKeyboardShortcuts"
 				@shortkey.native="toggleKeyboardShortcuts">
+				<template #icon>
+					<InformationVariant :size="20" decorative />
+				</template>
 				{{ $t('calendar', 'Show keyboard shortcuts') }}
 			</ActionButton>
 			<ShortcutOverview v-if="displayKeyboardShortcuts" @close="hideKeyboardShortcuts" />
@@ -140,6 +147,9 @@ import {
 
 import { getDefaultAlarms } from '../../defaults/defaultAlarmProvider.js'
 
+import ClipboardArrowLeftOutline from 'vue-material-design-icons/ClipboardArrowLeftOutline.vue'
+import InformationVariant from 'vue-material-design-icons/InformationVariant.vue'
+
 export default {
 	name: 'Settings',
 	components: {
@@ -150,6 +160,8 @@ export default {
 		Multiselect,
 		SettingsImportSection,
 		SettingsTimezoneSelect,
+		ClipboardArrowLeftOutline,
+		InformationVariant,
 	},
 	props: {
 		loadingCalendars: {

--- a/src/components/AppNavigation/Settings/SettingsImportSection.vue
+++ b/src/components/AppNavigation/Settings/SettingsImportSection.vue
@@ -27,7 +27,8 @@
 			:max="total" />
 	</li>
 	<li v-else class="settings-fieldset-interior-item">
-		<label class="settings-fieldset-interior-item__import-button button icon icon-upload" :for="inputUid">
+		<label class="settings-fieldset-interior-item__import-button button icon" :for="inputUid">
+			<Upload :size="20" decorative />
 			{{ $n('calendar', 'Import calendar', 'Import calendars', 1) }}
 		</label>
 		<input
@@ -67,10 +68,13 @@ import {
 	IMPORT_STAGE_PROCESSING,
 } from '../../../models/consts.js'
 
+import Upload from 'vue-material-design-icons/Upload.vue'
+
 export default {
 	name: 'SettingsImportSection',
 	components: {
 		ImportScreen,
+		Upload,
 	},
 	props: {
 		isDisabled: {

--- a/src/components/Editor/Alarm/AlarmListItem.vue
+++ b/src/components/Editor/Alarm/AlarmListItem.vue
@@ -26,7 +26,7 @@
 		v-click-outside="closeAlarmEditor"
 		class="property-alarm-item">
 		<div class="property-alarm-item__icon">
-			<div class="icon" :class="icon" />
+			<component :is="icon" :size="18" class="icon" />
 		</div>
 		<div
 			v-if="!isEditing"
@@ -111,7 +111,7 @@
 					{{ $t('calendar', 'Other notification') }}
 				</ActionRadio>
 
-				<ActionSeparator />
+				<ActionSeparator v-if="!isRecurring" />
 
 				<ActionRadio
 					v-if="!isRecurring"
@@ -132,20 +132,26 @@
 
 				<ActionButton
 					v-if="canEdit && !isEditing"
-					icon="icon-edit"
 					@click.stop="toggleEditAlarm">
+					<template #icon>
+						<Pencil :size="20" decorative />
+					</template>
 					{{ $t('calendar', 'Edit time') }}
 				</ActionButton>
 				<ActionButton
 					v-if="canEdit && isEditing"
-					icon="icon-checkmark"
 					@click="toggleEditAlarm">
+					<template #icon>
+						<Check :size="20" decorative />
+					</template>
 					{{ $t('calendar', 'Save time') }}
 				</ActionButton>
 
 				<ActionButton
-					icon="icon-delete"
 					@click="removeAlarm">
+					<template #icon>
+						<Delete :size="20" decorative />
+					</template>
 					{{ $t('calendar', 'Remove reminder') }}
 				</ActionButton>
 			</Actions>
@@ -166,6 +172,14 @@ import moment from '@nextcloud/moment'
 import TimePicker from '../../Shared/TimePicker.vue'
 import DatePicker from '../../Shared/DatePicker.vue'
 
+import Bell from 'vue-material-design-icons/Bell.vue'
+import Check from 'vue-material-design-icons/Check.vue'
+import Cog from 'vue-material-design-icons/Cog.vue'
+import Delete from 'vue-material-design-icons/Delete.vue'
+import Email from 'vue-material-design-icons/Email.vue'
+import Pencil from 'vue-material-design-icons/Pencil.vue'
+import VolumeHigh from 'vue-material-design-icons/VolumeHigh.vue'
+
 export default {
 	name: 'AlarmListItem',
 	components: {
@@ -176,6 +190,13 @@ export default {
 		ActionButton,
 		ActionRadio,
 		ActionSeparator,
+		Bell,
+		Check,
+		Cog,
+		Delete,
+		Email,
+		Pencil,
+		VolumeHigh,
 	},
 	directives: {
 		ClickOutside,
@@ -259,16 +280,16 @@ export default {
 		icon() {
 			switch (this.alarm.type) {
 			case 'AUDIO':
-				return 'icon-reminder-audio'
+				return 'VolumeHigh'
 
 			case 'DISPLAY':
-				return 'icon-reminder'
+				return 'Bell'
 
 			case 'EMAIL':
-				return 'icon-reminder-mail'
+				return 'Email'
 
 			default:
-				return 'icon-settings-dark'
+				return 'Cog'
 			}
 		},
 		currentUserTimezone() {

--- a/src/components/Editor/Alarm/NoAlarmView.vue
+++ b/src/components/Editor/Alarm/NoAlarmView.vue
@@ -22,7 +22,9 @@
 
 <template>
 	<div class="editor-invitee-list-empty-message">
-		<div class="icon icon-reminder editor-invitee-list-empty-message__icon" />
+		<div class="icon editor-invitee-list-empty-message__icon">
+			<Bell :size="50" decorative />
+		</div>
 		<div class="editor-invitee-list-empty-message__caption">
 			{{ $t('calendar', 'No reminders yet') }}
 		</div>
@@ -30,7 +32,12 @@
 </template>
 
 <script>
+import Bell from 'vue-material-design-icons/Bell.vue'
+
 export default {
 	name: 'NoAlarmView',
+	components: {
+		Bell,
+	},
 }
 </script>

--- a/src/components/Editor/NoAttendeesView.vue
+++ b/src/components/Editor/NoAttendeesView.vue
@@ -23,7 +23,11 @@
 
 <template>
 	<div class="editor-reminders-list-empty-message">
-		<div class="icon icon-group editor-reminders-list-empty-message__icon" />
+		<div class="icon editor-reminders-list-empty-message__icon">
+			<slot name="icon">
+				<AccountMultiple :size="50" decorative />
+			</slot>
+		</div>
 		<div class="editor-reminders-list-empty-message__caption">
 			{{ message }}
 		</div>
@@ -31,8 +35,13 @@
 </template>
 
 <script>
+import AccountMultiple from 'vue-material-design-icons/AccountMultiple.vue'
+
 export default {
 	name: 'NoAttendeesView',
+	components: {
+		AccountMultiple,
+	},
 	props: {
 		message: {
 			type: String,

--- a/src/components/Editor/Properties/PropertyColor.vue
+++ b/src/components/Editor/Properties/PropertyColor.vue
@@ -22,10 +22,12 @@
 
 <template>
 	<div class="property-color">
-		<div
+		<component
+			:is="icon"
+			:size="20"
 			class="property-color__icon"
-			:class="icon"
-			:title="readableName" />
+			:title="readableName"
+			decorative />
 
 		<div
 			v-if="isReadOnly"
@@ -48,8 +50,10 @@
 			<Actions
 				v-if="showColorRevertButton">
 				<ActionButton
-					icon="icon-history"
 					@click.prevent.stop="deleteColor">
+					<template #icon>
+						<Undo :size="20" decorative />
+					</template>
 					{{ $t('calendar', 'Remove color') }}
 				</ActionButton>
 			</Actions>
@@ -64,12 +68,15 @@ import ActionButton from '@nextcloud/vue/dist/Components/ActionButton'
 import ColorPicker from '@nextcloud/vue/dist/Components/ColorPicker'
 import debounce from 'debounce'
 
+import Undo from 'vue-material-design-icons/Undo.vue'
+
 export default {
 	name: 'PropertyColor',
 	components: {
 		Actions,
 		ActionButton,
 		ColorPicker,
+		Undo,
 	},
 	mixins: [
 		PropertyMixin,

--- a/src/components/Editor/Properties/PropertySelect.vue
+++ b/src/components/Editor/Properties/PropertySelect.vue
@@ -22,10 +22,11 @@
 
 <template>
 	<div v-if="display" class="property-select">
-		<div
-			class="property-select__icon"
-			:class="icon"
-			:title="readableName" />
+		<component
+			:is="icon"
+			:size="20"
+			:title="readableName"
+			class="property-select__icon" />
 
 		<div
 			class="property-select__input"
@@ -47,7 +48,11 @@
 		<div
 			v-if="hasInfo"
 			v-tooltip="info"
-			class="property-select__info icon-details" />
+			class="property-select__info">
+			<InformationVariant
+				:size="20"
+				decorative />
+		</div>
 	</div>
 </template>
 
@@ -55,10 +60,13 @@
 import PropertyMixin from '../../../mixins/PropertyMixin'
 import Multiselect from '@nextcloud/vue/dist/Components/Multiselect'
 
+import InformationVariant from 'vue-material-design-icons/InformationVariant.vue'
+
 export default {
 	name: 'PropertySelect',
 	components: {
 		Multiselect,
+		InformationVariant,
 	},
 	mixins: [
 		PropertyMixin,

--- a/src/components/Editor/Properties/PropertySelectMultiple.vue
+++ b/src/components/Editor/Properties/PropertySelectMultiple.vue
@@ -22,10 +22,11 @@
 
 <template>
 	<div v-if="display" class="property-select-multiple">
-		<div
-			class="property-select-multiple__icon"
-			:class="icon"
-			:title="readableName" />
+		<component
+			:is="icon"
+			:size="20"
+			:title="readableName"
+			class="property-select-multiple__icon" />
 
 		<div
 			class="property-select-multiple__input"
@@ -63,7 +64,11 @@
 		<div
 			v-if="hasInfo"
 			v-tooltip="info"
-			class="property-select-multiple__info icon-details" />
+			class="property-select__info">
+			<InformationVariant
+				:size="20"
+				decorative />
+		</div>
 	</div>
 </template>
 
@@ -74,12 +79,15 @@ import PropertySelectMultipleColoredTag from './PropertySelectMultipleColoredTag
 import PropertySelectMultipleColoredOption from './PropertySelectMultipleColoredOption.vue'
 import { getLocale } from '@nextcloud/l10n'
 
+import InformationVariant from 'vue-material-design-icons/InformationVariant.vue'
+
 export default {
 	name: 'PropertySelectMultiple',
 	components: {
 		PropertySelectMultipleColoredOption,
 		PropertySelectMultipleColoredTag,
 		Multiselect,
+		InformationVariant,
 	},
 	mixins: [
 		PropertyMixin,

--- a/src/components/Editor/Properties/PropertyText.vue
+++ b/src/components/Editor/Properties/PropertyText.vue
@@ -22,10 +22,11 @@
 
 <template>
 	<div v-if="display" class="property-text">
-		<div
-			class="property-text__icon"
-			:class="icon"
-			:title="readableName" />
+		<component
+			:is="icon"
+			:size="20"
+			:title="readableName"
+			class="property-text__icon" />
 
 		<div
 			class="property-text__input"
@@ -47,7 +48,11 @@
 		<div
 			v-if="hasInfo"
 			v-tooltip="info"
-			class="property-text__info icon-details" />
+			class="property-select__info">
+			<InformationVariant
+				:size="20"
+				decorative />
+		</div>
 	</div>
 </template>
 
@@ -56,11 +61,14 @@ import autosize from '../../../directives/autosize.js'
 import PropertyMixin from '../../../mixins/PropertyMixin'
 import { linkify } from '../../../directives/linkify.js'
 
+import InformationVariant from 'vue-material-design-icons/InformationVariant.vue'
+
 export default {
 	name: 'PropertyText',
 	directives: {
 		autosize,
 		linkify,
+		InformationVariant,
 	},
 	mixins: [
 		PropertyMixin,

--- a/src/components/Editor/Resources/ResourceList.vue
+++ b/src/components/Editor/Resources/ResourceList.vue
@@ -38,10 +38,18 @@
 
 		<NoAttendeesView
 			v-if="isReadOnly && isListEmpty"
-			:message="noResourcesMessage" />
+			:message="noResourcesMessage">
+			<template #icon>
+				<MapMarker :size="50" decorative />
+			</template>
+		</NoAttendeesView>
 		<NoAttendeesView
 			v-if="!isReadOnly && isListEmpty && hasUserEmailAddress"
-			:message="noResourcesMessage" />
+			:message="noResourcesMessage">
+			<template #icon>
+				<MapMarker :size="50" decorative />
+			</template>
+		</NoAttendeesView>
 		<OrganizerNoEmailError
 			v-if="!isReadOnly && isListEmpty && !hasUserEmailAddress" />
 	</div>
@@ -54,6 +62,8 @@ import ResourceListItem from './ResourceListItem'
 import OrganizerNoEmailError from '../OrganizerNoEmailError'
 import { organizerDisplayName, removeMailtoPrefix } from '../../../utils/attendee'
 
+import MapMarker from 'vue-material-design-icons/MapMarker.vue'
+
 export default {
 	name: 'ResourceList',
 	components: {
@@ -61,6 +71,7 @@ export default {
 		NoAttendeesView,
 		ResourceListSearch,
 		OrganizerNoEmailError,
+		MapMarker,
 	},
 	props: {
 		isReadOnly: {

--- a/src/components/EmptyCalendar.vue
+++ b/src/components/EmptyCalendar.vue
@@ -21,8 +21,11 @@
   -->
 
 <template>
-	<EmptyContent icon="icon-calendar-dark">
+	<EmptyContent>
 		{{ $t('calendar', 'Public calendar does not exist') }}
+		<template #icon>
+			<CalendarBlank :size="20" decorative />
+		</template>
 		<template #desc>
 			{{ $t('calendar', 'Maybe the share was deleted or has expired?' ) }}
 		</template>
@@ -31,11 +34,13 @@
 
 <script>
 import EmptyContent from '@nextcloud/vue/dist/Components/EmptyContent'
+import CalendarBlank from 'vue-material-design-icons/CalendarBlank.vue'
 
 export default {
 	name: 'EmptyCalendar',
 	components: {
 		EmptyContent,
+		CalendarBlank,
 	},
 }
 </script>

--- a/src/mixins/PropertyMixin.js
+++ b/src/mixins/PropertyMixin.js
@@ -26,7 +26,25 @@
  *
  * See inline for more documentation
  */
+
+import Briefcase from 'vue-material-design-icons/Briefcase.vue'
+import Check from 'vue-material-design-icons/Check.vue'
+import Eye from 'vue-material-design-icons/Eye.vue'
+import EyedropperVariant from 'vue-material-design-icons/EyedropperVariant.vue'
+import MapMarker from 'vue-material-design-icons/MapMarker.vue'
+import Tag from 'vue-material-design-icons/Tag.vue'
+import TextBoxOutline from 'vue-material-design-icons/TextBoxOutline.vue'
+
 export default {
+	components: {
+		Briefcase,
+		Check,
+		Eye,
+		EyedropperVariant,
+		MapMarker,
+		Tag,
+		TextBoxOutline,
+	},
 	props: {
 		/**
 		 * The prop-model object containing information about the

--- a/src/models/rfcProps.js
+++ b/src/models/rfcProps.js
@@ -34,7 +34,7 @@ const getRFCProperties = () => {
 		 */
 		accessClass: {
 			readableName: t('calendar', 'When shared show'),
-			icon: 'icon-eye',
+			icon: 'Eye',
 			options: [
 				{ value: 'PUBLIC', label: t('calendar', 'When shared show full event') },
 				{ value: 'CONFIDENTIAL', label: t('calendar', 'When shared show only busy') },
@@ -50,7 +50,7 @@ const getRFCProperties = () => {
 		location: {
 			readableName: t('calendar', 'Location'),
 			placeholder: t('calendar', 'Add a location'),
-			icon: 'icon-address',
+			icon: 'MapMarker',
 		},
 		/**
 		 * https://tools.ietf.org/html/rfc5545#section-3.8.1.5
@@ -58,7 +58,7 @@ const getRFCProperties = () => {
 		description: {
 			readableName: t('calendar', 'Description'),
 			placeholder: t('calendar', 'Add a description'),
-			icon: 'icon-menu',
+			icon: 'TextBoxOutline',
 			defaultNumberOfRows: 2,
 		},
 		/**
@@ -66,7 +66,7 @@ const getRFCProperties = () => {
 		 */
 		status: {
 			readableName: t('calendar', 'Status'),
-			icon: 'icon-checkmark',
+			icon: 'Check',
 			options: [
 				{ value: 'CONFIRMED', label: t('calendar', 'Confirmed') },
 				{ value: 'TENTATIVE', label: t('calendar', 'Tentative') },
@@ -81,7 +81,7 @@ const getRFCProperties = () => {
 		 */
 		timeTransparency: {
 			readableName: t('calendar', 'Show as'),
-			icon: 'icon-briefcase',
+			icon: 'Briefcase',
 			multiple: false,
 			info: t('calendar', 'Take this event into account when calculating free-busy information.'),
 			options: [
@@ -95,7 +95,7 @@ const getRFCProperties = () => {
 		 */
 		categories: {
 			readableName: t('calendar', 'Categories'),
-			icon: 'icon-tag',
+			icon: 'Tag',
 			multiple: true,
 			info: t('calendar', 'Categories help you to structure and organize your events.'),
 			placeholder: t('calendar', 'Search or add categories'),
@@ -107,7 +107,7 @@ const getRFCProperties = () => {
 		 */
 		color: {
 			readableName: t('calendar', 'Custom color'),
-			icon: 'icon-color-picker',
+			icon: 'EyedropperVariant',
 			multiple: false,
 			info: t('calendar', 'Special color of this event. Overrides the calendar-color.'),
 		},

--- a/src/views/EditSidebar.vue
+++ b/src/views/EditSidebar.vue
@@ -39,8 +39,11 @@
 		</template>
 
 		<template v-else-if="isError">
-			<EmptyContent icon="icon-calendar-dark">
+			<EmptyContent>
 				{{ $t('calendar', 'Event does not exist') }}
+				<template #icon>
+					<CalendarBlank :size="20" decorative />
+				</template>
 				<template #desc>
 					{{ error }}
 				</template>
@@ -55,17 +58,28 @@
 			v-if="!isLoading && !isError"
 			#secondary-actions>
 			<ActionLink v-if="hasDownloadURL"
-				icon="icon-download"
 				:href="downloadURL">
+				<template #icon>
+					<Download :size="20" decorative />
+				</template>
 				{{ $t('calendar', 'Download') }}
 			</ActionLink>
-			<ActionButton v-if="canDelete && !canCreateRecurrenceException" icon="icon-delete" @click="deleteAndLeave(false)">
+			<ActionButton v-if="canDelete && !canCreateRecurrenceException" @click="deleteAndLeave(false)">
+				<template #icon>
+					<Delete :size="20" decorative />
+				</template>
 				{{ $t('calendar', 'Delete') }}
 			</ActionButton>
-			<ActionButton v-if="canDelete && canCreateRecurrenceException" icon="icon-delete" @click="deleteAndLeave(false)">
+			<ActionButton v-if="canDelete && canCreateRecurrenceException" @click="deleteAndLeave(false)">
+				<template #icon>
+					<Delete :size="20" decorative />
+				</template>
 				{{ $t('calendar', 'Delete this occurrence') }}
 			</ActionButton>
-			<ActionButton v-if="canDelete && canCreateRecurrenceException" icon="icon-delete" @click="deleteAndLeave(true)">
+			<ActionButton v-if="canDelete && canCreateRecurrenceException" @click="deleteAndLeave(true)">
+				<template #icon>
+					<Delete :size="20" decorative />
+				</template>
 				{{ $t('calendar', 'Delete this and all future') }}
 			</ActionButton>
 		</template>
@@ -101,9 +115,11 @@
 			v-if="!isLoading && !isError"
 			id="app-sidebar-tab-details"
 			class="app-sidebar-tab"
-			icon="icon-details"
 			:name="$t('calendar', 'Details')"
 			:order="0">
+			<template #icon>
+				<InformationOutline :size="20" decorative />
+			</template>
 			<div class="app-sidebar-tab__content">
 				<PropertyText
 					:is-read-only="isReadOnly"
@@ -160,9 +176,11 @@
 			v-if="!isLoading && !isError"
 			id="app-sidebar-tab-attendees"
 			class="app-sidebar-tab"
-			icon="icon-group"
 			:name="$t('calendar', 'Attendees')"
 			:order="1">
+			<template #icon>
+				<AccountMultiple :size="20" decorative />
+			</template>
 			<div class="app-sidebar-tab__content">
 				<InviteesList
 					v-if="!isLoading"
@@ -185,6 +203,9 @@
 			icon="icon-address"
 			:name="$t('calendar', 'Resources')"
 			:order="2">
+			<template #icon>
+				<MapMarker :size="20" decorative />
+			</template>
 			<div class="app-sidebar-tab__content">
 				<ResourceList
 					v-if="!isLoading"
@@ -204,9 +225,11 @@
 			v-if="!isLoading && !isError"
 			id="app-sidebar-tab-reminders"
 			class="app-sidebar-tab"
-			icon="icon-reminder"
 			:name="$t('calendar', 'Reminders')"
 			:order="3">
+			<template #icon>
+				<Bell :size="20" decorative />
+			</template>
 			<div class="app-sidebar-tab__content">
 				<AlarmList
 					:calendar-object-instance="calendarObjectInstance"
@@ -225,9 +248,11 @@
 			v-if="!isLoading && !isError"
 			id="app-sidebar-tab-repeat"
 			class="app-sidebar-tab"
-			icon="icon-repeat"
 			:name="$t('calendar', 'Repeat')"
 			:order="4">
+			<template #icon>
+				<RepeatIcon :size="20" decorative />
+			</template>
 			<div class="app-sidebar-tab__content">
 				<!-- TODO: If not editing the master item, force updating this and all future   -->
 				<!-- TODO: You can't edit recurrence-rule of no-range recurrence-exception -->
@@ -276,6 +301,15 @@ import PropertySelectMultiple from '../components/Editor/Properties/PropertySele
 import PropertyColor from '../components/Editor/Properties/PropertyColor.vue'
 import ResourceList from '../components/Editor/Resources/ResourceList'
 
+import AccountMultiple from 'vue-material-design-icons/AccountMultiple.vue'
+import Bell from 'vue-material-design-icons/Bell.vue'
+import CalendarBlank from 'vue-material-design-icons/CalendarBlank.vue'
+import Delete from 'vue-material-design-icons/Delete.vue'
+import Download from 'vue-material-design-icons/Download.vue'
+import InformationOutline from 'vue-material-design-icons/InformationOutline.vue'
+import MapMarker from 'vue-material-design-icons/MapMarker.vue'
+import RepeatIcon from 'vue-material-design-icons/Repeat.vue'
+
 export default {
 	name: 'EditSidebar',
 	components: {
@@ -296,6 +330,14 @@ export default {
 		PropertyText,
 		PropertyTitleTimePicker,
 		Repeat,
+		AccountMultiple,
+		Bell,
+		CalendarBlank,
+		Delete,
+		Download,
+		InformationOutline,
+		MapMarker,
+		RepeatIcon,
 	},
 	mixins: [
 		EditorMixin,

--- a/src/views/EditSimple.vue
+++ b/src/views/EditSimple.vue
@@ -37,15 +37,20 @@
 			<div class="event-popover__top-right-actions">
 				<Actions>
 					<ActionButton
-						icon="icon-close"
 						@click="cancel">
+						<template #icon>
+							<Close :size="20" decorative />
+						</template>
 						{{ $t('calendar', 'Close') }}
 					</ActionButton>
 				</Actions>
 			</div>
 
-			<EmptyContent icon="icon-calendar-dark">
+			<EmptyContent>
 				{{ $t('calendar', 'Event does not exist') }}
+				<template #icon>
+					<CalendarBlank :size="20" decorative />
+				</template>
 				<template #desc>
 					{{ error }}
 				</template>
@@ -56,15 +61,19 @@
 			<div class="event-popover__top-right-actions">
 				<Actions v-if="isReadOnly">
 					<ActionButton
-						icon="icon-fullscreen"
 						@click="showMore">
+						<template #icon>
+							<ArrowExpand :size="20" decorative />
+						</template>
 						{{ $t('calendar', 'Show more details') }}
 					</ActionButton>
 				</Actions>
 				<Actions>
 					<ActionButton
-						icon="icon-close"
 						@click="cancel">
+						<template #icon>
+							<Close :size="20" decorative />
+						</template>
 						{{ $t('calendar', 'Close') }}
 					</ActionButton>
 				</Actions>
@@ -142,6 +151,10 @@ import SaveButtons from '../components/Editor/SaveButtons.vue'
 import PopoverLoadingIndicator from '../components/Popover/PopoverLoadingIndicator.vue'
 import { getPrefixedRoute } from '../utils/router.js'
 
+import ArrowExpand from 'vue-material-design-icons/ArrowExpand.vue'
+import CalendarBlank from 'vue-material-design-icons/CalendarBlank.vue'
+import Close from 'vue-material-design-icons/Close.vue'
+
 export default {
 	name: 'EditSimple',
 	components: {
@@ -156,6 +169,9 @@ export default {
 		Actions,
 		ActionButton,
 		EmptyContent,
+		ArrowExpand,
+		CalendarBlank,
+		Close,
 	},
 	mixins: [
 		EditorMixin,

--- a/tests/javascript/unit/models/rfcProps.test.js
+++ b/tests/javascript/unit/models/rfcProps.test.js
@@ -42,7 +42,7 @@ describe('Test suite: RFC properties (models/rfcProps.js)', () => {
 
 		expect(rfcProps.accessClass).toEqual(expect.any(Object))
 		expect(rfcProps.accessClass.readableName).toEqual('When shared show')
-		expect(rfcProps.accessClass.icon).toEqual('icon-eye')
+		expect(rfcProps.accessClass.icon).toEqual('Eye')
 		expect(rfcProps.accessClass.multiple).toEqual(false)
 		expect(rfcProps.accessClass.info).toEqual('The visibility of this event in shared calendars.')
 		expect(rfcProps.accessClass.defaultValue).toEqual('PUBLIC')
@@ -55,18 +55,18 @@ describe('Test suite: RFC properties (models/rfcProps.js)', () => {
 		expect(rfcProps.location).toEqual(expect.any(Object))
 		expect(rfcProps.location.readableName).toEqual('Location')
 		expect(rfcProps.location.placeholder).toEqual('Add a location')
-		expect(rfcProps.location.icon).toEqual('icon-address')
+		expect(rfcProps.location.icon).toEqual('MapMarker')
 		expect(rfcProps.location.defaultNumberOfRows).toEqual(undefined)
 
 		expect(rfcProps.description).toEqual(expect.any(Object))
 		expect(rfcProps.description.readableName).toEqual('Description')
 		expect(rfcProps.description.placeholder).toEqual('Add a description')
-		expect(rfcProps.description.icon).toEqual('icon-menu')
+		expect(rfcProps.description.icon).toEqual('TextBoxOutline')
 		expect(rfcProps.description.defaultNumberOfRows).toEqual(2)
 
 		expect(rfcProps.status).toEqual(expect.any(Object))
 		expect(rfcProps.status.readableName).toEqual('Status')
-		expect(rfcProps.status.icon).toEqual('icon-checkmark')
+		expect(rfcProps.status.icon).toEqual('Check')
 		expect(rfcProps.status.multiple).toEqual(false)
 		expect(rfcProps.status.info).toEqual('Confirmation about the overall status of the event.')
 		expect(rfcProps.status.defaultValue).toEqual('CONFIRMED')
@@ -78,7 +78,7 @@ describe('Test suite: RFC properties (models/rfcProps.js)', () => {
 
 		expect(rfcProps.timeTransparency).toEqual(expect.any(Object))
 		expect(rfcProps.timeTransparency.readableName).toEqual('Show as')
-		expect(rfcProps.timeTransparency.icon).toEqual('icon-briefcase')
+		expect(rfcProps.timeTransparency.icon).toEqual('Briefcase')
 		expect(rfcProps.timeTransparency.multiple).toEqual(false)
 		expect(rfcProps.timeTransparency.info).toEqual('Take this event into account when calculating free-busy information.')
 		expect(rfcProps.timeTransparency.defaultValue).toEqual('TRANSPARENT')
@@ -89,7 +89,7 @@ describe('Test suite: RFC properties (models/rfcProps.js)', () => {
 
 		expect(rfcProps.categories).toEqual(expect.any(Object))
 		expect(rfcProps.categories.readableName).toEqual('Categories')
-		expect(rfcProps.categories.icon).toEqual('icon-tag')
+		expect(rfcProps.categories.icon).toEqual('Tag')
 		expect(rfcProps.categories.multiple).toEqual(true)
 		expect(rfcProps.categories.info).toEqual('Categories help you to structure and organize your events.')
 		expect(rfcProps.categories.placeholder).toEqual('Search or add categories')
@@ -99,7 +99,7 @@ describe('Test suite: RFC properties (models/rfcProps.js)', () => {
 		expect(rfcProps.color).toEqual(expect.any(Object))
 		expect(rfcProps.color.readableName).toEqual('Custom color')
 		expect(rfcProps.color.multiple).toEqual(false)
-		expect(rfcProps.color.icon).toEqual('icon-color-picker')
+		expect(rfcProps.color.icon).toEqual('EyedropperVariant')
 		expect(rfcProps.color.info).toEqual('Special color of this event. Overrides the calendar-color.')
 
 		// expect(translate).toHaveBeenCalledTimes(10)


### PR DESCRIPTION
All icons of the app got replaced with the material-design equivalents. This is how the main view looks now:

After:
![Screenshot 2021-09-19 at 12-49-27 Woche 35 aus 2021 - Kalender - Nextcloud](https://user-images.githubusercontent.com/2496460/133924802-a82e763b-dba8-476d-ac73-8b2798bdf647.png)

Before:
![Screenshot 2021-09-19 at 12-53-26 Woche 35 aus 2021 - Kalender - Nextcloud](https://user-images.githubusercontent.com/2496460/133924917-78eb69fc-4ce9-47c4-b08b-0e0b246a9671.png)

I think that I replaced all icons. If not, it might be best to do it in a follow up (since this PR is already quite large). 