### PR TITLE
adjust week view

### DIFF
--- a/css/fullcalendar.scss
+++ b/css/fullcalendar.scss
@@ -60,6 +60,11 @@
 	color: var(--color-text-lighter) !important;
 }
 
+// Remove dotted half-lines
+.fc .fc-timegrid-slot-minor { 
+	border-top-style: none !important; 
+}
+
 // Center the date in month view
 .fc-daygrid-day-top {
 	justify-content: center;
@@ -204,9 +209,29 @@
 	word-break: break-word;
 	white-space: normal;
 }
-.fc-timeGridWeek-view .fc-daygrid-more-link {
-	word-break: break-all;
-	white-space: normal;
+.fc-timeGridWeek-view {
+	.fc-daygrid-more-link {
+		word-break: break-all;
+		white-space: normal;
+	}
+
+	.fc-day-today {
+		&.fc-col-header-cell {
+			background-color: var(--color-primary-light);
+		}
+
+		.fc-timegrid-col-frame {
+			background-color: var(--color-primary-light);
+		}
+
+		.fc-daygrid-day-frame {
+			background-color: var(--color-primary-light);
+		}
+
+		.fc-event {
+			box-shadow: 0px 0px 0px 1px var(--color-primary-light) !important;
+		}
+	}
 }
 
 .fc-v-event {


### PR DESCRIPTION
This is best reviewed like this: https://github.com/nextcloud/calendar/pull/3831/files?diff=unified&w=1

### Goal:
**Making today better recognizeable on big screens**

| Before | After |
|---|---|
| ![image](https://user-images.githubusercontent.com/42591237/146953496-513dcf39-7846-4451-8227-75bf32cabb96.png) |![image](https://user-images.githubusercontent.com/42591237/146952821-9e3b9106-b92a-44b4-83da-ef28d299d2b0.png) |
| ![image](https://user-images.githubusercontent.com/42591237/146953242-1cc3ad54-05c8-4957-9f97-076ce977c98e.png) | ![image](https://user-images.githubusercontent.com/42591237/146952734-e73b7a46-043e-4344-a295-51c956b09f60.png) |
Signed-off-by: szaimen <szaimen@e.mail.de>

<details>
<summary>For my own testing</summary>

```
docker run -it \
-e CALENDAR_BRANCH=enh/noid/adjust-week-view \
-p 8443:443 \
-e TRUSTED_DOMAIN=192.168.146.128 \
--name nextcloud-easy-test \
ghcr.io/szaimen/nextcloud-easy-test:latest
```

</details>