### PR TITLE
Persist the calendar URI for an appointment config

### DIFF
--- a/src/components/AppNavigation/AppointmentConfigList.vue
+++ b/src/components/AppNavigation/AppointmentConfigList.vue
@@ -93,7 +93,10 @@ export default {
 			configs: 'allConfigs',
 		}),
 		defaultConfig() {
-			return AppointmentConfig.createDefault(this.$store)
+			return AppointmentConfig.createDefault(
+				this.calendarUrlToUri(this.$store.getters.sortedCalendars[0].url),
+				this.$store.getters.getResolvedTimezone,
+			)
 		},
 		hasAtLeastOneCalendar() {
 			return !!this.$store.getters.sortedCalendars[0]
@@ -110,6 +113,12 @@ export default {
 	methods: {
 		closeModal() {
 			this.showModalForNewConfig = false
+		},
+		calendarUrlToUri(url) {
+			// Trim trailing slash and split into URL parts
+			const parts = url.replace(/\/$/, '').split('/')
+			// The last one is the URI
+			return parts[parts.length - 1]
 		},
 		async deleteConfig(config) {
 			logger.info('Deleting config', { config })

--- a/src/components/Shared/CalendarPicker.vue
+++ b/src/components/Shared/CalendarPicker.vue
@@ -1,7 +1,7 @@
 <template>
 	<Multiselect
 		label="displayName"
-		track-by="displayName"
+		track-by="url"
 		:disabled="isDisabled"
 		:options="calendars"
 		:value="calendar"

--- a/src/models/appointmentConfig.js
+++ b/src/models/appointmentConfig.js
@@ -111,12 +111,13 @@ export default class AppointmentConfig {
 	}
 
 	/**
-	 * Create a default appointment config instance from the given vuex store
+	 * Create a default appointment config instance
 	 *
-	 * @param {object} store The vuex store object (e.g. this.$store)
+	 * @param {string} targetCalendarUri
+	 * @param {string} timezoneId
 	 * @return {AppointmentConfig} Default appointment config instance
 	 */
-	static createDefault(store) {
+	static createDefault(targetCalendarUri, timezoneId) {
 		// Set default availability to Mo-Fr 9-5
 		// TODO: fetch user's working hours if possible
 		const tsAtTime = (hours, minutes) => Math.round((new Date()).setHours(hours, minutes, 0, 0) / 1000)
@@ -130,9 +131,9 @@ export default class AppointmentConfig {
 			name: '',
 			description: '',
 			location: '',
-			targetCalendarUri: store.getters.sortedCalendars[0].url,
+			targetCalendarUri,
 			availability: {
-				timezoneId: store.getters.getResolvedTimezone,
+				timezoneId,
 				slots,
 			},
 			visibility: 'PUBLIC',


### PR DESCRIPTION
Ref https://github.com/nextcloud/calendar/pull/3470#issuecomment-978031390

~~the calendar picker still doesn't work. @st3iny any idea? Did it ever work? Did we break it?~~ it tracked by display name and my two test calendars had the same name. Fixed this by switching to the unique URL.