### PR TITLE
Increase the avatar size on the appointment booking page

### DIFF
--- a/src/views/Appointments/Booking.vue
+++ b/src/views/Appointments/Booking.vue
@@ -27,7 +27,7 @@
 				:display-name="userInfo.displayName"
 				:disable-tooltip="true"
 				:disable-menu="true"
-				:size="64" />
+				:size="180" />
 			<div class="booking__display-name">
 				<strong>{{ userInfo.displayName }}</strong>
 			</div>


### PR DESCRIPTION
Fix #3641 

I opted for `:size="180"` to make it consistent with the avatar on the overview page. Doubling the size would have yielded `128`.

![Screenshot 2021-11-12 at 13-04-06 Nextcloud](https://user-images.githubusercontent.com/1479486/141464295-c2e387c6-9563-4f88-ab37-9b0608744ccb.png)


