### PR TITLE
Log debug infos of appointment slots

### DIFF
--- a/tests/php/unit/Service/Appointments/BookingServiceTest.php
+++ b/tests/php/unit/Service/Appointments/BookingServiceTest.php
@@ -45,6 +45,7 @@ use OCP\Calendar\ICalendarQuery;
 use OCP\IUser;
 use OCP\Security\ISecureRandom;
 use PHPUnit\Framework\MockObject\MockObject;
+use Psr\Log\LoggerInterface;
 use Safe\DateTimeImmutable;
 
 class BookingServiceTest extends TestCase {
@@ -73,6 +74,9 @@ class BookingServiceTest extends TestCase {
 	/** @var MailService|MockObject */
 	private $mailService;
 
+	/** @var MockObject|LoggerInterface */
+	private $logger;
+
 	/** @var BookingService */
 	private $service;
 
@@ -91,6 +95,7 @@ class BookingServiceTest extends TestCase {
 		$this->bookingCalendarWriter = $this->createMock(BookingCalendarWriter::class);
 		$this->random = $this->createMock(ISecureRandom::class);
 		$this->mailService = $this->createMock(MailService::class);
+		$this->logger = $this->createMock(LoggerInterface::class);
 		$this->service = new BookingService(
 			$this->availabilityGenerator,
 			$this->extrapolator,
@@ -99,7 +104,8 @@ class BookingServiceTest extends TestCase {
 			$this->bookingMapper,
 			$this->bookingCalendarWriter,
 			$this->random,
-			$this->mailService
+			$this->mailService,
+			$this->logger,
 		);
 	}
 


### PR DESCRIPTION
The logic is a black box otherwise and impossible to debug in
production.

Example log

```json
{
  "reqId": "9lovcMHpqpTdxWVQQJlX",
  "level": 0,
  "time": "2021-11-29T13:02:32+00:00",
  "remoteAddr": "127.0.0.1",
  "user": "admin",
  "app": "calendar",
  "method": "GET",
  "url": "/apps/calendar/appointment/27/slots?startTime=1638190952&timeZone=Europe%2FVienna",
  "message": "Appointment config QByBoCW64gbs has 1 intervals that result in 11 possible slots. 11 slots remain after the daily limit. 11 available slots remain after conflict checking.",
  "userAgent": "Mozilla/5.0 (X11; Linux x86_64; rv:94.0) Gecko/20100101 Firefox/94.0",
  "version": "24.0.0.0"
}
``` 