### PR TITLE
Fix calendar selection in editor sidebar

### DIFF
--- a/src/views/EditSidebar.vue
+++ b/src/views/EditSidebar.vue
@@ -92,7 +92,7 @@
 				:calendars="calendars"
 				:calendar="selectedCalendar"
 				:is-read-only="isReadOnly || !canModifyCalendar || isViewedByAttendee"
-				@selectCalendar="changeCalendar" />
+				@select-calendar="changeCalendar" />
 
 			<PropertyTitleTimePicker
 				:start-date="startDate"


### PR DESCRIPTION
Fixes https://github.com/nextcloud/calendar/issues/3838
Fixes https://github.com/nextcloud/calendar/issues/3842

## How to test
1. Have two or more calendars
2. Create an event in the first calendar
3. Open the editor sidebar
4. Try to switch to the second calendar

On main: calendar stays on the first one
Here: second calendar is selected