### PR TITLE
Do not show resource actions separator if unnecessary

### DIFF
--- a/src/components/Editor/Resources/ResourceListItem.vue
+++ b/src/components/Editor/Resources/ResourceListItem.vue
@@ -42,7 +42,7 @@
 					</template>
 					{{ $t('calendar', 'Remove resource') }}
 				</ActionButton>
-				<ActionSeparator />
+				<ActionSeparator v-if="seatingCapacity || roomType || hasProjector || hasWhiteboard || isAccessible" />
 				<ActionCaption
 					v-if="seatingCapacity"
 					:title="seatingCapacity" />


### PR DESCRIPTION
There's nothing to separate if no other actions are shown

## Before

![Bildschirmfoto von 2021-10-27 11-08-02](https://user-images.githubusercontent.com/1374172/139036262-2326e3a7-a8e4-47be-a6e1-4fb562b21a43.png)

## After

![Bildschirmfoto von 2021-10-27 11-09-17](https://user-images.githubusercontent.com/1374172/139036304-867a7561-347e-4aaa-b2d1-d85814df634a.png)

@nimishavijay as discussed :)