### PR TITLE
Add flex-wrap for better mobile design

### DIFF
--- a/src/views/Appointments/Booking.vue
+++ b/src/views/Appointments/Booking.vue
@@ -234,6 +234,7 @@ export default {
 	padding-top: 50px;
 	display: flex;
 	flex-direction: row;
+	flex-wrap: wrap;
 	max-width: 800px;
 
 	&__date-selection {


### PR DESCRIPTION
Added "flex-warp: wrap;" to prevent unusable mobile design since flex-wrap default is nowrap which leads to horizontal scrolling on mobile devices

I hope this pull request is right here. It's my first pull request, so i'm sorry if it doesn't belongs here :)

Fixes #3808