### PR TITLE
Delete appointment configs when the user is deleted

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -24,18 +24,15 @@ declare(strict_types=1);
 namespace OCA\Calendar\AppInfo;
 
 use OCA\Calendar\Dashboard\CalendarWidget;
+use OCA\Calendar\Listener\UserDeletedListener;
 use OCA\Calendar\Profile\AppointmentsAction;
 use OCP\AppFramework\App;
 use OCP\AppFramework\Bootstrap\IBootContext;
 use OCP\AppFramework\Bootstrap\IBootstrap;
 use OCP\AppFramework\Bootstrap\IRegistrationContext;
+use OCP\User\Events\UserDeletedEvent;
 use function method_exists;
 
-/**
- * Class Application
- *
- * @package OCA\Calendar\AppInfo
- */
 class Application extends App implements IBootstrap {
 
 	/** @var string */
@@ -58,6 +55,8 @@ class Application extends App implements IBootstrap {
 		if (method_exists($context, 'registerProfileLinkAction')) {
 			$context->registerProfileLinkAction(AppointmentsAction::class);
 		}
+
+		$context->registerEventListener(UserDeletedEvent::class, UserDeletedListener::class);
 	}
 
 	/**

--- a/lib/Db/AppointmentConfigMapper.php
+++ b/lib/Db/AppointmentConfigMapper.php
@@ -116,4 +116,13 @@ class AppointmentConfigMapper extends QBMapper {
 
 		return $qb->executeStatement();
 	}
+
+	public function deleteByUserId(string $uid): void {
+		$qb = $this->db->getQueryBuilder();
+
+		$qb->delete($this->tableName)
+			->where($qb->expr()->eq('user_id', $qb->createNamedParameter($uid, IQueryBuilder::PARAM_STR), IQueryBuilder::PARAM_STR));
+
+		$qb->executeStatement();
+	}
 }

--- a/lib/Db/BookingMapper.php
+++ b/lib/Db/BookingMapper.php
@@ -57,6 +57,23 @@ class BookingMapper extends QBMapper {
 		return $this->findEntity($qb);
 	}
 
+	public function deleteByUserId(string $uid) {
+		$subQuery = $this->db->getQueryBuilder();
+		$delete = $this->db->getQueryBuilder();
+		$subQuery->select('id')
+			->from('calendar_appt_configs')
+			->where($delete->expr()->eq('user_id', $delete->createNamedParameter($uid), IQueryBuilder::PARAM_STR), IQueryBuilder::PARAM_STR);
+		$delete->delete($this->getTableName())
+			->where(
+				$delete->expr()->in(
+					'appt_config_id',
+					$delete->createFunction($subQuery->getSQL()),
+					IQueryBuilder::PARAM_INT_ARRAY
+				)
+			);
+		return $delete->executeStatement();
+	}
+
 	/**
 	 * @param int $validFor is subtracted from time() and then compared against 'created_at'.
 	 * @throws DbException

--- a/lib/Listener/UserDeletedListener.php
+++ b/lib/Listener/UserDeletedListener.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * @copyright 2021 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @author 2021 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace OCA\Calendar\Listener;
+
+use OCA\Calendar\Service\Appointments\AppointmentConfigService;
+use OCA\Calendar\Service\Appointments\BookingService;
+use OCP\EventDispatcher\Event;
+use OCP\EventDispatcher\IEventListener;
+use OCP\User\Events\UserDeletedEvent;
+use Psr\Log\LoggerInterface;
+
+class UserDeletedListener implements IEventListener {
+
+	/** @var AppointmentConfigService */
+	private $appointmentConfigService;
+
+	/** @var BookingService */
+	private $bookingService;
+
+	/** @var LoggerInterface */
+	private $logger;
+
+	public function __construct(AppointmentConfigService $appointmentConfigService,
+								BookingService $bookingService,
+								LoggerInterface $logger) {
+		$this->appointmentConfigService = $appointmentConfigService;
+		$this->bookingService = $bookingService;
+		$this->logger = $logger;
+	}
+
+	public function handle(Event $event): void {
+		if (!($event instanceof UserDeletedEvent)) {
+			return;
+		}
+
+		$this->bookingService->deleteByUser($event->getUser());
+		$this->appointmentConfigService->deleteByUser($event->getUser());
+
+		$this->logger->info("Calendar appointments cleaned up for deleted user " . $event->getUser()->getUID());
+	}
+}

--- a/lib/Service/Appointments/AppointmentConfigService.php
+++ b/lib/Service/Appointments/AppointmentConfigService.php
@@ -34,6 +34,7 @@ use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\AppFramework\Db\MultipleObjectsReturnedException;
 use OCP\AppFramework\Http;
 use OCP\DB\Exception as DbException;
+use OCP\IUser;
 use OCP\Security\ISecureRandom;
 
 class AppointmentConfigService {
@@ -200,5 +201,9 @@ class AppointmentConfigService {
 		} catch (DbException $e) {
 			throw new ServiceException('Could not create new appointment', $e->getCode(), $e);
 		}
+	}
+
+	public function deleteByUser(IUser $getUser): void {
+		$this->mapper->deleteByUserId($getUser->getUID());
 	}
 }

--- a/lib/Service/Appointments/BookingService.php
+++ b/lib/Service/Appointments/BookingService.php
@@ -38,6 +38,7 @@ use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\AppFramework\Http;
 use OCP\DB\Exception;
 use OCP\DB\Exception as DbException;
+use OCP\IUser;
 use OCP\Security\ISecureRandom;
 
 class BookingService {
@@ -179,6 +180,10 @@ class BookingService {
 				Http::STATUS_NOT_FOUND
 			);
 		}
+	}
+
+	public function deleteByUser(IUser $user): void {
+		$this->bookingMapper->deleteByUserId($user->getUID());
 	}
 
 	/**

--- a/tests/php/unit/Listener/UserDeletedListenerTest.php
+++ b/tests/php/unit/Listener/UserDeletedListenerTest.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * @copyright 2021 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @author 2021 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace OCA\Calendar\Tests\Unit\Listener;
+
+use ChristophWurst\Nextcloud\Testing\TestCase;
+use OCA\Calendar\Listener\UserDeletedListener;
+use OCP\EventDispatcher\Event;
+use OCP\IUser;
+use OCP\User\Events\UserDeletedEvent;
+
+class UserDeletedListenerTest extends TestCase {
+
+	/** @var \ChristophWurst\Nextcloud\Testing\ServiceMockObject */
+	private $serviceMock;
+
+	/** @var UserDeletedListener */
+	private $listener;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->serviceMock = $this->createServiceMock(UserDeletedListener::class);
+		$this->listener = $this->serviceMock->getService();
+	}
+
+	public function testHandleUnrelated(): void {
+		$event = new Event();
+		$this->serviceMock->getParameter('appointmentConfigService')
+			->expects(self::never())
+			->method('deleteByUser');
+		$this->serviceMock->getParameter('bookingService')
+			->expects(self::never())
+			->method('deleteByUser');
+
+		$this->listener->handle($event);
+	}
+
+	public function testHandle(): void {
+		$user = $this->createMock(IUser::class);
+		$event = new UserDeletedEvent($user);
+		$this->serviceMock->getParameter('appointmentConfigService')
+			->expects(self::once())
+			->method('deleteByUser')
+			->with($user);
+		$this->serviceMock->getParameter('bookingService')
+			->expects(self::once())
+			->method('deleteByUser')
+			->with($user);
+
+		$this->listener->handle($event);
+	}
+}

--- a/tests/php/unit/Service/Appointments/AppointmentConfigServiceTest.php
+++ b/tests/php/unit/Service/Appointments/AppointmentConfigServiceTest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * @copyright 2021 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @author 2021 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace OCA\Calendar\Tests\Unit\Service\Appointments;
+
+use ChristophWurst\Nextcloud\Testing\ServiceMockObject;
+use ChristophWurst\Nextcloud\Testing\TestCase;
+use OCA\Calendar\Service\Appointments\AppointmentConfigService;
+use OCP\IUser;
+
+class AppointmentConfigServiceTest extends TestCase {
+
+	/** @var ServiceMockObject */
+	private $serviceMock;
+
+	/** @var AppointmentConfigService */
+	private $service;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->serviceMock = $this->createServiceMock(AppointmentConfigService::class);
+		$this->service = $this->serviceMock->getService();
+	}
+
+	public function testDeleteByUser(): void {
+		$user = $this->createMock(IUser::class);
+		$user->method('getUid')->willReturn('user123');
+		$this->serviceMock->getParameter('mapper')
+			->expects(self::once())
+			->method('deleteByUserId')
+			->with('user123');
+
+		$this->service->deleteByUser($user);
+	}
+}

--- a/tests/php/unit/Service/Appointments/BookingServiceTest.php
+++ b/tests/php/unit/Service/Appointments/BookingServiceTest.php
@@ -23,6 +23,7 @@ declare(strict_types=1);
  * License along with this library.  If not, see <http://www.gnu.org/licenses/>.
  *
  */
+
 namespace OCA\Calendar\Tests\Unit\Service\Appointments;
 
 use ChristophWurst\Nextcloud\Testing\TestCase;
@@ -41,6 +42,7 @@ use OCA\Calendar\Service\Appointments\MailService;
 use OCA\Calendar\Service\Appointments\SlotExtrapolator;
 use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\Calendar\ICalendarQuery;
+use OCP\IUser;
 use OCP\Security\ISecureRandom;
 use PHPUnit\Framework\MockObject\MockObject;
 use Safe\DateTimeImmutable;
@@ -113,7 +115,7 @@ class BookingServiceTest extends TestCase {
 		$this->eventConflictFilter->expects(self::once())
 			->method('filter');
 
-		$slots = $this->service-> getAvailableSlots($config, 0, 100);
+		$slots = $this->service->getAvailableSlots($config, 0, 100);
 		self::assertEmpty($slots);
 	}
 
@@ -285,7 +287,17 @@ class BookingServiceTest extends TestCase {
 		$this->service->findByToken($token);
 	}
 
-	public function testDeleteOutdated() : void {
+	public function testDeleteByUser(): void {
+		$user = $this->createMock(IUser::class);
+		$user->method('getUid')->willReturn('user123');
+		$this->bookingMapper->expects(self::once())
+			->method('deleteByUserId')
+			->with('user123');
+
+		$this->service->deleteByUser($user);
+	}
+
+	public function testDeleteOutdated(): void {
 		$this->bookingMapper->expects(self::once())
 			->method('deleteOutdated')
 			->with(24 * 60 * 60)


### PR DESCRIPTION
Fixes https://github.com/nextcloud/calendar/issues/3604

To test create a new user on your dev instance, then create at least one appointment config. Delete the user after and check the database. There shouldn't be any configs of that user.