### PR TITLE
Show room suggestions for events

### DIFF
--- a/src/components/Editor/AvatarParticipationStatus.vue
+++ b/src/components/Editor/AvatarParticipationStatus.vue
@@ -26,9 +26,9 @@
 			:disable-tooltip="true"
 			:user="avatarLink"
 			:is-no-user="isResource" />
-		<div class="avatar-participation-status__indicator" :class="className.class" />
+		<div class="avatar-participation-status__indicator" :class="status.indicatorClass" />
 		<div class="avatar-participation-status__text">
-			{{ className.label }}
+			{{ status.label }}
 		</div>
 	</div>
 </template>
@@ -62,6 +62,10 @@ export default {
 			type: Boolean,
 			required: true,
 		},
+		isSuggestion: {
+			type: Boolean,
+			default: false,
+		},
 		attendeeIsOrganizer: {
 			type: Boolean,
 			required: true,
@@ -72,36 +76,42 @@ export default {
 		},
 	},
 	computed: {
-		className() {
+		status() {
+			if (this.isSuggestion) {
+				return {
+					indicatorClass: ['accepted', 'icon', 'icon-checkmark-white'],
+					label: t('calendar', 'Suggested.'),
+				}
+			}
 
 			if (this.isResource && this.participationStatus === 'ACCEPTED') {
 				return {
-					class: ['accepted', 'icon', 'icon-checkmark-white'],
+					indicatorClass: ['accepted', 'icon', 'icon-checkmark-white'],
 					label: t('calendar', 'Available.'),
 				}
 			}
 			if (this.isResource && this.participationStatus === 'DECLINED') {
 				return {
-					class: ['declined', 'icon', 'icon-close-white'],
+					indicatorClass: ['declined', 'icon', 'icon-close-white'],
 					label: t('calendar', 'Not available.'),
 				}
 			}
 			if (this.isResource) {
 				return {
-					class: ['no-response', 'icon', 'icon-invitees-no-response-white'],
+					indicatorClass: ['no-response', 'icon', 'icon-invitees-no-response-white'],
 					label: t('calendar', 'Checking availability.'),
 				}
 			}
 
 			if (this.participationStatus === 'ACCEPTED' && this.isViewedByOrganizer) {
 				return {
-					class: ['accepted', 'icon', 'icon-checkmark-white'],
+					indicatorClass: ['accepted', 'icon', 'icon-checkmark-white'],
 					label: t('calendar', 'Invitation accepted.'),
 				}
 			}
 			if (this.participationStatus === 'ACCEPTED' && !this.isViewedByOrganizer) {
 				return {
-					class: ['accepted', 'icon', 'icon-checkmark-white'],
+					indicatorClass: ['accepted', 'icon', 'icon-checkmark-white'],
 					label: t('calendar', 'Accepted {organizerName}\'s invitation.', {
 						organizerName: this.organizerDisplayName,
 					}),
@@ -110,13 +120,13 @@ export default {
 
 			if (this.participationStatus === 'DECLINED' && this.isViewedByOrganizer) {
 				return {
-					class: ['declined', 'icon', 'icon-close-white'],
+					indicatorClass: ['declined', 'icon', 'icon-close-white'],
 					label: t('calendar', 'Invitation declined.'),
 				}
 			}
 			if (this.participationStatus === 'DECLINED' && !this.isViewedByOrganizer) {
 				return {
-					class: ['declined', 'icon', 'icon-close-white'],
+					indicatorClass: ['declined', 'icon', 'icon-close-white'],
 					label: t('calendar', 'Declined {organizerName}\'s invitation.', {
 						organizerName: this.organizerDisplayName,
 					}),
@@ -124,23 +134,26 @@ export default {
 			}
 
 			if (this.participationStatus === 'DELEGATED') {
-				return this.$t('calendar', 'Invitation is delegated.')
+				return {
+					indicatorClass: [],
+					label: this.$t('calendar', 'Invitation is delegated.'),
+				}
 			}
 			if (this.participationStatus === 'TENTATIVE') {
 				return {
-					class: ['tentative', 'icon', 'icon-checkmark-white'],
+					indicatorClass: ['tentative', 'icon', 'icon-checkmark-white'],
 					label: t('calendar', 'Participation marked as tentative.'),
 				}
 			}
 
 			if (this.isViewedByOrganizer) {
 				return {
-					class: ['no-response', 'icon', 'icon-invitees-no-response-white'],
+					indicatorClass: ['no-response', 'icon', 'icon-invitees-no-response-white'],
 					label: t('calendar', 'Invitation sent.'),
 				}
 			} else {
 				return {
-					class: ['no-response', 'icon', 'icon-invitees-no-response-white'],
+					indicatorClass: ['no-response', 'icon', 'icon-invitees-no-response-white'],
 					label: t('calendar', 'Has not responded to {organizerName}\'s invitation yet.', {
 						organizerName: this.organizerDisplayName,
 					}),

--- a/src/components/Editor/Resources/ResourceList.vue
+++ b/src/components/Editor/Resources/ResourceList.vue
@@ -45,10 +45,25 @@
 		</NoAttendeesView>
 		<OrganizerNoEmailError
 			v-if="!isReadOnly && isListEmpty && !hasUserEmailAddress" />
+
+		<h3 v-if="suggestedRooms.length">
+			{{ $t('calendar', 'Suggestions') }}
+		</h3>
+		<ResourceListItem
+			v-for="room in suggestedRooms"
+			:key="room.email + '-suggested'"
+			:resource="room"
+			:is-read-only="false"
+			:organizer-display-name="organizerDisplayName"
+			:is-suggestion="true"
+			@add-suggestion="addResource" />
 	</div>
 </template>
 
 <script>
+import { advancedPrincipalPropertySearch } from '../../../services/caldavService'
+import { checkResourceAvailability } from '../../../services/freeBusyService'
+import logger from '../../../utils/logger'
 import NoAttendeesView from '../NoAttendeesView'
 import ResourceListSearch from './ResourceListSearch'
 import ResourceListItem from './ResourceListItem'
@@ -76,17 +91,31 @@ export default {
 			required: true,
 		},
 	},
+	data() {
+		return {
+			suggestedRooms: [],
+		}
+	},
 	computed: {
 		resources() {
 			return this.calendarObjectInstance.attendees.filter(attendee => {
 				return ['ROOM', 'RESOURCE'].includes(attendee.attendeeProperty.userType)
 			})
 		},
+		attendees() {
+			return this.calendarObjectInstance.attendees.filter(attendee => {
+				return !['RESOURCE', 'ROOM'].includes(attendee.attendeeProperty.userType)
+			})
+		},
+		hasAdvancedFilters() {
+			// TODO: Remove me when Calendar doesn't support server < 23
+			return parseInt(OC.config.version.split('.')[0]) >= 23
+		},
 		noResourcesMessage() {
 			return this.$t('calendar', 'No rooms or resources yet')
 		},
 		isListEmpty() {
-			return this.resources.length === 0
+			return this.resources.length === 0 && this.suggestedRooms.length === 0
 		},
 		alreadyInvitedEmails() {
 			return this.resources.map(attendee => removeMailtoPrefix(attendee.uri))
@@ -98,6 +127,14 @@ export default {
 			const emailAddress = this.$store.getters.getCurrentUserPrincipal?.emailAddress
 			return !!emailAddress
 		},
+	},
+	watch: {
+		resources() {
+			this.loadRoomSuggestions()
+		},
+	},
+	async mounted() {
+		await this.loadRoomSuggestions()
 	},
 	methods: {
 		addResource({ commonName, email, calendarUserType, language, timezoneId, roomAddress }) {
@@ -120,6 +157,45 @@ export default {
 				calendarObjectInstance: this.calendarObjectInstance,
 				attendee: resource,
 			})
+		},
+		async loadRoomSuggestions() {
+			if (this.resources.length > 0 || !this.hasAdvancedFilters) {
+				this.suggestedRooms = []
+				return
+			}
+
+			try {
+				logger.info('fetching suggestions for ' + this.attendees.length + ' attendees')
+				const query = {
+					capacity: this.attendees.length,
+				}
+				const results = (await advancedPrincipalPropertySearch(query)).map(principal => {
+					return {
+						commonName: principal.displayname,
+						email: principal.email,
+						calendarUserType: principal.calendarUserType,
+						displayName: principal.displayname ?? principal.email,
+						isAvailable: true,
+						roomAddress: principal.roomAddress,
+						uri: principal.email,
+						organizer: this.$store.getters.getCurrentUserPrincipal,
+					}
+				})
+
+				await checkResourceAvailability(
+					results,
+					this.$store.getters.getCurrentUserPrincipalEmail,
+					this.calendarObjectInstance.eventComponent.startDate,
+					this.calendarObjectInstance.eventComponent.endDate,
+				)
+				logger.debug('availability of room suggestions fetched', { results })
+
+				// Take the first three available options
+				this.suggestedRooms = results.filter(room => room.isAvailable).slice(0, 3)
+			} catch (error) {
+				logger.error('Could not find resources', { error })
+				this.suggestedRooms = []
+			}
 		},
 		/**
 		 * Apply the location of the first resource to the event.

--- a/src/components/Editor/Resources/ResourceListItem.vue
+++ b/src/components/Editor/Resources/ResourceListItem.vue
@@ -26,15 +26,24 @@
 			:attendee-is-organizer="false"
 			:is-viewed-by-organizer="isViewedByOrganizer"
 			:is-resource="true"
+			:is-suggestion="isSuggestion"
 			:avatar-link="commonName"
-			:participation-status="resource.participationStatus"
+			:participation-status="participationStatus"
 			:organizer-display-name="organizerDisplayName"
 			:common-name="commonName" />
 		<div class="resource-list-item__displayname">
 			{{ commonName }}
 		</div>
 		<div class="resource-list-item__actions">
-			<Actions v-if="isViewedByOrganizer">
+			<Actions v-if="isViewedByOrganizer && isSuggestion">
+				<ActionButton @click="addSuggestion">
+					<template #icon>
+						<Plus :size="20" decorative />
+					</template>
+					{{ $t('calendar', 'Add resource') }}
+				</ActionButton>
+			</actions>
+			<Actions v-else-if="isViewedByOrganizer">
 				<ActionCaption
 					v-if="seatingCapacity"
 					:title="seatingCapacity" />
@@ -74,6 +83,7 @@ import { principalPropertySearchByDisplaynameOrEmail } from '../../../services/c
 import { formatRoomType } from '../../../models/resourceProps'
 
 import Delete from 'vue-material-design-icons/Delete.vue'
+import Plus from 'vue-material-design-icons/Plus.vue'
 
 export default {
 	name: 'ResourceListItem',
@@ -84,6 +94,7 @@ export default {
 		ActionSeparator,
 		Actions,
 		Delete,
+		Plus,
 	},
 	props: {
 		resource: {
@@ -97,6 +108,10 @@ export default {
 		isReadOnly: {
 			type: Boolean,
 			required: true,
+		},
+		isSuggestion: {
+			type: Boolean,
+			default: false,
 		},
 	},
 	data() {
@@ -147,6 +162,13 @@ export default {
 			const roomType = this.principal?.roomType
 			return formatRoomType(roomType) ?? roomType
 		},
+		participationStatus() {
+			if (this.isSuggestion) {
+				return ''
+			}
+
+			return this.resource.participationStatus
+		},
 	},
 	watch: {
 		async resource() {
@@ -157,6 +179,12 @@ export default {
 		await this.fetchPrincipal()
 	},
 	methods: {
+		/**
+		 * Add this suggestions to the event
+		 */
+		addSuggestion() {
+			this.$emit('add-suggestion', this.resource)
+		},
 		/**
 		 * Removes a resource from the event
 		 */

--- a/src/services/freeBusyService.js
+++ b/src/services/freeBusyService.js
@@ -1,0 +1,60 @@
+/**
+ * @copyright 2021 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @author 2021 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+import { AttendeeProperty } from '@nextcloud/calendar-js'
+import { addMailtoPrefix, removeMailtoPrefix } from '../utils/attendee'
+import { doFreeBusyRequest } from '../utils/freebusy'
+
+/**
+ * Check resource availability using a free busy request
+ * and amend the status to the option object (option.isAvailable)
+ *
+ * @param {object[]} options The search results to amend with an availability
+ * @param {string} principalEmail Principal of the organizer
+ * @param {DateTimeValue} start Start date
+ * @param {DateTimeValue} end End date
+ */
+export async function checkResourceAvailability(options, principalEmail, start, end) {
+	if (options.length === 0) {
+		return
+	}
+
+	const organizer = new AttendeeProperty(
+		'ORGANIZER',
+		addMailtoPrefix(principalEmail),
+	)
+	const attendees = []
+	for (const option of options) {
+		attendees.push(new AttendeeProperty('ATTENDEE', addMailtoPrefix(option.email)))
+	}
+
+	for await (const [attendeeProperty] of doFreeBusyRequest(start, end, organizer, attendees)) {
+		const attendeeEmail = removeMailtoPrefix(attendeeProperty.email)
+		for (const option of options) {
+			if (removeMailtoPrefix(option.email) === attendeeEmail) {
+				options.participationStatus = ''
+				option.isAvailable = false
+				break
+			}
+		}
+	}
+}


### PR DESCRIPTION
Suggest up to three available rooms for events with participants but no selected rooms or resources. The current number of participants is used to find fitting suggestions.

Fixes https://github.com/nextcloud/calendar/issues/3418

Todo
- [x] Logic to find suggestions
- [x] Render suggestions nicely

![Bildschirmfoto von 2021-11-05 10-14-40](https://user-images.githubusercontent.com/1374172/140486961-fe7e4198-135f-40c3-ba43-d430c85d1a1f.png)

^ against what we discussed last week I still went with a subline because without it it is even harder to see that the resource isn't part of the event yet. We can fine tune this in follow-ups.
