### PR TITLE
Shim ICAL to prevent using the global object

### DIFF
--- a/webpack.js
+++ b/webpack.js
@@ -55,7 +55,14 @@ webpackConfig.plugins.push(
 			pattern: './src/assets/iconfont/*.svg'
 		}
 	}),
-	new webpack.IgnorePlugin(/^\.\/locale(s)?$/, /(moment)$/)
+	new webpack.IgnorePlugin(/^\.\/locale(s)?$/, /(moment)$/),
+	new webpack.ProvidePlugin({
+		// Shim ICAL to prevent using the global object (window.ICAL).
+		// The library ical.js heavily depends on instanceof checks which will
+		// break if two separate versions of the library are used (e.g. bundled one
+		// and global one).
+		ICAL: 'ical.js',
+	}),
 )
 
 module.exports = webpackConfig


### PR DESCRIPTION
Fix #3649 

The library ical.js heavily depends on instanceof checks which will break if two separate versions of the library are used (e.g. bundled one and global one).

Ref https://webpack.js.org/guides/shimming/

## How to test

1. Create some events in the near future
2. Observe that the calendar widget is working fine
3. Install notes
4. Observe that the calendar widget doesn't show any events anymore
5. Apply my patch
6. Observe that the calendar widget is working fine again
