### PR TITLE
fix simple editor size

### DIFF
--- a/css/app-sidebar.scss
+++ b/css/app-sidebar.scss
@@ -557,7 +557,11 @@
 			textarea,
 			input,
 			div.multiselect {
-				width: 100%
+				width: 100%;
+			}
+
+			textarea {
+				max-height: calc(100vh - 600px);
 			}
 
 			&--readonly {


### PR DESCRIPTION
Fix https://github.com/nextcloud/calendar/issues/2200

Signed-off-by: szaimen <szaimen@e.mail.de>

<details>
<summary>For my own testing</summary>

```
docker run -it \
-e CALENDAR_BRANCH=enh/2200/fix-simple-editor-size \
-p 8443:443 \
-e TRUSTED_DOMAIN=192.168.178.34 \
--name nextcloud-easy-test \
ghcr.io/szaimen/nextcloud-easy-test:latest
```

</details>