### PR TITLE
Update info.xml authors with new maintainers and co-maintainers

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -17,12 +17,8 @@
 	]]></description>
 	<version>3.1.0-alpha.1</version>
 	<licence>agpl</licence>
-	<author homepage="https://georg.coffee">Georg Ehrke</author>
-	<author homepage="https://tcit.fr">Thomas Citharel</author>
-	<author>Christoph Wurst</author>
-	<author>Greta Doçi</author>
-	<author>Richard Steinmetz</author>
 	<author>Anna Larch</author>
+	<author homepage="https://github.com/nextcloud/groupware">Nextcloud Groupware Team</author>
 	<namespace>Calendar</namespace>
 	<documentation>
 		<user>https://docs.nextcloud.com/server/latest/user_manual/en/groupware/calendar.html</user>


### PR DESCRIPTION
Ref https://github.com/nextcloud/groupware/issues/6#issuecomment-975367771

Ideally `<author>` was named `<maintainer>`. Obviously we are all still authors. But there is now one main person to maintain the app, the rest of us are co-maintainers.