### PR TITLE
Fix vertical padding on booking page

### DIFF
--- a/src/views/Appointments/Booking.vue
+++ b/src/views/Appointments/Booking.vue
@@ -230,8 +230,8 @@ export default {
 
 <style lang="scss" scoped>
 .booking {
-	margin: auto;
-	padding-top: 80px;
+	margin: 0 auto;
+	padding-top: 50px;
 	display: flex;
 	flex-direction: row;
 	max-width: 800px;


### PR DESCRIPTION
Fix #3726

This also eliminates the jump when selecting a date with many slots.

![Screenshot 2021-11-30 at 12-02-13 Nextcloud](https://user-images.githubusercontent.com/1479486/144035906-50cd1430-fd17-485f-b4c5-b38a98f38ff2.png)
