### PR TITLE
Removed times 60 multiplier for appointments

### DIFF
--- a/lib/Service/Appointments/AvailabilityGenerator.php
+++ b/lib/Service/Appointments/AvailabilityGenerator.php
@@ -61,7 +61,7 @@ class AvailabilityGenerator {
 							 int $end): array {
 		$now = $this->timeFactory->getTime();
 
-		$bufferBeforeStart = ($config->getTimeBeforeNextSlot() ?? 0) * 60;
+		$bufferBeforeStart = ($config->getTimeBeforeNextSlot() ?? 0);
 		$earliestStart = max(
 			$start,
 			$now + $bufferBeforeStart,
@@ -72,7 +72,7 @@ class AvailabilityGenerator {
 		//      when the user opens the page at 10:17.
 		// But only do this when the time isn't already a "pretty" time
 		if($earliestStart % $config->getLength() !== 0) {
-			$roundTo = (int) round(($config->getLength() * 60) / 300) * 300;
+			$roundTo = (int) round(($config->getLength()) / 300) * 300;
 			$earliestStart = (int) ceil($earliestStart / $roundTo) * $roundTo;
 		}
 		$latestEnd = min(

--- a/lib/Service/Appointments/EventConflictFilter.php
+++ b/lib/Service/Appointments/EventConflictFilter.php
@@ -56,8 +56,8 @@ class EventConflictFilter {
 		}
 		// Always check the target calendar for conflicts
 		$query->addSearchCalendar($config->getTargetCalendarUri());
-		$preparationDuration = DateInterval::createFromDateString($config->getPreparationDuration() . ' minutes');
-		$followUpDuration = DateInterval::createFromDateString($config->getFollowupDuration() . ' minutes');
+		$preparationDuration = DateInterval::createFromDateString($config->getPreparationDuration() . ' seconds');
+		$followUpDuration = DateInterval::createFromDateString($config->getFollowupDuration() . ' seconds');
 
 		return array_filter($slots, function (Interval $slot) use ($followUpDuration, $preparationDuration, $query): bool {
 			$query->setTimerangeStart($slot->getStartAsObject()->sub($preparationDuration));

--- a/lib/Service/Appointments/SlotExtrapolator.php
+++ b/lib/Service/Appointments/SlotExtrapolator.php
@@ -38,8 +38,8 @@ class SlotExtrapolator {
 	 */
 	public function extrapolate(AppointmentConfig $config,
 								array $availabilityIntervals): array {
-		$increment = $config->getIncrement() * 60;
-		$length = $config->getLength() * 60;
+		$increment = $config->getIncrement();
+		$length = $config->getLength();
 		$slots = [];
 
 		foreach ($availabilityIntervals as $available) {

--- a/src/views/Appointments/Booking.vue
+++ b/src/views/Appointments/Booking.vue
@@ -122,7 +122,7 @@ export default {
 			now
 		))
 		if (this.config.timeBeforeNextSlot) {
-			selectedDate.setSeconds(selectedDate.getSeconds() + this.config.timeBeforeNextSlot * 60)
+			selectedDate.setSeconds(selectedDate.getSeconds() + this.config.timeBeforeNextSlot)
 		}
 
 		const minimumDate = new Date(selectedDate.getTime())

--- a/tests/php/integration/Db/AppointmentConfigMapperTest.php
+++ b/tests/php/integration/Db/AppointmentConfigMapperTest.php
@@ -70,8 +70,8 @@ class AppointmentConfigMapperTest extends TestCase {
 		$appointment->setToken('okens');
 		$appointment->setName('Test 2');
 		$appointment->setDescription('Test Description');
-		$appointment->setIncrement(15);
-		$appointment->setLength(60);
+		$appointment->setIncrement(15 * 60);
+		$appointment->setLength(60 * 60);
 		$appointment->setTargetCalendarUri('testuri');
 		$appointment->setVisibility(AppointmentConfig::VISIBILITY_PUBLIC);
 		$appointment->setUserId('testuser');
@@ -87,9 +87,9 @@ class AppointmentConfigMapperTest extends TestCase {
 		$this->assertObjectHasAttribute('description', $appointment);
 		$this->assertEquals('Test Description', $appointment->getDescription());
 		$this->assertObjectHasAttribute('increment', $appointment);
-		$this->assertEquals(15, $appointment->getIncrement());
+		$this->assertEquals(15 * 60, $appointment->getIncrement());
 		$this->assertObjectHasAttribute('length', $appointment);
-		$this->assertEquals(60, $appointment->getLength());
+		$this->assertEquals(60 * 60, $appointment->getLength());
 		$this->assertObjectHasAttribute('targetCalendarUri', $appointment);
 		$this->assertEquals('testuri', $appointment->getTargetCalendarUri());
 		$this->assertObjectHasAttribute('visibility', $appointment);
@@ -106,8 +106,8 @@ class AppointmentConfigMapperTest extends TestCase {
 		$appointment->setToken('okensdsadsas');
 		$appointment->setName('Test 2');
 		$appointment->setDescription('Test Description');
-		$appointment->setIncrement(15);
-		$appointment->setLength(60);
+		$appointment->setIncrement(15 * 60);
+		$appointment->setLength(60 * 60);
 		$appointment->setTargetCalendarUri('testuri');
 		$appointment->setVisibility(AppointmentConfig::VISIBILITY_PUBLIC);
 		$appointment->setUserId('testuser');
@@ -123,9 +123,9 @@ class AppointmentConfigMapperTest extends TestCase {
 		$this->assertObjectHasAttribute('description', $appointment);
 		$this->assertEquals('Test Description', $appointment->getDescription());
 		$this->assertObjectHasAttribute('increment', $appointment);
-		$this->assertEquals(15, $appointment->getIncrement());
+		$this->assertEquals(15 * 60, $appointment->getIncrement());
 		$this->assertObjectHasAttribute('length', $appointment);
-		$this->assertEquals(60, $appointment->getLength());
+		$this->assertEquals(60 * 60, $appointment->getLength());
 		$this->assertObjectHasAttribute('targetCalendarUri', $appointment);
 		$this->assertEquals('testuri', $appointment->getTargetCalendarUri());
 		$this->assertObjectHasAttribute('visibility', $appointment);
@@ -139,8 +139,8 @@ class AppointmentConfigMapperTest extends TestCase {
 		$appointment->setToken('frokns');
 		$appointment->setName('Test 3');
 		$appointment->setDescription('Test Description');
-		$appointment->setIncrement(15);
-		$appointment->setLength(60);
+		$appointment->setIncrement(15 * 60);
+		$appointment->setLength(60 * 60);
 		$appointment->setTargetCalendarUri('testuri');
 		$appointment->setVisibility(AppointmentConfig::VISIBILITY_PUBLIC);
 		$appointment->setUserId('testuser');
@@ -161,8 +161,8 @@ class AppointmentConfigMapperTest extends TestCase {
 		$appointment->setToken('frokns');
 		$appointment->setName('Test 2');
 		$appointment->setDescription('Test Description');
-		$appointment->setIncrement(15);
-		$appointment->setLength(60);
+		$appointment->setIncrement(15 * 60);
+		$appointment->setLength(60 * 60);
 		$appointment->setTargetCalendarUri('testuri');
 		$appointment->setVisibility(AppointmentConfig::VISIBILITY_PUBLIC);
 		$appointment->setUserId('testuser');

--- a/tests/php/unit/BackgroundJob/CleanupOutdatedBookingJobTest.php
+++ b/tests/php/unit/BackgroundJob/CleanupOutdatedBookingJobTest.php
@@ -23,6 +23,7 @@ declare(strict_types=1);
  *
  */
 
+use ChristophWurst\Nextcloud\Testing\TestCase;
 use OC\BackgroundJob\JobList;
 use OCA\Calendar\BackgroundJob\CleanUpOutdatedBookingsJob;
 use OCA\Calendar\Service\Appointments\BookingService;
@@ -31,7 +32,6 @@ use OCP\Calendar\ICalendarQuery;
 use OCP\ILogger;
 use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Log\LoggerInterface;
-use Test\TestCase;
 
 class CleanupOutdatedBookingJobTest extends TestCase {
 

--- a/tests/php/unit/Controller/AppointmentConfigControllerTest.php
+++ b/tests/php/unit/Controller/AppointmentConfigControllerTest.php
@@ -137,8 +137,8 @@ class AppointmentConfigControllerTest extends TestCase {
 		$appointment->setLocation('Test');
 		$appointment->setVisibility('PUBLIC');
 		$appointment->setTargetCalendarUri('test');
-		$appointment->setLength(5);
-		$appointment->setIncrement(5);
+		$appointment->setLength(5 * 60);
+		$appointment->setIncrement(5 * 60);
 
 		$this->service->expects($this->once())
 			->method('create')
@@ -152,8 +152,8 @@ class AppointmentConfigControllerTest extends TestCase {
 			'PUBLIC',
 			'test',
 			null,
-			5,
-			5
+			5 * 60,
+			5 * 60
 		);
 
 		$this->assertEquals(200, $response->getStatus());
@@ -166,8 +166,8 @@ class AppointmentConfigControllerTest extends TestCase {
 		$appointment->setLocation('Test');
 		$appointment->setVisibility('PUBLIC');
 		$appointment->setTargetCalendarUri('test');
-		$appointment->setLength(5);
-		$appointment->setIncrement(5);
+		$appointment->setLength(5 * 60);
+		$appointment->setIncrement(5 * 60);
 
 		$this->service->expects($this->once())
 			->method('create')
@@ -181,8 +181,8 @@ class AppointmentConfigControllerTest extends TestCase {
 			'PUBLIC',
 			'test',
 			null,
-			5,
-			5
+			5 * 60,
+			5 * 60
 		);
 
 		$this->assertEquals(500, $response->getStatus());
@@ -196,8 +196,8 @@ class AppointmentConfigControllerTest extends TestCase {
 		$appointment->setLocation('Test');
 		$appointment->setVisibility('PUBLIC');
 		$appointment->setTargetCalendarUri('test');
-		$appointment->setLength(5);
-		$appointment->setIncrement(5);
+		$appointment->setLength(5 * 60);
+		$appointment->setIncrement(5 * 60);
 
 		$this->service->expects($this->once())
 			->method('findByIdAndUser')
@@ -217,8 +217,8 @@ class AppointmentConfigControllerTest extends TestCase {
 			'PUBLIC',
 			'test',
 			null,
-			5,
-			5
+			5 * 60,
+			5 * 60
 		);
 
 		$this->assertEquals(200, $response->getStatus());
@@ -232,8 +232,8 @@ class AppointmentConfigControllerTest extends TestCase {
 		$appointment->setLocation('Test');
 		$appointment->setVisibility('PUBLIC');
 		$appointment->setTargetCalendarUri('test');
-		$appointment->setLength(5);
-		$appointment->setIncrement(5);
+		$appointment->setLength(5 * 60);
+		$appointment->setIncrement(5 * 60);
 
 		$this->service->expects($this->once())
 			->method('findByIdAndUser')
@@ -247,8 +247,8 @@ class AppointmentConfigControllerTest extends TestCase {
 			'PUBLIC',
 			'test',
 			null,
-			5,
-			5
+			5 * 60,
+			5 * 60
 		);
 
 		$this->assertEquals(500, $response->getStatus());
@@ -262,8 +262,8 @@ class AppointmentConfigControllerTest extends TestCase {
 		$appointment->setLocation('Test');
 		$appointment->setVisibility('PUBLIC');
 		$appointment->setTargetCalendarUri('test');
-		$appointment->setLength(5);
-		$appointment->setIncrement(5);
+		$appointment->setLength(5 * 60);
+		$appointment->setIncrement(5 * 60);
 
 		$this->service->expects($this->once())
 			->method('update')
@@ -277,8 +277,8 @@ class AppointmentConfigControllerTest extends TestCase {
 			'PUBLIC',
 			'test',
 			null,
-			5,
-			5
+			5 * 60,
+			5 * 60
 		);
 
 		$this->assertEquals(403, $response->getStatus());

--- a/tests/php/unit/Service/Appointments/AvailabilityGeneratorTest.php
+++ b/tests/php/unit/Service/Appointments/AvailabilityGeneratorTest.php
@@ -59,7 +59,7 @@ class AvailabilityGeneratorTest extends TestCase {
 
 	public function testNoAvailabilitySet(): void {
 		$config = new AppointmentConfig();
-		$config->setLength(60);
+		$config->setLength(60 * 60);
 		$config->setAvailability(null);
 
 		$slots = $this->generator->generate($config, 1 * 3600, 2 * 3600);
@@ -72,7 +72,7 @@ class AvailabilityGeneratorTest extends TestCase {
 
 	public function testNoAvailabilitySetRoundToFive(): void {
 		$config = new AppointmentConfig();
-		$config->setLength(47);
+		$config->setLength(47 * 60);
 		$config->setAvailability(null);
 
 		$slots = $this->generator->generate($config, (int)2.8 * 3600, 4 * 3600);
@@ -83,8 +83,8 @@ class AvailabilityGeneratorTest extends TestCase {
 
 	public function testNoAvailabilitySetRoundWithIncrement(): void {
 		$config = new AppointmentConfig();
-		$config->setLength(90);
-		$config->setIncrement(60);
+		$config->setLength(90 * 60);
+		$config->setIncrement(60 * 60);
 		$config->setAvailability(null);
 
 		$slots = $this->generator->generate($config, 1 * 5400, 2 * 5400);
@@ -95,7 +95,7 @@ class AvailabilityGeneratorTest extends TestCase {
 
 	public function testNoAvailabilitySetRoundWithPrettyNumbers(): void {
 		$config = new AppointmentConfig();
-		$config->setLength(90);
+		$config->setLength(90 * 60);
 		$config->setAvailability(null);
 
 		$slots = $this->generator->generate($config, 1 * 5400 + 1, 2 * 5400 + 1);
@@ -107,7 +107,7 @@ class AvailabilityGeneratorTest extends TestCase {
 
 	public function testNoAvailabilitySetRoundWithFourtyMinutes(): void {
 		$config = new AppointmentConfig();
-		$config->setLength(40);
+		$config->setLength(40 * 60);
 		$config->setAvailability(null);
 
 		$slots = $this->generator->generate($config, 1 * 2400, 2 * 2400);
@@ -118,7 +118,7 @@ class AvailabilityGeneratorTest extends TestCase {
 
 	public function testNoAvailabilitySetRoundWithFourtyMinutesNotPretty(): void {
 		$config = new AppointmentConfig();
-		$config->setLength(40);
+		$config->setLength(40 * 60);
 		$config->setAvailability(null);
 
 		$slots = $this->generator->generate($config, 1 * 2400 +1, 2 * 2400+1);
@@ -130,7 +130,7 @@ class AvailabilityGeneratorTest extends TestCase {
 
 	public function testNoAvailabilityButEndDate(): void {
 		$config = new AppointmentConfig();
-		$config->setLength(60);
+		$config->setLength(60 * 60);
 		$config->setAvailability(null);
 		$config->setEnd(10*3600);
 
@@ -146,7 +146,7 @@ class AvailabilityGeneratorTest extends TestCase {
 		$this->timeFactory->method('getTime')
 			->willReturn(15*3600);
 		$config = new AppointmentConfig();
-		$config->setLength(60);
+		$config->setLength(60 * 60);
 		$config->setAvailability(null);
 		$config->setEnd(10*3600);
 
@@ -194,7 +194,7 @@ class AvailabilityGeneratorTest extends TestCase {
 		$array = json_encode($testData, JSON_THROW_ON_ERROR);
 
 		$config = new AppointmentConfig();
-		$config->setLength(60);
+		$config->setLength(60 * 60);
 		$config->setAvailability($array);
 
 		$wednesdayMidnight = (new DateTimeImmutable())->setDate(2021, 11, 3)->setTime(0, 0);
@@ -244,13 +244,14 @@ class AvailabilityGeneratorTest extends TestCase {
 		$array = json_encode($testData, JSON_THROW_ON_ERROR);
 
 		$config = new AppointmentConfig();
-		$config->setLength(60);
-		$config->setAvailability($array);
+		$config->setLength(60 * 60
+		);
+		$config->setAvailability('RRULE:FREQ=MINUTELY;INTERVAL=15;WKST=MO;BYDAY=MO;BYHOUR=8,9,10,11');
 
-		$wednesdayMidnight = (new DateTimeImmutable())->setDate(2021, 11, 3)->setTime(0, 0);
-		$thursdayMidnight = $wednesdayMidnight->modify('+1 day');
+		$mondayMidnight = (new DateTimeImmutable())->setDate(2021, 11, 1)->setTime(0, 0);
+		$sundayMidnight = $mondayMidnight->modify('+7 days');
 
-		$slots = $this->generator->generate($config, $wednesdayMidnight->getTimestamp(), $thursdayMidnight->getTimestamp());
+		$slots = $this->generator->generate($config, $mondayMidnight->getTimestamp(), $sundayMidnight->getTimestamp());
 
 		self::assertCount(1, $slots);
 	}
@@ -293,7 +294,7 @@ class AvailabilityGeneratorTest extends TestCase {
 		$array = json_encode($testData, JSON_THROW_ON_ERROR);
 
 		$config = new AppointmentConfig();
-		$config->setLength(60);
+		$config->setLength(60 * 60);
 		$config->setAvailability($array);
 
 		$wednesdayMidnight = (new DateTimeImmutable())->setDate(2021, 11, 3)->setTime(0, 0);
@@ -344,7 +345,7 @@ class AvailabilityGeneratorTest extends TestCase {
 		$array = json_encode($testData, JSON_THROW_ON_ERROR);
 
 		$config = new AppointmentConfig();
-		$config->setLength(60);
+		$config->setLength(60 * 60);
 		$config->setAvailability($array);
 
 		$wednesdayMidnight = (new DateTimeImmutable())->setTimezone($tz)->setDate(2021, 11, 3)->setTime(0, 0);
@@ -393,7 +394,7 @@ class AvailabilityGeneratorTest extends TestCase {
 		$array = json_encode($testData, JSON_THROW_ON_ERROR);
 
 		$config = new AppointmentConfig();
-		$config->setLength(60);
+		$config->setLength(60 * 60);
 		$config->setAvailability($array);
 
 		$auckland = new DateTimeZone('Pacific/Auckland');
@@ -444,7 +445,7 @@ class AvailabilityGeneratorTest extends TestCase {
 		$array = json_encode($testData, JSON_THROW_ON_ERROR);
 
 		$config = new AppointmentConfig();
-		$config->setLength(60);
+		$config->setLength(60 * 60);
 		$config->setAvailability($array);
 
 		$auckland = new DateTimeZone('Pacific/Auckland');

--- a/tests/php/unit/Service/Appointments/SlotExtrapolatorTest.php
+++ b/tests/php/unit/Service/Appointments/SlotExtrapolatorTest.php
@@ -48,8 +48,8 @@ class SlotExtrapolatorTest extends TestCase {
 
 	public function testNoAvailability(): void {
 		$config = new AppointmentConfig();
-		$config->setLength(60);
-		$config->setIncrement(15);
+		$config->setLength(60 * 60);
+		$config->setIncrement(15 * 60);
 		$availabilityIntervals = [];
 
 		$slots = $this->extrapolator->extrapolate($config, $availabilityIntervals);
@@ -62,10 +62,10 @@ class SlotExtrapolatorTest extends TestCase {
 	 */
 	public function testNoneFits(): void {
 		$config = new AppointmentConfig();
-		$config->setLength(60);
-		$config->setIncrement(15);
+		$config->setLength(60 * 60);
+		$config->setIncrement(15 * 60);
 		$availabilityIntervals = [
-			new Interval(0, 30 * 60),
+			new Interval(0, 30 * 60 * 60),
 		];
 
 		$slots = $this->extrapolator->extrapolate($config, $availabilityIntervals);
@@ -78,10 +78,10 @@ class SlotExtrapolatorTest extends TestCase {
 	 */
 	public function testExactlyOne(): void {
 		$config = new AppointmentConfig();
-		$config->setLength(60);
-		$config->setIncrement(15);
+		$config->setLength(60 * 60);
+		$config->setIncrement(15 * 60);
 		$availabilityIntervals = [
-			new Interval(0, 60 * 60),
+			new Interval(0, 60 * 60 *60),
 		];
 
 		$slots = $this->extrapolator->extrapolate($config, $availabilityIntervals);
@@ -94,10 +94,10 @@ class SlotExtrapolatorTest extends TestCase {
 	 */
 	public function testOverlaps(): void {
 		$config = new AppointmentConfig();
-		$config->setLength(60);
-		$config->setIncrement(15);
+		$config->setLength(60 * 60);
+		$config->setIncrement(15 * 60);
 		$availabilityIntervals = [
-			new Interval(0, 90 * 60),
+			new Interval(0, 90 * 60 * 60),
 		];
 
 		$slots = $this->extrapolator->extrapolate($config, $availabilityIntervals);
@@ -110,11 +110,11 @@ class SlotExtrapolatorTest extends TestCase {
 	 */
 	public function testMultipleIntervals(): void {
 		$config = new AppointmentConfig();
-		$config->setLength(60);
-		$config->setIncrement(15);
+		$config->setLength(60 * 60);
+		$config->setIncrement(15 * 60);
 		$availabilityIntervals = [
-			new Interval(0, 60 * 60),
-			new Interval(100 * 60, 160 * 60),
+			new Interval(0, 60 * 60 * 60),
+			new Interval(100 * 60 * 60, 160 * 60 * 60),
 		];
 
 		$slots = $this->extrapolator->extrapolate($config, $availabilityIntervals);


### PR DESCRIPTION
Remove the times 60 multiplier as increments, length etc should be sent and received as seconds.