### PR TITLE
Fix: Inconsistencies due to ALTREP parameter

### DIFF
--- a/src/store/calendarObjectInstance.js
+++ b/src/store/calendarObjectInstance.js
@@ -1527,6 +1527,18 @@ const actions = {
 		const calendarObject = state.calendarObject
 
 		if (eventComponent.isDirty()) {
+			// ALTREP parameter is not set by NC calendar, but by CalDAV clients like Thunderbird.
+			// To avoid inconsistencies, remove ALTREP parameter upon modification.
+			const veventComponent = calendarObject.calendarComponent.getFirstComponent('VEVENT')
+			if (veventComponent) {
+				const descriptionProperty = veventComponent.getFirstProperty('Description')
+				if (descriptionProperty) {
+					if (descriptionProperty.hasParameter('ALTREP')) {
+						descriptionProperty.deleteParameter('ALTREP')
+					}
+				}
+			}
+
 			const isForkedItem = eventComponent.primaryItem !== null
 			let original = null
 			let fork = null

--- a/src/store/calendarObjectInstance.js
+++ b/src/store/calendarObjectInstance.js
@@ -320,6 +320,14 @@ const mutations = {
 	 * @param {string} data.description New description to set
 	 */
 	changeDescription(state, { calendarObjectInstance, description }) {
+		// ALTREP parameter is not set by NC calendar, but by CalDAV clients like Thunderbird.
+		// To avoid inconsistencies, remove ALTREP parameter upon modification.
+		const descriptionProperty = calendarObjectInstance.eventComponent.getFirstProperty('Description')
+		if (descriptionProperty) {
+			if (descriptionProperty.hasParameter('ALTREP')) {
+				descriptionProperty.deleteParameter('ALTREP')
+			}
+		}
 		calendarObjectInstance.eventComponent.description = description
 		calendarObjectInstance.description = description
 	},
@@ -1527,18 +1535,6 @@ const actions = {
 		const calendarObject = state.calendarObject
 
 		if (eventComponent.isDirty()) {
-			// ALTREP parameter is not set by NC calendar, but by CalDAV clients like Thunderbird.
-			// To avoid inconsistencies, remove ALTREP parameter upon modification.
-			const veventComponent = calendarObject.calendarComponent.getFirstComponent('VEVENT')
-			if (veventComponent) {
-				const descriptionProperty = veventComponent.getFirstProperty('Description')
-				if (descriptionProperty) {
-					if (descriptionProperty.hasParameter('ALTREP')) {
-						descriptionProperty.deleteParameter('ALTREP')
-					}
-				}
-			}
-
 			const isForkedItem = eventComponent.primaryItem !== null
 			let original = null
 			let fork = null


### PR DESCRIPTION
This PR addresses issue #3863: In addition to the plain text description of an event, Thunderbird also saves a formatted HTML version inside the ALTREP parameter. NC calendar does not alter the ALTREP parameter when the plain text description is changed. This results in inconsistencies.

The proposed solution deletes the ALTREP parameter upon modification. This prevents inconsistencies. Thunderbird keeps accepting plaintext-only descriptions.

I will have opened a [similar PR](https://github.com/nextcloud/tasks/pull/1916) in nextcloud/tasks as it is equally concerned.