### PR TITLE
Revert "Fix events being editable by invitees"

### DIFF
--- a/src/components/Editor/Invitees/InviteesList.vue
+++ b/src/components/Editor/Invitees/InviteesList.vue
@@ -36,7 +36,6 @@
 			:key="invitee.email"
 			:attendee="invitee"
 			:is-read-only="isReadOnly"
-			:is-viewed-by-organizer="isViewedByOrganizer"
 			:organizer-display-name="organizerDisplayName"
 			@remove-attendee="removeAttendee" />
 		<NoAttendeesView
@@ -97,10 +96,6 @@ export default {
 	},
 	props: {
 		isReadOnly: {
-			type: Boolean,
-			required: true,
-		},
-		isViewedByOrganizer: {
 			type: Boolean,
 			required: true,
 		},

--- a/src/components/Editor/Invitees/InviteesListItem.vue
+++ b/src/components/Editor/Invitees/InviteesListItem.vue
@@ -34,7 +34,7 @@
 			{{ commonName }}
 		</div>
 		<div class="invitees-list-item__actions">
-			<Actions v-if="!isReadOnly && isViewedByOrganizer">
+			<Actions v-if="isViewedByOrganizer">
 				<ActionCheckbox
 					:checked="attendee.rsvp"
 					@change="toggleRSVP">
@@ -111,10 +111,6 @@ export default {
 			type: Boolean,
 			required: true,
 		},
-		isViewedByOrganizer: {
-			type: Boolean,
-			required: true,
-		},
 	},
 	computed: {
 		avatarLink() {
@@ -146,6 +142,10 @@ export default {
 		},
 		isNonParticipant() {
 			return this.attendee.role === 'NON-PARTICIPANT'
+		},
+		isViewedByOrganizer() {
+			// TODO: check if also viewed by organizer
+			return !this.isReadOnly
 		},
 	},
 	methods: {

--- a/src/components/Editor/SaveButtons.vue
+++ b/src/components/Editor/SaveButtons.vue
@@ -74,23 +74,19 @@ export default {
 			type: Boolean,
 			default: false,
 		},
-		isReadOnly: {
-			type: Boolean,
-			default: false,
-		},
 	},
 	computed: {
 		showSaveButton() {
-			return this.isNew && !this.canCreateRecurrenceException && !this.isReadOnly
+			return this.isNew && !this.canCreateRecurrenceException
 		},
 		showUpdateButton() {
-			return !this.isNew && !this.canCreateRecurrenceException && !this.isReadOnly
+			return !this.isNew && !this.canCreateRecurrenceException
 		},
 		showUpdateOnlyThisButton() {
-			return this.canCreateRecurrenceException && !this.forceThisAndAllFuture && !this.isReadOnly
+			return this.canCreateRecurrenceException && !this.forceThisAndAllFuture
 		},
 		showUpdateThisAndFutureButton() {
-			return this.canCreateRecurrenceException && !this.isReadOnly
+			return this.canCreateRecurrenceException
 		},
 	},
 	methods: {

--- a/src/mixins/EditorMixin.js
+++ b/src/mixins/EditorMixin.js
@@ -30,7 +30,6 @@ import {
 	mapState,
 } from 'vuex'
 import { translate as t } from '@nextcloud/l10n'
-import { removeMailtoPrefix } from '../utils/attendee'
 
 /**
  * This is a mixin for the editor. It contains common Vue stuff, that is
@@ -212,19 +211,6 @@ export default {
 			return calendar.readOnly
 		},
 		/**
-		 * Returns whether or not an attendee is viewing the event
-		 *
-		 * @return {boolean}
-		 */
-		isViewedByAttendee() {
-			if (!this.calendarObjectInstance.organizer) {
-				return false
-			}
-
-			const principal = removeMailtoPrefix(this.$store.getters.getCurrentUserPrincipalEmail)
-			return removeMailtoPrefix(this.calendarObjectInstance.organizer.uri) !== principal
-		},
-		/**
 		 * Returns all calendars selectable by the user
 		 *
 		 * @return {object[]}
@@ -272,9 +258,6 @@ export default {
 				return false
 			}
 			if (this.isLoading) {
-				return false
-			}
-			if (this.isViewedByAttendee) {
 				return false
 			}
 

--- a/src/views/EditSidebar.vue
+++ b/src/views/EditSidebar.vue
@@ -91,7 +91,7 @@
 				v-if="showCalendarPicker"
 				:calendars="calendars"
 				:calendar="selectedCalendar"
-				:is-read-only="isReadOnly || !canModifyCalendar || isViewedByAttendee"
+				:is-read-only="isReadOnly || !canModifyCalendar"
 				@select-calendar="changeCalendar" />
 
 			<PropertyTitleTimePicker
@@ -100,7 +100,7 @@
 				:end-date="endDate"
 				:end-timezone="endTimezone"
 				:is-all-day="isAllDay"
-				:is-read-only="isReadOnly || isViewedByAttendee"
+				:is-read-only="isReadOnly"
 				:can-modify-all-day="canModifyAllDay"
 				:user-timezone="currentUserTimezone"
 				:append-to-body="true"
@@ -122,35 +122,35 @@
 			</template>
 			<div class="app-sidebar-tab__content">
 				<PropertyText
-					:is-read-only="isReadOnly || isViewedByAttendee"
+					:is-read-only="isReadOnly"
 					:prop-model="rfcProps.location"
 					:value="location"
 					@update:value="updateLocation" />
 				<PropertyText
-					:is-read-only="isReadOnly || isViewedByAttendee"
+					:is-read-only="isReadOnly"
 					:prop-model="rfcProps.description"
 					:value="description"
 					@update:value="updateDescription" />
 
 				<PropertySelect
-					:is-read-only="isReadOnly || isViewedByAttendee"
+					:is-read-only="isReadOnly"
 					:prop-model="rfcProps.status"
 					:value="status"
 					@update:value="updateStatus" />
 				<PropertySelect
-					:is-read-only="isReadOnly || isViewedByAttendee"
+					:is-read-only="isReadOnly"
 					:prop-model="rfcProps.accessClass"
 					:value="accessClass"
 					@update:value="updateAccessClass" />
 				<PropertySelect
-					:is-read-only="isReadOnly || isViewedByAttendee"
+					:is-read-only="isReadOnly"
 					:prop-model="rfcProps.timeTransparency"
 					:value="timeTransparency"
 					@update:value="updateTimeTransparency" />
 
 				<PropertySelectMultiple
 					:colored-options="true"
-					:is-read-only="isReadOnly || isViewedByAttendee"
+					:is-read-only="isReadOnly"
 					:prop-model="rfcProps.categories"
 					:value="categories"
 					@add-single-value="addCategory"
@@ -158,7 +158,7 @@
 
 				<PropertyColor
 					:calendar-color="selectedCalendarColor"
-					:is-read-only="isReadOnly || isViewedByAttendee"
+					:is-read-only="isReadOnly"
 					:prop-model="rfcProps.color"
 					:value="color"
 					@update:value="updateColor" />
@@ -172,7 +172,7 @@
 				<Repeat
 					:calendar-object-instance="calendarObjectInstance"
 					:recurrence-rule="calendarObjectInstance.recurrenceRule"
-					:is-read-only="isReadOnly || isViewedByAttendee"
+					:is-read-only="isReadOnly"
 					:is-editing-master-item="isEditingMasterItem"
 					:is-recurrence-exception="isRecurrenceException"
 					@force-this-and-all-future="forceModifyingFuture" />
@@ -199,8 +199,7 @@
 				<InviteesList
 					v-if="!isLoading"
 					:calendar-object-instance="calendarObjectInstance"
-					:is-viewed-by-organizer="!isViewedByAttendee"
-					:is-read-only="isReadOnly || isViewedByAttendee" />
+					:is-read-only="isReadOnly" />
 			</div>
 			<SaveButtons
 				v-if="showSaveButtons"
@@ -224,7 +223,7 @@
 				<ResourceList
 					v-if="!isLoading"
 					:calendar-object-instance="calendarObjectInstance"
-					:is-read-only="isReadOnly || isViewedByAttendee" />
+					:is-read-only="isReadOnly" />
 			</div>
 			<SaveButtons
 				v-if="showSaveButtons"

--- a/src/views/EditSimple.vue
+++ b/src/views/EditSimple.vue
@@ -112,14 +112,14 @@
 
 			<PropertyTitle
 				:value="title"
-				:is-read-only="isReadOnly || isViewedByAttendee"
+				:is-read-only="isReadOnly"
 				@update:value="updateTitle" />
 
 			<PropertyCalendarPicker
 				v-if="showCalendarPicker"
 				:calendars="calendars"
 				:calendar="selectedCalendar"
-				:is-read-only="isReadOnly || isViewedByAttendee"
+				:is-read-only="isReadOnly"
 				@select-calendar="changeCalendar" />
 
 			<PropertyTitleTimePicker
@@ -128,7 +128,7 @@
 				:end-date="endDate"
 				:end-timezone="endTimezone"
 				:is-all-day="isAllDay"
-				:is-read-only="isReadOnly || isViewedByAttendee"
+				:is-read-only="isReadOnly"
 				:can-modify-all-day="canModifyAllDay"
 				:user-timezone="currentUserTimezone"
 				@update-start-date="updateStartDate"
@@ -138,23 +138,23 @@
 				@toggle-all-day="toggleAllDay" />
 
 			<PropertyText
-				:is-read-only="isReadOnly || isViewedByAttendee"
+				:is-read-only="isReadOnly"
 				:prop-model="rfcProps.location"
 				:value="location"
 				@update:value="updateLocation" />
 			<PropertyText
-				:is-read-only="isReadOnly || isViewedByAttendee"
+				:is-read-only="isReadOnly"
 				:prop-model="rfcProps.description"
 				:value="description"
 				@update:value="updateDescription" />
 
 			<SaveButtons
+				v-if="!isReadOnly"
 				class="event-popover__buttons"
 				:can-create-recurrence-exception="canCreateRecurrenceException"
 				:is-new="isNew"
 				:force-this-and-all-future="forceThisAndAllFuture"
 				:show-more-button="true"
-				:is-read-only="isReadOnly || isViewedByAttendee"
 				@save-this-only="saveAndLeave(false)"
 				@save-this-and-all-future="saveAndLeave(true)"
 				@show-more="showMore" />


### PR DESCRIPTION
Fix #3866

Replaces https://github.com/nextcloud/calendar/pull/3884

This reverts commit 74b78b9dc601424665fa333fcfdd25726f61ec5b because it introduced some edge cases.

It can be hard to distinguish between invitee, owner and organizer so we shall not enforce invitations to be read only for now.