### PR TITLE
Fix freebusyUris naming inconsistencies

### DIFF
--- a/lib/Controller/AppointmentConfigController.php
+++ b/lib/Controller/AppointmentConfigController.php
@@ -142,7 +142,7 @@ class AppointmentConfigController extends Controller {
 	 * @param int $followupDuration
 	 * @param int $timeBeforeNextSlot
 	 * @param int|null $dailyMax
-	 * @param string[]|null $freebusyUris
+	 * @param string[]|null $calendarFreeBusyUris
 	 * @param int|null $start
 	 * @param int|null $end
 	 * @return JsonResponse
@@ -160,7 +160,7 @@ class AppointmentConfigController extends Controller {
 		int $followupDuration = 0,
 		int $timeBeforeNextSlot = 0,
 		?int $dailyMax = null,
-		?array $freebusyUris = null,
+		?array $calendarFreeBusyUris = null,
 		?int $start = null,
 		?int $end = null): JsonResponse {
 		if ($this->userId === null) {
@@ -187,7 +187,7 @@ class AppointmentConfigController extends Controller {
 				$followupDuration,
 				$timeBeforeNextSlot,
 				$dailyMax,
-				$freebusyUris,
+				$calendarFreeBusyUris,
 				$start,
 				$end
 			);
@@ -233,7 +233,7 @@ class AppointmentConfigController extends Controller {
 		int $followupDuration = 0,
 		int $timeBeforeNextSlot = 0,
 		?int $dailyMax = null,
-		?array $freebusyUris = null,
+		?array $calendarFreeBusyUris = null,
 		?int $start = null,
 		?int $end = null): JsonResponse {
 		if ($this->userId === null) {
@@ -265,7 +265,7 @@ class AppointmentConfigController extends Controller {
 		$appointmentConfig->setFollowupDuration($followupDuration);
 		$appointmentConfig->setTimeBeforeNextSlot($timeBeforeNextSlot);
 		$appointmentConfig->setDailyMax($dailyMax);
-		$appointmentConfig->setCalendarFreeBusyUrisAsArray($freebusyUris ?? []);
+		$appointmentConfig->setCalendarFreeBusyUrisAsArray($calendarFreeBusyUris ?? []);
 		$appointmentConfig->setStart($start);
 		$appointmentConfig->setEnd($end);
 

--- a/lib/Db/AppointmentConfig.php
+++ b/lib/Db/AppointmentConfig.php
@@ -186,7 +186,7 @@ class AppointmentConfig extends Entity implements JsonSerializable {
 			'visibility' => $this->getVisibility(),
 			'userId' => $this->getUserId(),
 			'targetCalendarUri' => $this->getTargetCalendarUri(),
-			'calendarFreeBusyUris' => $this->getCalendarFreebusyUris(),
+			'calendarFreeBusyUris' => $this->getCalendarFreebusyUrisAsArray(),
 			'availability' => $this->getAvailability() === null ? null : json_decode($this->getAvailability(), true),
 			'start' => $this->getStart(),
 			'end' => $this->getEnd(),

--- a/lib/Service/Appointments/AppointmentConfigService.php
+++ b/lib/Service/Appointments/AppointmentConfigService.php
@@ -155,7 +155,7 @@ class AppointmentConfigService {
 	 * @param int $followupDuration
 	 * @param int $buffer
 	 * @param int|null $dailyMax
-	 * @param string[] $freebusyUris
+	 * @param string[] $calendarFreeBusyUris
 	 * @param int|null $start
 	 * @param int|null $end
 	 * @return AppointmentConfig
@@ -174,7 +174,7 @@ class AppointmentConfigService {
 						   int $followupDuration,
 						   int $buffer,
 						   ?int $dailyMax,
-						   ?array $freebusyUris = [],
+						   ?array $calendarFreeBusyUris = [],
 						   ?int $start = null,
 						   ?int $end = null): AppointmentConfig {
 		try {
@@ -193,7 +193,7 @@ class AppointmentConfigService {
 			$appointmentConfig->setFollowupDuration($followupDuration);
 			$appointmentConfig->setTimeBeforeNextSlot($buffer);
 			$appointmentConfig->setDailyMax($dailyMax);
-			$appointmentConfig->setCalendarFreeBusyUrisAsArray($freebusyUris);
+			$appointmentConfig->setCalendarFreeBusyUrisAsArray($calendarFreeBusyUris);
 			$appointmentConfig->setStart($start);
 			$appointmentConfig->setEnd($end);
 

--- a/src/components/AppointmentConfigModal.vue
+++ b/src/components/AppointmentConfigModal.vue
@@ -219,7 +219,7 @@ export default {
 			return this.ownSortedCalendars.find(cal => this.calendarUrlToUri(cal.url) === uri)
 		},
 		conflictCalendars() {
-			const freebusyUris = this.editing.freebusyUris ?? []
+			const freebusyUris = this.editing.calendarFreeBusyUris ?? []
 			return freebusyUris.map(uri => {
 				return this.ownSortedCalendars.find(cal => this.calendarUrlToUri(cal.url) === uri)
 			})
@@ -258,10 +258,10 @@ export default {
 			this.editing.targetCalendarUri = this.calendarUrlToUri(calendar.url)
 		},
 		addConflictCalender(calendar) {
-			this.editing.freebusyUris.push(this.calendarUrlToUri(calendar.url))
+			this.editing.calendarFreeBusyUris.push(this.calendarUrlToUri(calendar.url))
 		},
 		removeConflictCalendar(calendar) {
-			this.editing.freebusyUris = this.editing.freebusyUris.filter(uri => uri !== this.calendarUrlToUri(calendar.url))
+			this.editing.calendarFreeBusyUris = this.editing.calendarFreeBusyUris.filter(uri => uri !== this.calendarUrlToUri(calendar.url))
 		},
 		async save() {
 			if (!this.enablePreparationDuration) {

--- a/src/models/appointmentConfig.js
+++ b/src/models/appointmentConfig.js
@@ -50,7 +50,7 @@ export default class AppointmentConfig {
 	/** @member {string} */
 	targetCalendarUri
 
-	/** @member {Object} */
+	/** @member {object} */
 	availability
 
 	/** @member {number} */
@@ -72,7 +72,7 @@ export default class AppointmentConfig {
 	dailyMax
 
 	/** @member {?string[]} */
-	freebusyUris
+	calendarFreeBusyUris
 
 	/**
 	 * Create a new AppointmentConfig from the given plain object data
@@ -85,14 +85,14 @@ export default class AppointmentConfig {
 	 * @param {string} data.location Location
 	 * @param {string} data.visibility Visibility
 	 * @param {string} data.targetCalendarUri Target calendar URI
-	 * @param {Object} data.availability Availability
+	 * @param {object} data.availability Availability
 	 * @param {number} data.length Length in seconds
 	 * @param {number} data.increment Increment in seconds
 	 * @param {number} data.preparationDuration Preparation duration in seconds
 	 * @param {number} data.followupDuration Followup duration in seconds
 	 * @param {number} data.timeBeforeNextSlot Time before next slot in seconds
 	 * @param {?number} data.dailyMax Max daily slots
-	 * @param {?string[]} data.freebusyUris FreeBusy URIs
+	 * @param {?string[]} data.calendarFreeBusyUris URIs of calendars to check for conflicts
 	 */
 	constructor(data) {
 		data ??= {}
@@ -110,7 +110,7 @@ export default class AppointmentConfig {
 		this.followupDuration = tryParseInt(data.followupDuration)
 		this.timeBeforeNextSlot = tryParseInt(data.timeBeforeNextSlot)
 		this.dailyMax = tryParseInt(data.dailyMax)
-		this.freebusyUris = data.freebusyUris
+		this.calendarFreeBusyUris = data.calendarFreeBusyUris
 	}
 
 	/**
@@ -151,7 +151,7 @@ export default class AppointmentConfig {
 			preparationDuration: 0,
 			followupDuration: 0,
 			timeBeforeNextSlot: 0,
-			freebusyUris: [],
+			calendarFreeBusyUris: [],
 		})
 
 	}


### PR DESCRIPTION
The name of the conflict calendar URIs field was inconsistent between the front and back end.

## How to test?

Create new and edit existing appointment configs and observe that conflict calendars are saved correctly.