### PR TITLE
pick time first

### DIFF
--- a/src/components/Shared/DatePicker.vue
+++ b/src/components/Shared/DatePicker.vue
@@ -144,7 +144,7 @@ export default {
 				stringify: this.stringify,
 				parse: this.parse,
 			},
-			showTimePanel: false,
+			showTimePanel: true,
 		}
 	},
 	computed: {
@@ -255,10 +255,10 @@ export default {
 			this.showTimezonePopover = !this.showTimezonePopover
 		},
 		/**
-		 * Reset to date-panel on close of datepicker
+		 * Reset to time-panel on close of datepicker
 		 */
 		close() {
-			this.showTimePanel = false
+			this.showTimePanel = true
 			this.$emit('close')
 		},
 		/**


### PR DESCRIPTION
This will show the timepicker (instead of the datepicker) directly when clicking into the date/time field. In my opinion would be having two dedicated fields for date and time be the proper solution but until then is being able to choose the time before the date the much better flow since most of the time you want to choose/change the time and not the date.

Signed-off-by: szaimen <szaimen@e.mail.de>

<details>
<summary>For my own testing</summary>

```
docker run -it \
-e CALENDAR_BRANCH=enh/noid/pick-time-first \
-p 8443:443 \
-e TRUSTED_DOMAIN=192.168.146.128 \
--name nextcloud-easy-test \
ghcr.io/szaimen/nextcloud-easy-test:latest
```

</details>