### PR TITLE
Accept and decline invitations

### DIFF
--- a/src/components/Editor/InvitationResponseButtons.vue
+++ b/src/components/Editor/InvitationResponseButtons.vue
@@ -1,0 +1,180 @@
+<!--
+  - @copyright Copyright (c) 2021 Richard Steinmetz <richard@steinmetz.cloud>
+  -
+  - @author Richard Steinmetz <richard@steinmetz.cloud>
+  -
+  - @license GNU AGPL version 3 or any later version
+  -
+  - This program is free software: you can redistribute it and/or modify
+  - it under the terms of the GNU Affero General Public License as
+  - published by the Free Software Foundation, either version 3 of the
+  - License, or (at your option) any later version.
+  -
+  - This program is distributed in the hope that it will be useful,
+  - but WITHOUT ANY WARRANTY; without even the implied warranty of
+  - MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  - GNU Affero General Public License for more details.
+  -
+  - You should have received a copy of the GNU Affero General Public License
+  - along with this program. If not, see <http://www.gnu.org/licenses/>.
+  -
+  -->
+
+<template>
+	<div
+		class="invitation-response-buttons"
+		:class="{ 'invitation-response-buttons--narrow': narrow }">
+		<button
+			v-if="!isAccepted"
+			class="invitation-response-buttons__button primary"
+			:disabled="loading"
+			@click="accept">
+			{{ t('calendar', 'Accept') }}
+		</button>
+		<button
+			v-if="!isDeclined"
+			class="invitation-response-buttons__button error"
+			:disabled="loading"
+			@click="decline">
+			{{ t('calendar', 'Decline') }}
+		</button>
+		<template v-if="!isTentative">
+			<button
+				v-if="!narrow"
+				class="invitation-response-buttons__button"
+				:disabled="loading"
+				@click="tentative">
+				{{ t('calendar', 'Tentative') }}
+			</button>
+			<Actions v-else>
+				<ActionButton
+					:disabled="loading"
+					@click="tentative">
+					<template #icon>
+						<CalendarQuestionIcon :size="20" />
+					</template>
+					{{ t('calendar', 'Tentative') }}
+				</ActionButton>
+			</Actions>
+		</template>
+	</div>
+</template>
+
+<script>
+import Actions from '@nextcloud/vue/dist/Components/Actions'
+import ActionButton from '@nextcloud/vue/dist/Components/ActionButton'
+import CalendarQuestionIcon from 'vue-material-design-icons/CalendarQuestion.vue'
+import { showError, showSuccess } from '@nextcloud/dialogs'
+import logger from '../../utils/logger'
+
+export default {
+	name: 'InvitationResponseButtons',
+	components: {
+		Actions,
+		ActionButton,
+		CalendarQuestionIcon,
+	},
+	props: {
+		attendee: {
+			type: Object,
+			required: true,
+		},
+		calendarId: {
+			type: String,
+			required: true,
+		},
+		narrow: {
+			type: Boolean,
+			default: false,
+		},
+	},
+	data() {
+		return {
+			loading: false,
+		}
+	},
+	computed: {
+		isAccepted() {
+			return this.attendee.participationStatus === 'ACCEPTED'
+		},
+		isDeclined() {
+			return this.attendee.participationStatus === 'DECLINED'
+		},
+		isTentative() {
+			return this.attendee.participationStatus === 'TENTATIVE'
+		},
+	},
+	methods: {
+		async accept() {
+			try {
+				await this.setParticipationStatus('ACCEPTED')
+				showSuccess(this.t('calendar', 'The invitation has been accepted successfully.'))
+				this.$emit('close')
+			} catch (e) {
+				showError(this.t('calendar', 'Failed to accept the invitation.'))
+			}
+		},
+		async decline() {
+			try {
+				await this.setParticipationStatus('DECLINED')
+				showSuccess(this.t('calendar', 'The invitation has been declined successfully.'))
+				this.$emit('close')
+			} catch (e) {
+				showError(this.t('calendar', 'Failed to decline the invitation.'))
+			}
+		},
+		async tentative() {
+			try {
+				await this.setParticipationStatus('TENTATIVE')
+				showSuccess(this.t('calendar', 'Your participation has been marked as tentative.'))
+				this.$emit('close')
+			} catch (e) {
+				showError(this.t('calendar', 'Failed to set the participation status to tentative.'))
+			}
+		},
+		/**
+		 * Set the participation status and save the event
+		 *
+		 * @param {string} participationStatus The new participation status
+		 * @return {Promise<void>}
+		 */
+		async setParticipationStatus(participationStatus) {
+			this.loading = true
+			try {
+				this.$store.commit('changeAttendeesParticipationStatus', {
+					attendee: this.attendee,
+					participationStatus,
+				})
+				// TODO: What about recurring events? Add new buttons like "Accept this and all future"?
+				// Currently, this will only accept a single occurrence.
+				await this.$store.dispatch('saveCalendarObjectInstance', {
+					thisAndAllFuture: false,
+					calendarId: this.calendarId,
+				})
+			} catch (error) {
+				logger.error('Failed to set participation status', { error, participationStatus })
+				throw error
+			} finally {
+				this.loading = false
+			}
+		},
+	},
+}
+</script>
+
+<style lang="scss" scoped>
+.invitation-response-buttons {
+	display: flex;
+	width: 100%;
+
+	&__button {
+		flex: 1 auto;
+		width: 100%;
+	}
+
+	// Fix alignment of buttons on simple editor
+	&--narrow > button + button {
+			margin-left: 5px;
+	}
+}
+</style>

--- a/src/views/EditSidebar.vue
+++ b/src/views/EditSidebar.vue
@@ -109,6 +109,13 @@
 				@update-end-date="updateEndDate"
 				@update-end-timezone="updateEndTimezone"
 				@toggle-all-day="toggleAllDay" />
+
+			<InvitationResponseButtons
+				v-if="isViewedByAttendee && userAsAttendee"
+				:attendee="userAsAttendee"
+				:calendar-id="calendarId"
+				:narrow="true"
+				@close="closeEditorAndSkipAction" />
 		</template>
 
 		<AppSidebarTab
@@ -261,6 +268,7 @@ import SaveButtons from '../components/Editor/SaveButtons.vue'
 import PropertySelectMultiple from '../components/Editor/Properties/PropertySelectMultiple.vue'
 import PropertyColor from '../components/Editor/Properties/PropertyColor.vue'
 import ResourceList from '../components/Editor/Resources/ResourceList'
+import InvitationResponseButtons from '../components/Editor/InvitationResponseButtons'
 
 import AccountMultiple from 'vue-material-design-icons/AccountMultiple.vue'
 import CalendarBlank from 'vue-material-design-icons/CalendarBlank.vue'
@@ -295,6 +303,7 @@ export default {
 		Download,
 		InformationOutline,
 		MapMarker,
+		InvitationResponseButtons,
 	},
 	mixins: [
 		EditorMixin,

--- a/src/views/EditSimple.vue
+++ b/src/views/EditSimple.vue
@@ -148,6 +148,12 @@
 				:value="description"
 				@update:value="updateDescription" />
 
+			<InvitationResponseButtons
+				v-if="isViewedByAttendee && userAsAttendee"
+				:attendee="userAsAttendee"
+				:calendar-id="calendarId"
+				@close="closeEditorAndSkipAction" />
+
 			<SaveButtons
 				v-if="!isReadOnly"
 				class="event-popover__buttons"
@@ -176,6 +182,7 @@ import PropertyText from '../components/Editor/Properties/PropertyText.vue'
 import SaveButtons from '../components/Editor/SaveButtons.vue'
 import PopoverLoadingIndicator from '../components/Popover/PopoverLoadingIndicator.vue'
 import { getPrefixedRoute } from '../utils/router.js'
+import InvitationResponseButtons from '../components/Editor/InvitationResponseButtons'
 
 import ArrowExpand from 'vue-material-design-icons/ArrowExpand.vue'
 import CalendarBlank from 'vue-material-design-icons/CalendarBlank.vue'
@@ -203,6 +210,7 @@ export default {
 		Close,
 		Download,
 		Delete,
+		InvitationResponseButtons,
 	},
 	mixins: [
 		EditorMixin,


### PR DESCRIPTION
Fixes #144

According to https://icalendar.org/CalDAV-Scheduling-RFC-6638/b-3-example-attendee-replying-to-an-invitation.html responding to an invitation is done by setting the participation status and sending the modified ics data to the server. Thunderbird seems to do the same thing.

The local participation status in the invitees list is updated right away (without reloading the page). There is one minor side effect: The accept/decline buttons internally trigger a full save which also persists changes of e.g. reminders. Fixing this would need a lot of potentially ugly code. Again, Thunderbird also ignores this case and other changes to the event are also saved upon accepting or declining.

| Simple | Sidebar|
| ---    | ---    |
| ![Screenshot 2022-01-04 at 18-04-30 April 2022 - Calendar - Nextcloud](https://user-images.githubusercontent.com/1479486/148096223-1bc8fc45-e471-402d-a14a-47c5a2c85021.png) | ![Screenshot_20220104_180654](https://user-images.githubusercontent.com/1479486/148096516-98c64192-5341-461b-bac7-d7b9cbb9831b.png) |


## Accept using the sidebar editor
![accept-sidebar](https://user-images.githubusercontent.com/1479486/148095016-88529948-15b5-47f8-a84b-eabe62801252.gif)

## Decline using the simple editor
![decline-simple](https://user-images.githubusercontent.com/1479486/148095020-41e60029-cd4f-4151-971f-38fee17d659e.gif)

## TODO
* [x] Fix red CI