### PR TITLE
Add 'Written test' and 'Oral test' to exam illustration strings

### DIFF
--- a/src/utils/illustration.js
+++ b/src/utils/illustration.js
@@ -406,7 +406,9 @@ const data = [{
 		'Oral test',
 		// TRANSLATORS This string is used for matching the event title to an illustration
 		t('calendar', 'Exam'),
+		// TRANSLATORS This string is used for matching the event title to an illustration
 		t('calendar', 'Written test'),
+		// TRANSLATORS This string is used for matching the event title to an illustration
 		t('calendar', 'Oral test'),
 	],
 	illustrationNames: [


### PR DESCRIPTION
I want to add these Strings because it covers calendar titles of students with exams better.
As a german user, I noticed "Klausur" and "Kolloquium" missing, so I added the English equivalents.
I intend to add these Translations via transifex after the merge.
In some languages catching the "test" part of these two phrases may be sufficient, but since "test" has a few more meanings than exam in english I opted to specify the two phrases directly.