### PR TITLE
fix short events being to long

### DIFF
--- a/css/fullcalendar.scss
+++ b/css/fullcalendar.scss
@@ -212,7 +212,7 @@
 .fc-v-event {
 	min-height: 4em;
 
-	.fc-timegrid-event-short {
+	&.fc-timegrid-event-short {
 		min-height: 2em;
 	}
 


### PR DESCRIPTION
| Before | After |
|---|---|
| ![image](https://user-images.githubusercontent.com/42591237/146766498-c54a25df-b036-4aca-9830-89e4a62d8ebc.png) | ![image](https://user-images.githubusercontent.com/42591237/146767322-5ba5301f-979b-4681-99d3-f84e9bcf9198.png) |

Signed-off-by: szaimen <szaimen@e.mail.de>

<details>
<summary>For my own testing</summary>

```
docker run -it \
-e CALENDAR_BRANCH=enh/noid/short-events \
-p 8443:443 \
-e TRUSTED_DOMAIN=192.168.146.128 \
--name nextcloud-easy-test \
ghcr.io/szaimen/nextcloud-easy-test:latest
```

</details>