### PR TITLE
Fix appointments availability handling: start, end and time before next slot

### DIFF
--- a/lib/Db/AppointmentConfig.php
+++ b/lib/Db/AppointmentConfig.php
@@ -127,6 +127,17 @@ class AppointmentConfig extends Entity implements JsonSerializable {
 	/** @var string */
 	public const VISIBILITY_PRIVATE = 'PRIVATE';
 
+	public function __construct() {
+		$this->addType('start', 'int');
+		$this->addType('end', 'int');
+		$this->addType('length', 'int');
+		$this->addType('increment', 'int');
+		$this->addType('preparationDuration', 'int');
+		$this->addType('followupDuration', 'int');
+		$this->addType('timeBeforeNextSlot', 'int');
+		$this->addType('dailyMax', 'int');
+	}
+
 	/**
 	 * Total length of one slot of the appointment config
 	 * in minutes

--- a/src/appointments/main-booking.js
+++ b/src/appointments/main-booking.js
@@ -1,6 +1,8 @@
 /**
  * @copyright 2021 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
  * @author 2021 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
  * @license GNU AGPL version 3 or any later version
  *
  * This program is free software: you can redistribute it and/or modify
@@ -15,6 +17,7 @@
  *
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
  */
 
 import { getRequestToken } from '@nextcloud/auth'

--- a/src/appointments/main-overview.js
+++ b/src/appointments/main-overview.js
@@ -1,6 +1,8 @@
 /**
  * @copyright 2021 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
  * @author 2021 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
  * @license GNU AGPL version 3 or any later version
  *
  * This program is free software: you can redistribute it and/or modify
@@ -15,6 +17,7 @@
  *
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
  */
 
 import { getRequestToken } from '@nextcloud/auth'

--- a/src/services/appointmentService.js
+++ b/src/services/appointmentService.js
@@ -1,6 +1,8 @@
 /**
  * @copyright 2021 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
  * @author 2021 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
  * @license GNU AGPL version 3 or any later version
  *
  * This program is free software: you can redistribute it and/or modify
@@ -15,6 +17,7 @@
  *
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
  */
 
 import axios from '@nextcloud/axios'

--- a/src/utils/localeTime.js
+++ b/src/utils/localeTime.js
@@ -1,6 +1,8 @@
 /**
  * @copyright 2021 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
  * @author 2021 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
  * @license GNU AGPL version 3 or any later version
  *
  * This program is free software: you can redistribute it and/or modify
@@ -15,6 +17,7 @@
  *
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
  */
 
 import { getCanonicalLocale } from '@nextcloud/l10n'


### PR DESCRIPTION
* Factor in *start time*
  * Do not let the user select times before that
  * Do not generate available slot before
* Factor in *end time*
  * Do not let the users select times after that
  * Do not generate available slots after
* Factor in *Minimum time before next slot*
  * Do not let the user select dates without a possible first bookable slot
  * Do not generate available slots before

`start` and `end` are missing from the UI. You have to generate timestamps and add them to the DB manually.