### PR TITLE
Add picker for conflict calendars of appointments

### DIFF
--- a/css/app-modal.scss
+++ b/css/app-modal.scss
@@ -57,6 +57,12 @@
 					flex: 1 200px;
 				}
 			}
+
+			// Rows that don't have their own vue components
+			&--local {
+				display: flex;
+				flex-direction: column;
+			}
 		}
 
 		&__row + &__row {

--- a/css/app-sidebar.scss
+++ b/css/app-sidebar.scss
@@ -804,7 +804,6 @@
 }
 
 .calendar-picker-option {
-	width: 100%;
 	display: flex;
 	align-items: center;
 

--- a/src/components/AppNavigation/Settings/ImportScreenRow.vue
+++ b/src/components/AppNavigation/Settings/ImportScreenRow.vue
@@ -26,7 +26,7 @@
 			{{ file.name }}
 		</div>
 		<CalendarPicker class="import-modal-file-item__calendar-select"
-			:calendar="calendar"
+			:value="calendar"
 			:calendars="calendars"
 			@select-calendar="selectCalendar" />
 	</li>

--- a/src/components/AppointmentConfigModal.vue
+++ b/src/components/AppointmentConfigModal.vue
@@ -52,7 +52,7 @@
 							<div class="calendar-select">
 								<label>{{ t('calendar', 'Calendar') }}</label>
 								<CalendarPicker v-if="calendar !== undefined"
-									:calendar="calendar"
+									:value="calendar"
 									:calendars="ownSortedCalendars"
 									:show-calendar-on-select="false"
 									@select-calendar="changeCalendar" />
@@ -69,6 +69,18 @@
 							<DurationSelect
 								:label="t('calendar', 'Increments')"
 								:value.sync="editing.increment" />
+						</div>
+
+						<div
+							class="appointment-config-modal__form__row appointment-config-modal__form__row--local">
+							<label>Calendars to check for conflicts</label>
+							<CalendarPicker
+								:value="conflictCalendars"
+								:calendars="ownSortedCalendars"
+								:multiple="true"
+								:show-calendar-on-select="false"
+								@select-calendar="addConflictCalender"
+								@remove-calendar="removeConflictCalendar" />
 						</div>
 					</fieldset>
 
@@ -206,6 +218,12 @@ export default {
 			const uri = this.editing.targetCalendarUri
 			return this.ownSortedCalendars.find(cal => this.calendarUrlToUri(cal.url) === uri)
 		},
+		conflictCalendars() {
+			const freebusyUris = this.editing.freebusyUris ?? []
+			return freebusyUris.map(uri => {
+				return this.ownSortedCalendars.find(cal => this.calendarUrlToUri(cal.url) === uri)
+			})
+		},
 		defaultConfig() {
 			return AppointmentConfig.createDefault(
 				this.calendarUrlToUri(this.$store.getters.ownSortedCalendars[0].url),
@@ -238,6 +256,12 @@ export default {
 		},
 		changeCalendar(calendar) {
 			this.editing.targetCalendarUri = this.calendarUrlToUri(calendar.url)
+		},
+		addConflictCalender(calendar) {
+			this.editing.freebusyUris.push(this.calendarUrlToUri(calendar.url))
+		},
+		removeConflictCalendar(calendar) {
+			this.editing.freebusyUris = this.editing.freebusyUris.filter(uri => uri !== this.calendarUrlToUri(calendar.url))
 		},
 		async save() {
 			if (!this.enablePreparationDuration) {

--- a/src/components/Editor/Properties/PropertyCalendarPicker.vue
+++ b/src/components/Editor/Properties/PropertyCalendarPicker.vue
@@ -27,7 +27,7 @@
 			:class="{ 'property-select__input--readonly-calendar-picker': isReadOnly }">
 			<CalendarPicker
 				v-if="!isReadOnly"
-				:calendar="calendar"
+				:value="calendar"
 				:calendars="calendars"
 				:show-calendar-on-select="true"
 				@select-calendar="selectCalendar" />

--- a/src/components/Shared/CalendarPicker.vue
+++ b/src/components/Shared/CalendarPicker.vue
@@ -4,13 +4,20 @@
 		track-by="url"
 		:disabled="isDisabled"
 		:options="calendars"
-		:value="calendar"
-		@select="change">
-		<template #singleLabel="scope">
-			<CalendarPickerOption v-bind="scope.option" />
+		:value="value"
+		:multiple="multiple"
+		@select="change"
+		@remove="remove">
+		<template #singleLabel="{ option }">
+			<CalendarPickerOption v-bind="option" />
 		</template>
-		<template #option="scope">
-			<CalendarPickerOption v-bind="scope.option" />
+		<template #option="{ option }">
+			<CalendarPickerOption v-bind="option" />
+		</template>
+		<template #tag="{ option }">
+			<div class="calendar-picker__tag">
+				<CalendarPickerOption v-bind="option" />
+			</div>
 		</template>
 	</Multiselect>
 </template>
@@ -25,8 +32,8 @@ export default {
 		Multiselect,
 	},
 	props: {
-		calendar: {
-			type: Object,
+		value: {
+			type: [Object, Array],
 			required: true,
 		},
 		calendars: {
@@ -34,6 +41,10 @@ export default {
 			required: true,
 		},
 		showCalendarOnSelect: {
+			type: Boolean,
+			default: false,
+		},
+		multiple: {
 			type: Boolean,
 			default: false,
 		},
@@ -62,6 +73,11 @@ export default {
 
 			this.$emit('select-calendar', newCalendar)
 		},
+		remove(calendar) {
+			if (this.multiple) {
+				this.$emit('remove-calendar', calendar)
+			}
+		},
 	},
 }
 </script>
@@ -69,5 +85,15 @@ export default {
 <style lang="scss" scoped>
 ::v-deep .multiselect__tags {
 	margin: 3px 0;
+}
+
+.calendar-picker__tag {
+	border: 1px solid var(--color-border);
+	border-radius: var(--border-radius);
+	padding: 0 5px;
+}
+
+.calendar-picker__tag + .calendar-picker__tag {
+	margin-left: 5px;
 }
 </style>


### PR DESCRIPTION
Fix #3722 

![Peek 2021-12-01 12-43](https://user-images.githubusercontent.com/1479486/144228664-068d9579-fe9b-4289-ad33-fcfcdfc64439.gif)


I refactored the existing `CalendarPicker` component to also work with multiple values so here is some proof that it still works elsewhere:

## Usages in editors

![Screenshot 2021-12-01 at 12-44-58 Dezember 2021 - Kalender - Nextcloud](https://user-images.githubusercontent.com/1479486/144228926-0e2ad070-c87d-4571-bacc-c02e527f9341.png)
![Screenshot 2021-12-01 at 12-45-13 Dezember 2021 - Kalender - Nextcloud](https://user-images.githubusercontent.com/1479486/144228930-4e01578c-9584-4ff7-b5b7-54823c06c5dd.png)

## Usages in read only shared editors

![Screenshot 2021-12-01 at 12-32-54 Dezember 2021 - Kalender - Nextcloud](https://user-images.githubusercontent.com/1479486/144228379-b089a28f-a93e-4919-9f9b-7135da8b1eea.png)
![Screenshot 2021-12-01 at 12-40-40 Dezember 2021 - Kalender - Nextcloud](https://user-images.githubusercontent.com/1479486/144228381-dd0e1a8f-1070-43e6-b391-0d07efd48d23.png)

(Couldn't debug the last usage in the import modal because I failed to provide a valid ICS file.)
