### PR TITLE
Fix white space in appointment descriptions

### DIFF
--- a/src/components/Appointments/AppointmentDetails.vue
+++ b/src/components/Appointments/AppointmentDetails.vue
@@ -19,9 +19,8 @@
 				<div class="booking__time">
 					{{ startTime }} - {{ endTime }}
 				</div>
-				<div class="booking__description">
-					{{ config.description }}
-				</div>
+				<!-- Description needs to stay inline due to its whitespace -->
+				<span class="booking__description">{{ config.description }}</span>
 			</div>
 			<div class="appointment-details">
 				<div>
@@ -176,6 +175,10 @@ export default {
 
 .booking-error {
 	color: var(--color-error);
+}
+
+.booking__description {
+	white-space: break-spaces;
 }
 
 .buttons {

--- a/src/views/Appointments/Booking.vue
+++ b/src/views/Appointments/Booking.vue
@@ -36,6 +36,7 @@
 			<h2 class="booking__name">
 				{{ config.name }}
 			</h2>
+			<!-- Description needs to stay inline due to its whitespace -->
 			<span class="booking__description">{{ config.description }}</span>
 		</div>
 		<div class="booking__date-selection">
@@ -238,6 +239,10 @@ export default {
 	&__date-selection {
 		display: flex;
 		flex-direction: column;
+	}
+
+	&__description {
+		white-space: break-spaces;
 	}
 
 	&__config-user-info,


### PR DESCRIPTION
Fix #3737 

## Booking overview page
![Screenshot 2021-11-29 at 17-22-18 Nextcloud](https://user-images.githubusercontent.com/1479486/143904759-4228a7fa-4f37-405e-80f7-381260fb91dd.png)

## Booking modal
![Screenshot 2021-11-29 at 17-22-58 Nextcloud](https://user-images.githubusercontent.com/1479486/143904762-4314f385-0c41-4d75-b4be-4f52b72afd48.png)
