### PR TITLE
Filter rooms by type and availability

### DIFF
--- a/css/app-sidebar.scss
+++ b/css/app-sidebar.scss
@@ -475,7 +475,7 @@
 	}
 
 	.resource-search {
-		&__filter {
+		&__capacity {
 			display: flex;
 			align-items: center;
 
@@ -524,7 +524,8 @@
 	.property-color,
 	.property-select-multiple,
 	.property-title,
-	.resource-capacity {
+	.resource-capacity,
+	.resource-room-type {
 		display: flex;
 		width: 100%;
 		align-items: flex-start;
@@ -643,6 +644,10 @@
 		&__input input {
 			font-size: 20px;
 		}
+	}
+
+	.resource-room-type {
+		margin-bottom: 5px;
 	}
 
 	.illustration-header {

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
 				"@nextcloud/vue": "^4.1.1",
 				"@nextcloud/vue-dashboard": "^2.0.1",
 				"autosize": "^5.0.1",
-				"cdav-library": "github:nextcloud/cdav-library#84375800890d756d45eae9f55fe1103d67fde943",
+				"cdav-library": "github:nextcloud/cdav-library#57ca862240db65dfd3326570848f06948db26435",
 				"closest-css-color": "^1.0.0",
 				"color-convert": "^2.0.1",
 				"core-js": "^3.17.3",
@@ -5210,11 +5210,11 @@
 		},
 		"node_modules/cdav-library": {
 			"version": "0.0.1",
-			"resolved": "git+ssh://git@github.com/nextcloud/cdav-library.git#84375800890d756d45eae9f55fe1103d67fde943",
-			"integrity": "sha512-rfsEMmpF0vuCnMZ4uSR5173OPbKVDzeJA46lwtHLs0/2ICwkBPLJBKNEiHdK3LU5c7uzYMero/RlhkuQ1I2Thg==",
+			"resolved": "git+ssh://git@github.com/nextcloud/cdav-library.git#57ca862240db65dfd3326570848f06948db26435",
+			"integrity": "sha512-mv6seVLPhkX8gtRLYEgrOezlGD15QgbEDRpD89zRvCu5rws7uhwwe/h6TSevJxa5qFabql/mmn0C/hXr9vFtWw==",
 			"license": "AGPL-3.0",
 			"dependencies": {
-				"core-js": "^3.17.2",
+				"core-js": "^3.17.3",
 				"regenerator-runtime": "^0.13.9"
 			},
 			"engines": {
@@ -23967,11 +23967,11 @@
 			"integrity": "sha512-cyBkXJDMeI4wthy8xJ2FvDU6+0dtcZSJW3voUF8+e9f1bBeuvyZfc3PNbkOETyhbR+dGCPzn9E7MA3iwzusOhQ=="
 		},
 		"cdav-library": {
-			"version": "git+ssh://git@github.com/nextcloud/cdav-library.git#84375800890d756d45eae9f55fe1103d67fde943",
-			"integrity": "sha512-rfsEMmpF0vuCnMZ4uSR5173OPbKVDzeJA46lwtHLs0/2ICwkBPLJBKNEiHdK3LU5c7uzYMero/RlhkuQ1I2Thg==",
-			"from": "cdav-library@github:nextcloud/cdav-library#84375800890d756d45eae9f55fe1103d67fde943",
+			"version": "git+ssh://git@github.com/nextcloud/cdav-library.git#57ca862240db65dfd3326570848f06948db26435",
+			"integrity": "sha512-mv6seVLPhkX8gtRLYEgrOezlGD15QgbEDRpD89zRvCu5rws7uhwwe/h6TSevJxa5qFabql/mmn0C/hXr9vFtWw==",
+			"from": "cdav-library@github:nextcloud/cdav-library#57ca862240db65dfd3326570848f06948db26435",
 			"requires": {
-				"core-js": "^3.17.2",
+				"core-js": "^3.17.3",
 				"regenerator-runtime": "^0.13.9"
 			}
 		},

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
 		"@nextcloud/vue": "^4.1.1",
 		"@nextcloud/vue-dashboard": "^2.0.1",
 		"autosize": "^5.0.1",
-		"cdav-library": "github:nextcloud/cdav-library#84375800890d756d45eae9f55fe1103d67fde943",
+		"cdav-library": "github:nextcloud/cdav-library#57ca862240db65dfd3326570848f06948db26435",
 		"closest-css-color": "^1.0.0",
 		"color-convert": "^2.0.1",
 		"core-js": "^3.17.3",

--- a/src/components/Editor/Resources/ResourceRoomType.vue
+++ b/src/components/Editor/Resources/ResourceRoomType.vue
@@ -1,0 +1,81 @@
+<!--
+  - @copyright Copyright (c) 2021 Richard Steinmetz <richard@steinmetz.cloud>
+  -
+  - @author Richard Steinmetz <richard@steinmetz.cloud>
+  -
+  - @license GNU AGPL version 3 or any later version
+  -
+  - This program is free software: you can redistribute it and/or modify
+  - it under the terms of the GNU Affero General Public License as
+  - published by the Free Software Foundation, either version 3 of the
+  - License, or (at your option) any later version.
+  -
+  - This program is distributed in the hope that it will be useful,
+  - but WITHOUT ANY WARRANTY; without even the implied warranty of
+  - MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  - GNU Affero General Public License for more details.
+  -
+  - You should have received a copy of the GNU Affero General Public License
+  - along with this program. If not, see <http://www.gnu.org/licenses/>.
+  -
+  -->
+
+<template>
+	<div class="resource-room-type">
+		<div class="resource-room-type__input">
+			<Multiselect
+				:value="getOption(value)"
+				:options="options"
+				:placeholder="placeholder"
+				track-by="value"
+				label="label"
+				@update:value="changeValue">
+				<template #option="{ option }">
+					<div>{{ option.label }}</div>
+				</template>
+			</Multiselect>
+		</div>
+	</div>
+</template>
+
+<script>
+import Multiselect from '@nextcloud/vue/dist/Components/Multiselect'
+import { getAllRoomTypes } from '../../../models/resourceProps'
+
+export default {
+	name: 'ResourceRoomType',
+	components: {
+		Multiselect,
+	},
+	props: {
+		value: {
+			type: String,
+			required: true,
+		},
+	},
+	computed: {
+		placeholder() {
+			return this.$t('calendar', 'Room type')
+		},
+		options() {
+			return [
+				{ value: '', label: this.$t('calendar', 'Any') },
+				...getAllRoomTypes(),
+			]
+		},
+	},
+	methods: {
+		getOption(value) {
+			// Selecting 'Any' will reset the input
+			if (value === '') {
+				return undefined
+			}
+
+			return this.options.find(option => option.value === value)
+		},
+		changeValue(option) {
+			this.$emit('update:value', option.value)
+		},
+	},
+}
+</script>

--- a/src/models/resourceProps.js
+++ b/src/models/resourceProps.js
@@ -1,0 +1,37 @@
+/**
+ * @copyright Copyright (c) 2021 Richard Steinmetz
+ *
+ * @author Richard Steinmetz <richard@steinmetz.cloud>
+ *
+ * @license AGPL-3.0-or-later
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+import { translate as t } from '@nextcloud/l10n'
+
+/**
+ * Return all supported room types
+ *
+ * @return {{label: string, value: string}[]} List of supported room types
+ */
+export function getAllRoomTypes() {
+	return [
+		{ value: 'meeting-room', label: t('calendar', 'Meeting room') },
+		{ value: 'lecture-hall', label: t('calendar', 'Lecture hall') },
+		{ value: 'seminar-room', label: t('calendar', 'Seminar room') },
+		{ value: 'other', label: t('calendar', 'Other') },
+	]
+}

--- a/src/services/caldavService.js
+++ b/src/services/caldavService.js
@@ -222,16 +222,17 @@ const principalPropertySearchByDisplaynameOrEmail = async (term) => {
 }
 
 /**
- * Performs a principal property search based on display name, capacity and features
+ * Performs a principal property search based on multiple advanced filters
  *
  * @param {object} query The destructuring query object
  * @param {string=} query.displayName The display name to search for
  * @param {number=} query.capacity The minimum required seating capacity
- * @param {Array<string>=} query.features The required features
+ * @param {string[]=} query.features The features to filter by
+ * @param {string=} query.roomType The room type to filter by
  * @return {Promise<Principal[]>}
  */
-const principalPropertySearchByDisplaynameAndCapacityAndFeatures = async (query) => {
-	return getClient().principalPropertySearchByDisplaynameAndCapacityAndFeatures(query)
+const advancedPrincipalPropertySearch = async (query) => {
+	return getClient().advancedPrincipalPropertySearch(query)
 }
 
 /**
@@ -258,6 +259,6 @@ export {
 	getBirthdayCalendar,
 	getCurrentUserPrincipal,
 	principalPropertySearchByDisplaynameOrEmail,
-	principalPropertySearchByDisplaynameAndCapacityAndFeatures,
+	advancedPrincipalPropertySearch,
 	findPrincipalByUrl,
 }


### PR DESCRIPTION
Fix #3417

~Requires https://github.com/nextcloud/cdav-library/pull/554~ via this PR

Implements filtering rooms by type and availability. The availability will be hidden from the search results if the user only searches for available rooms/resources.

I took all supported room types from https://github.com/nextcloud/calendar/issues/3184#issuecomment-872172487. Letting the user filter room types using a text input will reduce the usability. Maybe we can implement a way to define custom room types when we implement the frontend for room creation. Then we can populate the room type dropdown from the backend.