### PR TITLE
show the whole title if the event is long enough

### DIFF
--- a/css/fullcalendar.scss
+++ b/css/fullcalendar.scss
@@ -210,11 +210,15 @@
 }
 
 .fc-v-event {
-        min-height: 4em;
-}
+	min-height: 4em;
 
-.fc-v-event.fc-timegrid-event-short {
-        min-height: 2em;
+	.fc-timegrid-event-short {
+		min-height: 2em;
+	}
+
+	.fc-event-title {
+		white-space: initial;
+	}
 }
 
 // Fix Month view


### PR DESCRIPTION
| Before | After |
|---|---|
| ![image](https://user-images.githubusercontent.com/42591237/145900304-6e4e3cfb-1ecd-4503-bf1d-bed1922c144a.png) | ![image](https://user-images.githubusercontent.com/42591237/145900325-11117097-463e-43e5-81a9-f56deb396e1e.png) |


Signed-off-by: szaimen <szaimen@e.mail.de>

<details>
<summary>For my own testing</summary>

```
docker run -it \
-e CALENDAR_BRANCH=enh/noid/show-whole-title \
-p 8443:443 \
-e TRUSTED_DOMAIN=192.168.146.128 \
--name nextcloud-easy-test \
ghcr.io/szaimen/nextcloud-easy-test:latest
```

</details>