### PR TITLE
fix layout for slotduration of one hour

### DIFF
--- a/src/components/CalendarGrid.vue
+++ b/src/components/CalendarGrid.vue
@@ -135,6 +135,7 @@ export default {
 				headerToolbar: false,
 				height: '100%',
 				slotDuration: this.slotDuration,
+				expandRows: true,
 				weekNumbers: this.showWeekNumbers,
 				weekends: this.showWeekends,
 				dayMaxEventRows: this.eventLimit,


### PR DESCRIPTION
| Before | After |
|---|---|
| ![image](https://user-images.githubusercontent.com/42591237/146650269-a6115b7a-102b-4553-abf7-52955d6a7d4f.png) | ![image](https://user-images.githubusercontent.com/42591237/146650144-42eb5caa-8271-469d-a787-527e38c46db3.png) |

Signed-off-by: szaimen <szaimen@e.mail.de>

<details>
<summary>For my own testing</summary>

```
docker run -it \
-e CALENDAR_BRANCH=enh/noid/slot-duration \
-p 8443:443 \
-e TRUSTED_DOMAIN=192.168.146.128 \
--name nextcloud-easy-test \
ghcr.io/szaimen/nextcloud-easy-test:latest
```

</details>