### PR TITLE
Equalize margins between properties on details tab

### DIFF
--- a/css/app-sidebar.scss
+++ b/css/app-sidebar.scss
@@ -360,7 +360,7 @@
 		}
 
 		&__label {
-			padding: 0 8px;
+			padding: 0 7px;
 			overflow: hidden;
 			white-space: nowrap;
 			text-overflow: ellipsis;
@@ -529,6 +529,7 @@
 		display: flex;
 		width: 100%;
 		align-items: flex-start;
+		margin-bottom: 5px;
 
 		&__icon,
 		&__info {
@@ -562,6 +563,8 @@
 
 			textarea {
 				max-height: calc(100vh - 600px);
+				vertical-align: top;
+				margin: 0;
 			}
 
 			&--readonly {
@@ -607,6 +610,7 @@
 			border-radius: var(--border-radius);
 			height: 34px !important;
 			width: 34px !important;
+			margin: 0;
 		}
 	}
 

--- a/src/components/Editor/Properties/PropertySelect.vue
+++ b/src/components/Editor/Properties/PropertySelect.vue
@@ -98,11 +98,9 @@ export default {
 <style lang="scss" scoped>
 
 .property-select {
-	margin-bottom: 4px;
 	&__input {
 		// 34px left and right need to be subtracted. See https://github.com/nextcloud/calendar/pull/3361
 		width: calc(100% - 34px - 34px);
-		padding-bottom: 5px;
 	}
 }
 


### PR DESCRIPTION
## Before
![Screenshot 2021-10-01 at 14-53-25 Woche 39 aus 2021 - Kalender - Nextcloud](https://user-images.githubusercontent.com/1479486/135622912-25af9360-34a3-4c92-8891-ed63898e6b49.png)

## After
![Screenshot 2021-10-01 at 14-56-39 Woche 39 aus 2021 - Kalender - Nextcloud](https://user-images.githubusercontent.com/1479486/135623292-e41be28d-4219-4314-85a7-54364fefa02f.png)

