### PR TITLE
Fix appointment availability time zone from caldav

### DIFF
--- a/src/models/appointmentConfig.js
+++ b/src/models/appointmentConfig.js
@@ -126,7 +126,7 @@ export default class AppointmentConfig {
 		if (scheduleInbox && scheduleInbox.availability) {
 			const converted = vavailabilityToSlots(scheduleInbox.availability)
 			slots = converted.slots
-			timezoneId = slots.timezoneId
+			timezoneId = converted.timezoneId ?? timezoneId
 		} else {
 			// Set default availability to Mo-Fr 9-5
 			const tsAtTime = (hours, minutes) => Math.round((new Date()).setHours(hours, minutes, 0, 0) / 1000);


### PR DESCRIPTION
And add a fallback as well.

Bug introduced with https://github.com/nextcloud/calendar/pull/3700. The time zone was missing from the availability data structure and the validation did not allow creation of new configs.