### PR TITLE
Show resource and room search input on top

### DIFF
--- a/src/components/Editor/Resources/ResourceListSearch.vue
+++ b/src/components/Editor/Resources/ResourceListSearch.vue
@@ -22,30 +22,6 @@
 
 <template>
 	<div class="resource-search">
-		<template v-if="hasAdvancedFilters">
-			<div class="resource-search__capacity">
-				<ResourceSeatingCapacity :value.sync="capacity" />
-				<Actions
-					v-if="hasAdvancedFilters"
-					class="resource-search__capacity__actions">
-					<ActionCheckbox :checked.sync="isAvailable">
-						<!-- Translators room or resource is not yet booked -->
-						{{ $t('calendar', 'Available') }}
-					</ActionCheckbox>
-					<ActionCheckbox :checked.sync="hasProjector">
-						{{ $t('calendar', 'Projector') }}
-					</ActionCheckbox>
-					<ActionCheckbox :checked.sync="hasWhiteboard">
-						{{ $t('calendar', 'Whiteboard') }}
-					</ActionCheckbox>
-					<ActionCheckbox :checked.sync="isAccessible">
-						{{ $t('calendar', 'Wheelchair accessible') }}
-					</ActionCheckbox>
-				</Actions>
-			</div>
-			<ResourceRoomType :value.sync="roomType" />
-		</template>
-
 		<Multiselect
 			class="resource-search__multiselect"
 			:options="matches"
@@ -82,6 +58,30 @@
 				</div>
 			</template>
 		</Multiselect>
+
+		<template v-if="hasAdvancedFilters">
+			<div class="resource-search__capacity">
+				<ResourceSeatingCapacity :value.sync="capacity" />
+				<Actions
+					v-if="hasAdvancedFilters"
+					class="resource-search__capacity__actions">
+					<ActionCheckbox :checked.sync="isAvailable">
+						<!-- Translators room or resource is not yet booked -->
+						{{ $t('calendar', 'Available') }}
+					</ActionCheckbox>
+					<ActionCheckbox :checked.sync="hasProjector">
+						{{ $t('calendar', 'Projector') }}
+					</ActionCheckbox>
+					<ActionCheckbox :checked.sync="hasWhiteboard">
+						{{ $t('calendar', 'Whiteboard') }}
+					</ActionCheckbox>
+					<ActionCheckbox :checked.sync="isAccessible">
+						{{ $t('calendar', 'Wheelchair accessible') }}
+					</ActionCheckbox>
+				</Actions>
+			</div>
+			<ResourceRoomType :value.sync="roomType" />
+		</template>
 	</div>
 </template>
 
@@ -293,3 +293,9 @@ export default {
 	},
 }
 </script>
+
+<style lang="scss" scoped>
+.resource-search__multiselect {
+	padding-bottom: 5px !important;
+}
+</style>

--- a/src/views/EditSimple.vue
+++ b/src/views/EditSimple.vue
@@ -202,7 +202,7 @@ export default {
 		CalendarBlank,
 		Close,
 		Download,
-		Delete
+		Delete,
 	},
 	mixins: [
 		EditorMixin,


### PR DESCRIPTION
Room capacity and room type are less important. They are now shown
underneath.

![Bildschirmfoto von 2021-10-27 11-49-31](https://user-images.githubusercontent.com/1374172/139042611-3ee0d558-06dc-4d89-bb2c-9bea87f31fc8.png)

As discussed with @nimishavijay 