### PR TITLE
Fix time zone handling for appointment slots

### DIFF
--- a/lib/Controller/BookingController.php
+++ b/lib/Controller/BookingController.php
@@ -71,7 +71,6 @@ class BookingController extends Controller {
 	 */
 	public function getBookableSlots(int $appointmentConfigId,
 									 int $startTime,
-									 int $endTime,
 									 string $timeZone): JsonResponse {
 		// Convert the timestamps to the beginning and end of the respective day in the specified timezone
 		$tz = new DateTimeZone($timeZone);
@@ -81,7 +80,7 @@ class BookingController extends Controller {
 			->setTime(0, 0)
 			->getTimestamp();
 		$endTimeInTz = (new DateTimeImmutable())
-			->setTimestamp($endTime)
+			->setTimestamp($startTime)
 			->setTimezone($tz)
 			->setTime(23, 59, 59)
 			->getTimestamp();

--- a/src/services/appointmentService.js
+++ b/src/services/appointmentService.js
@@ -23,14 +23,12 @@ import { generateUrl } from '@nextcloud/router'
 /**
  * @param config {object} the appointment config object
  * @param start {Number} interval start time as unix timestamp
- * @param end {Number} interval end time as unix timestamp
  * @param timeZone {String} target time zone for the time stamps
  */
-export async function findSlots(config, start, end, timeZone) {
+export async function findSlots(config, start, timeZone) {
 	const url = generateUrl('/apps/calendar/appointment/{id}/slots?startTime={start}&endTime={end}&timeZone={timeZone}', {
 		id: config.id,
 		start,
-		end,
 		timeZone,
 	})
 

--- a/src/views/Appointments/Booking.vue
+++ b/src/views/Appointments/Booking.vue
@@ -131,15 +131,11 @@ export default {
 			this.loadingSlots = true
 
 			const startOfDay = new Date(this.selectedDate.getTime())
-			startOfDay.setUTCHours(0, 0, 0, 0)
-			const endOfDay = new Date(this.selectedDate.getTime())
-			endOfDay.setUTCHours(23, 59, 59, 999)
 
 			try {
 				this.slots = await findSlots(
 					this.config,
 					Math.round(startOfDay.getTime() / 1000),
-					Math.round(endOfDay.getTime() / 1000),
 					this.timeZone,
 				)
 			} catch (e) {


### PR DESCRIPTION
If we push to the start of the day in UTC and then in the respective time zone, we might shift by two days. This is testable if you provide slots in UTC but book in Auckland time. November 4th slots are requested but November 2n is where the first one started.