### PR TITLE
Transpile yocto-queue

### DIFF
--- a/webpack.js
+++ b/webpack.js
@@ -20,6 +20,7 @@ webpackRules.RULE_JS.exclude = BabelLoaderExcludeNodeModulesExcept([
 	'p-queue',
 	'p-try',
 	'cdav-library',
+	'yocto-queue',
 ])
 
 // Edit SCSS rule


### PR DESCRIPTION
Ref #3412 

It breaks compatibility with Firefox < 90 which we support according to our browserslist config.

## Testing

Running `npm run dev && grep '#head' js/*.js` should only show occurrences in comments after applying this PR.