### PR TITLE
Set default preparation and followup durations to 0 minutes

### DIFF
--- a/src/components/AppointmentConfigModal/CheckedDurationSelect.vue
+++ b/src/components/AppointmentConfigModal/CheckedDurationSelect.vue
@@ -34,6 +34,7 @@
 		</div>
 		<DurationSelect
 			class="checked-duration-select__duration"
+			:allow-zero="true"
 			:disabled="!enabled"
 			:value="value"
 			@update:value="$emit('update:value', $event)" />
@@ -56,7 +57,7 @@ export default {
 		},
 		value: {
 			type: Number,
-			default: undefined,
+			default: 0,
 		},
 		enabled: {
 			type: Boolean,

--- a/src/components/AppointmentConfigModal/DurationSelect.vue
+++ b/src/components/AppointmentConfigModal/DurationSelect.vue
@@ -50,18 +50,27 @@ export default {
 			type: Boolean,
 			default: false,
 		},
+		allowZero: {
+			type: Boolean,
+			default: false,
+		},
 	},
-	data() {
-		return {
-			options: [
+	computed: {
+		options() {
+			const options = [
+				{ value: 0, label: this.t('calendar', '0 minutes') },
 				{ value: 5 * 60, label: this.t('calendar', '5 minutes') },
 				{ value: 10 * 60, label: this.t('calendar', '10 minutes') },
 				{ value: 15 * 60, label: this.t('calendar', '15 minutes') },
 				{ value: 30 * 60, label: this.t('calendar', '30 minutes') },
 				{ value: 45 * 60, label: this.t('calendar', '45 minutes') },
 				{ value: 60 * 60, label: this.t('calendar', '1 hour') },
-			],
-		}
+			]
+			if (!this.allowZero) {
+				options.splice(0, 1)
+			}
+			return options
+		},
 	},
 }
 </script>


### PR DESCRIPTION
Fix #3628

![Screenshot 2021-11-09 at 18-32-36 November 2021 - Kalender - Nextcloud](https://user-images.githubusercontent.com/1479486/140975031-b52cf0c9-51a7-4177-aa76-0387a65861df.png)


