### PR TITLE
Fix avatars not being reactive in invitee search

### DIFF
--- a/src/components/Editor/Invitees/InviteesListSearch.vue
+++ b/src/components/Editor/Invitees/InviteesListSearch.vue
@@ -33,14 +33,24 @@
 		:placeholder="placeholder"
 		:class="{ 'showContent': inputGiven, 'icon-loading': isLoading }"
 		open-direction="bottom"
-		track-by="email"
+		track-by="uid"
 		label="dropdownName"
 		@search-change="findAttendees"
 		@select="addAttendee">
 		<template #option="{ option }">
 			<div class="invitees-search-list-item">
-				<Avatar v-if="option.isUser" :user="option.avatar" :display-name="option.dropdownName" />
-				<Avatar v-if="!option.isUser" :url="option.avatar" :display-name="option.dropdownName" />
+				<!-- We need to specify a unique key here for the avatar to be reactive. -->
+				<Avatar
+					v-if="option.isUser"
+					:key="option.uid"
+					:user="option.avatar"
+					:display-name="option.dropdownName" />
+				<Avatar
+					v-else
+					:key="option.uid"
+					:url="option.avatar"
+					:display-name="option.dropdownName" />
+
 				<div class="invitees-search-list-item__label">
 					<div>
 						{{ option.dropdownName }}
@@ -122,6 +132,11 @@ export default {
 							dropdownName: query,
 						})
 					}
+				}
+
+				// Generate a unique id for every result to make the avatar components reactive
+				for (const match of matches) {
+					match.uid = Math.random().toString(16).slice(2)
 				}
 
 				this.isLoading = false


### PR DESCRIPTION
Fix #3464 

The avatars/statuses of invitee search results are not fully reactive and might not update properly if the search results change.

This one is hard to test so have a look at my recordings (and don't mind the placeholder avatars :D):

## Before
![Peek 2021-10-08 15-26](https://user-images.githubusercontent.com/1479486/136565405-76bcefbe-b208-4f1b-9b1a-b4e9c1e2c467.gif)

## After
![Peek 2021-10-08 15-24](https://user-images.githubusercontent.com/1479486/136565413-760d105e-ea6b-4e24-a4fd-83fe289b78a5.gif)