### PR TITLE
Fix usage of IgnorePlugin

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -60,7 +60,10 @@ webpackConfig.plugins.push(
 			pattern: './src/assets/iconfont/*.svg',
 		},
 	}),
-	new webpack.IgnorePlugin(/^\.\/locale(s)?$/, /(moment)$/),
+	new webpack.IgnorePlugin({
+		resourceRegExp: /^\.\/locale$/,
+		contextRegExp: /moment$/,
+	}),
 	new webpack.ProvidePlugin({
 		// Shim ICAL to prevent using the global object (window.ICAL).
 		// The library ical.js heavily depends on instanceof checks which will


### PR DESCRIPTION
Required for https://github.com/nextcloud/calendar/pull/3901

The constructor of `IgnorePlugin` has changed since webpack v5.

Ref https://webpack.js.org/plugins/ignore-plugin/#example-of-ignoring-moment-locales