### PR TITLE
Clean up date formatting

### DIFF
--- a/src/fullcalendar/localization/dateFormattingConfig.js
+++ b/src/fullcalendar/localization/dateFormattingConfig.js
@@ -3,6 +3,8 @@
  *
  * @author Georg Ehrke <oc.list@georgehrke.com>
  *
+ * @author Richard Steinmetz <richard@steinmetz.cloud>
+ *
  * @license AGPL-3.0-or-later
  *
  * This program is free software: you can redistribute it and/or modify
@@ -28,19 +30,32 @@
 const getDateFormattingConfig = () => {
 	return {
 		// Date formatting:
-		eventTimeFormat: 'LT',
+		eventTimeFormat: {
+			hour: '2-digit',
+			minute: '2-digit',
+		},
 		views: {
 			dayGridMonth: {
-				dayHeaderFormat: 'ddd',
-				titleFormat: 'll',
+				dayHeaderFormat: { weekday: 'short' },
+				titleFormat: { day: 'numeric' },
 			},
 			timeGridDay: {
-				dayHeaderFormat: 'ddd l',
-				titleFormat: 'll',
+				dayHeaderFormat: {
+					weekday: 'short',
+					year: 'numeric',
+					month: '2-digit',
+					day: '2-digit',
+					omitCommas: true,
+				},
 			},
 			timeGridWeek: {
-				dayHeaderFormat: 'ddd l',
-				titleFormat: 'll',
+				dayHeaderFormat: {
+					weekday: 'short',
+					year: 'numeric',
+					month: '2-digit',
+					day: '2-digit',
+					omitCommas: true,
+				},
 			},
 		},
 	}


### PR DESCRIPTION
Fix #3526 

The format syntax we used before is not documented, so I switched to the official object based configuration. The formatting of all column headers, cell headers and event times should stay the same.

However, I changed the day and month to always show 2 digits to be more in line with date formatting standards.

## Before
![Screenshot 2021-10-08 at 13-07-22 Week 40 of 2021 - Calendar - Nextcloud](https://user-images.githubusercontent.com/1479486/136546304-83cd4373-069c-42dd-ad9a-2e885597310f.png)

## After
![Screenshot 2021-10-08 at 13-06-53 Week 40 of 2021 - Calendar - Nextcloud](https://user-images.githubusercontent.com/1479486/136546294-3db75c77-66cc-4544-b818-0ae0d7c05cb7.png)
