### PR TITLE
Prefill event location with room name

### DIFF
--- a/src/components/Editor/Resources/ResourceList.vue
+++ b/src/components/Editor/Resources/ResourceList.vue
@@ -107,7 +107,7 @@ export default {
 		},
 	},
 	methods: {
-		addResource({ commonName, email, calendarUserType, language, timezoneId }) {
+		addResource({ commonName, email, calendarUserType, language, timezoneId, roomAddress }) {
 			this.$store.commit('addAttendee', {
 				calendarObjectInstance: this.calendarObjectInstance,
 				commonName,
@@ -120,11 +120,32 @@ export default {
 				timezoneId,
 				organizer: this.$store.getters.getCurrentUserPrincipal,
 			})
+			this.updateLocation(roomAddress)
 		},
 		removeResource(resource) {
 			this.$store.commit('removeAttendee', {
 				calendarObjectInstance: this.calendarObjectInstance,
 				attendee: resource,
+			})
+		},
+		/**
+		 * Apply the location of the first resource to the event.
+		 * Has no effect if the location is already set or there are multiple resource.
+		 *
+		 * @param {string} location The location to apply
+		 */
+		updateLocation(location) {
+			if (this.calendarObjectInstance.location || this.calendarObjectInstance.eventComponent.location) {
+				return
+			}
+
+			if (this.resources.length !== 1) {
+				return
+			}
+
+			this.$store.commit('changeLocation', {
+				calendarObjectInstance: this.calendarObjectInstance,
+				location,
 			})
 		},
 	},

--- a/src/components/Editor/Resources/ResourceListSearch.vue
+++ b/src/components/Editor/Resources/ResourceListSearch.vue
@@ -227,6 +227,7 @@ export default {
 						displayName: principal.displayname ?? principal.email,
 						subLine: subLineData.join(' - '),
 						isAvailable: true,
+						roomAddress: principal.roomAddress,
 					}
 				})
 


### PR DESCRIPTION
Fix #3420 

Only acts if there is exactly one room specified.

**Note:** The resource search might be broken until #3534 is merged.

## How to test?

1. Create a new event.
2. Leave the location empty.
3. Add a resource with an address to the database.
4. Add the resource to the event.
5. Look at the event location on the details tab.