### PR TITLE
Make appointment configs not clickable

### DIFF
--- a/css/app-navigation.scss
+++ b/css/app-navigation.scss
@@ -314,6 +314,11 @@
 			.app-navigation-caption {
 				margin-top: 22px;
 			}
+
+			.app-navigation-entry-link,
+			.app-navigation-entry-link * {
+				cursor: default;
+			}
 		}
 	}
 }

--- a/src/components/AppNavigation/AppointmentConfigList/AppointmentConfigListItem.vue
+++ b/src/components/AppNavigation/AppointmentConfigList/AppointmentConfigListItem.vue
@@ -23,7 +23,8 @@
 <template>
 	<div>
 		<AppNavigationItem
-			:title="config.name">
+			:title="config.name"
+			@click.prevent>
 			<template #icon>
 				<CalendarCheckIcon :size="20" decorative />
 			</template>


### PR DESCRIPTION
Fix #3625

Entries in the appointment config list show the default cursor instead of the pointer cursor now.