### PR TITLE
Bump @nextcloud/calendar-js from 2.0.0 to 3.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
 				"@nextcloud/auth": "^1.3.0",
 				"@nextcloud/axios": "^1.8.0",
 				"@nextcloud/calendar-availability-vue": "^0.2.1",
-				"@nextcloud/calendar-js": "^2.0.0",
+				"@nextcloud/calendar-js": "^3.0.0",
 				"@nextcloud/cdav-library": "^1.0.0",
 				"@nextcloud/dialogs": "^3.1.2",
 				"@nextcloud/event-bus": "^2.1.1",
@@ -2691,16 +2691,16 @@
 			}
 		},
 		"node_modules/@nextcloud/calendar-js": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@nextcloud/calendar-js/-/calendar-js-2.0.0.tgz",
-			"integrity": "sha512-wGDDWjnXaMTJVxK2B31S0BAstN5759fptuddWRVZcFU2gEFXZyiv0iFgcbCOdAni+/Mz9rBbdV8h+TYWbst6Qg==",
-			"dependencies": {
-				"ical.js": "^1.4.0",
-				"uuid": "^8.3.2"
-			},
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@nextcloud/calendar-js/-/calendar-js-3.0.0.tgz",
+			"integrity": "sha512-Uy/etWwRmbzG1jxcfampOCEXbGMEzY1xVCBlONVrkusUmD9t02u3jWFkRJGAHvFAtLd4iM+MdTo1x3VXemBvcA==",
 			"engines": {
 				"node": ">=14.0.0",
 				"npm": ">=7.0.0"
+			},
+			"peerDependencies": {
+				"ical.js": "^1.4.0",
+				"uuid": "^8.3.2"
 			}
 		},
 		"node_modules/@nextcloud/capabilities": {
@@ -3127,6 +3127,19 @@
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
 			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+		},
+		"node_modules/@nextcloud/vue/node_modules/@nextcloud/calendar-js": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@nextcloud/calendar-js/-/calendar-js-2.0.0.tgz",
+			"integrity": "sha512-wGDDWjnXaMTJVxK2B31S0BAstN5759fptuddWRVZcFU2gEFXZyiv0iFgcbCOdAni+/Mz9rBbdV8h+TYWbst6Qg==",
+			"dependencies": {
+				"ical.js": "^1.4.0",
+				"uuid": "^8.3.2"
+			},
+			"engines": {
+				"node": ">=14.0.0",
+				"npm": ">=7.0.0"
+			}
 		},
 		"node_modules/@nextcloud/vue/node_modules/ansi-regex": {
 			"version": "6.0.1",
@@ -20730,13 +20743,10 @@
 			}
 		},
 		"@nextcloud/calendar-js": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@nextcloud/calendar-js/-/calendar-js-2.0.0.tgz",
-			"integrity": "sha512-wGDDWjnXaMTJVxK2B31S0BAstN5759fptuddWRVZcFU2gEFXZyiv0iFgcbCOdAni+/Mz9rBbdV8h+TYWbst6Qg==",
-			"requires": {
-				"ical.js": "^1.4.0",
-				"uuid": "^8.3.2"
-			}
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@nextcloud/calendar-js/-/calendar-js-3.0.0.tgz",
+			"integrity": "sha512-Uy/etWwRmbzG1jxcfampOCEXbGMEzY1xVCBlONVrkusUmD9t02u3jWFkRJGAHvFAtLd4iM+MdTo1x3VXemBvcA==",
+			"requires": {}
 		},
 		"@nextcloud/capabilities": {
 			"version": "1.0.4",
@@ -20959,6 +20969,15 @@
 				"vue2-datepicker": "^3.6.3"
 			},
 			"dependencies": {
+				"@nextcloud/calendar-js": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/@nextcloud/calendar-js/-/calendar-js-2.0.0.tgz",
+					"integrity": "sha512-wGDDWjnXaMTJVxK2B31S0BAstN5759fptuddWRVZcFU2gEFXZyiv0iFgcbCOdAni+/Mz9rBbdV8h+TYWbst6Qg==",
+					"requires": {
+						"ical.js": "^1.4.0",
+						"uuid": "^8.3.2"
+					}
+				},
 				"ansi-regex": {
 					"version": "6.0.1",
 					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
 		"@nextcloud/auth": "^1.3.0",
 		"@nextcloud/axios": "^1.8.0",
 		"@nextcloud/calendar-availability-vue": "^0.2.1",
-		"@nextcloud/calendar-js": "^2.0.0",
+		"@nextcloud/calendar-js": "^3.0.0",
 		"@nextcloud/cdav-library": "^1.0.0",
 		"@nextcloud/dialogs": "^3.1.2",
 		"@nextcloud/event-bus": "^2.1.1",


### PR DESCRIPTION
Fixes the time zone of reminders. It was initialized to UTC but now it's copied from the event.