### PR TITLE
improve UX regarding target time

### DIFF
--- a/src/store/calendarObjectInstance.js
+++ b/src/store/calendarObjectInstance.js
@@ -214,11 +214,20 @@ const mutations = {
 			// endDate is inclusive, but DTEND needs to be exclusive, so always add one day
 			calendarObjectInstance.eventComponent.endDate.addDuration(DurationValue.fromSeconds(60 * 60 * 24))
 		} else {
+			// Is end before start?
 			if (endDateObj.compare(startDateObj) === -1) {
-				const timezone = getTimezoneManager().getTimezoneForId(startDateObj.timezoneId)
-				calendarObjectInstance.eventComponent.startDate
-					= calendarObjectInstance.eventComponent.endDate.getInTimezone(timezone)
-				calendarObjectInstance.startDate = getDateFromDateTimeValue(calendarObjectInstance.eventComponent.startDate)
+				// Is end more than one day before start?
+				endDateObj.addDuration(DurationValue.fromSeconds(60 * 60 * 24))
+				if (endDateObj.compare(startDateObj) === -1) {
+					const timezone = getTimezoneManager().getTimezoneForId(startDateObj.timezoneId)
+					calendarObjectInstance.eventComponent.startDate
+						= calendarObjectInstance.eventComponent.endDate.getInTimezone(timezone)
+					calendarObjectInstance.startDate = getDateFromDateTimeValue(calendarObjectInstance.eventComponent.startDate)
+				} else {
+					// add one day to endDate if the endDate is before the startDate which allows to easily create events that reach over or to 0:00
+					calendarObjectInstance.eventComponent.endDate.addDuration(DurationValue.fromSeconds(60 * 60 * 24))
+					endDate = new Date(endDate.getTime() + 24 * 60 * 60 * 1000)
+				}
 			}
 		}
 


### PR DESCRIPTION
This is best reviewed like this https://github.com/nextcloud/calendar/pull/3825/files?diff=unified&w=1

Close https://github.com/nextcloud/calendar/issues/3824

## Before
https://user-images.githubusercontent.com/42591237/146625622-af0640fd-7da5-4d03-acc0-cde6fbbd3d74.mp4

## After
https://user-images.githubusercontent.com/42591237/146625491-3b64b552-e0f5-4ee8-8c19-beb51d4785c7.mp4

Signed-off-by: szaimen <szaimen@e.mail.de>

<details>
<summary>For my own testing</summary>

```
docker run -it \
-e CALENDAR_BRANCH=enh/3824/target-time \
-p 8443:443 \
-e TRUSTED_DOMAIN=192.168.146.128 \
--name nextcloud-easy-test \
ghcr.io/szaimen/nextcloud-easy-test:latest
```

</details>