### PR TITLE
Add REST API for appointment configs

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -56,5 +56,8 @@ return [
 		['name' => 'settings#setConfig', 'url' => '/v1/config/{key}', 'verb' => 'POST'],
 		// Tools
 		['name' => 'email#sendEmailPublicLink', 'url' => '/v1/public/sendmail', 'verb' => 'POST'],
+	],
+	'resources' => [
+		'appointmentConfig' => ['url' => 'v1/appointment_configs']
 	]
 ];

--- a/lib/Db/AppointmentConfig.php
+++ b/lib/Db/AppointmentConfig.php
@@ -30,6 +30,7 @@ namespace OCA\Calendar\Db;
 use JsonSerializable;
 use OCP\AppFramework\Db\Entity;
 use function json_decode;
+use function json_encode;
 
 /**
  * @method int getId()
@@ -139,6 +140,15 @@ class AppointmentConfig extends Entity implements JsonSerializable {
 
 	public function getCalendarFreebusyUrisAsArray(): array {
 		return json_decode($this->getCalendarFreebusyUris(), true, 512, JSON_THROW_ON_ERROR);
+	}
+
+	/**
+	 * @param string[] $uris
+	 */
+	public function setCalendarFreeBusyUrisAsArray(array $uris): self {
+		$this->setCalendarFreebusyUris(json_encode($uris));
+
+		return $this;
 	}
 
 	public function jsonSerialize() {

--- a/lib/Db/AppointmentConfigMapper.php
+++ b/lib/Db/AppointmentConfigMapper.php
@@ -44,9 +44,7 @@ class AppointmentConfigMapper extends QBMapper {
 	 * @param int $id
 	 * @param string $userId
 	 * @return AppointmentConfig
-	 * @throws DbException
 	 * @throws DoesNotExistException
-	 * @throws MultipleObjectsReturnedException
 	 */
 	public function findByIdForUser(int $id, string $userId) : AppointmentConfig {
 		$qb = $this->db->getQueryBuilder();


### PR DESCRIPTION
Fixes https://github.com/nextcloud/calendar/issues/3481

Base URL is `/apps/calendar/v1/appointment_configs`. You can `GET` it to get all configs, and `GET`, `POST` and `DELETE` a specific config at `/apps/calendar/v1/appointment_configs/123`.