### PR TITLE
Append the datepicker in the sidebar to body

### DIFF
--- a/src/components/Editor/Properties/PropertyTitleTimePicker.vue
+++ b/src/components/Editor/Properties/PropertyTitleTimePicker.vue
@@ -32,6 +32,7 @@
 				:timezone-id="startTimezone"
 				prefix="from"
 				:is-all-day="isAllDay"
+				:append-to-body="appendToBody"
 				:user-timezone-id="userTimezone"
 				@change="changeStart"
 				@change-timezone="changeStartTimezone" />
@@ -41,6 +42,7 @@
 				:timezone-id="endTimezone"
 				prefix="to"
 				:is-all-day="isAllDay"
+				:append-to-body="appendToBody"
 				:user-timezone-id="userTimezone"
 				@change="changeEnd"
 				@change-timezone="changeEndTimezone" />
@@ -155,6 +157,15 @@ export default {
 		userTimezone: {
 			type: String,
 			required: true,
+		},
+		/**
+		 * Whether to append the datepickers to body or not.
+		 * Necessary in the AppSidebar, otherwise it will be cut off be the
+		 * AppSidebar edges.
+		 */
+		appendToBody: {
+			type: Boolean,
+			default: false,
 		},
 	},
 	data() {

--- a/src/components/Shared/DatePicker.vue
+++ b/src/components/Shared/DatePicker.vue
@@ -35,6 +35,7 @@
 		:show-time-panel="showTimePanel"
 		:show-week-number="showWeekNumbers"
 		:use12h="showAmPm"
+		:append-to-body="appendToBody"
 		v-bind="$attrs"
 		v-on="$listeners"
 		@close="close"
@@ -129,6 +130,10 @@ export default {
 		max: {
 			type: Date,
 			default: null,
+		},
+		appendToBody: {
+			type: Boolean,
+			default: false,
 		},
 	},
 	data() {

--- a/src/views/EditSidebar.vue
+++ b/src/views/EditSidebar.vue
@@ -89,6 +89,7 @@
 				:is-read-only="isReadOnly"
 				:can-modify-all-day="canModifyAllDay"
 				:user-timezone="currentUserTimezone"
+				:append-to-body="true"
 				@update-start-date="updateStartDate"
 				@update-start-timezone="updateStartTimezone"
 				@update-end-date="updateEndDate"


### PR DESCRIPTION
This PR appends the datepicker in the AppSidebar to body. This prevents the datepicker to be cut off.

After:
![Screenshot 2021-09-11 at 21-42-42 Woche 35 aus 2021 - Kalender - Nextcloud](https://user-images.githubusercontent.com/2496460/132959661-f008839c-67c7-4860-9b25-a8b96f52d199.png)

Before:
![Screenshot 2021-09-11 at 21-44-11 Woche 35 aus 2021 - Kalender - Nextcloud](https://user-images.githubusercontent.com/2496460/132959701-362dc8ea-e418-466f-aa9e-ecc5891f9d02.png)

Closes #2880.