### PR TITLE
Fix: Inconsistencies due to parameters in description property

### DIFF
--- a/src/store/calendarObjectInstance.js
+++ b/src/store/calendarObjectInstance.js
@@ -320,7 +320,7 @@ const mutations = {
 	 * @param {string} data.description New description to set
 	 */
 	changeDescription(state, { calendarObjectInstance, description }) {
-		// To avoid inconsistencies, remove all parameters (e.g., ALTREP) upon modification.
+		// To avoid inconsistencies (bug #3863), remove all parameters (e.g., ALTREP) upon modification
 		const descriptionProperty = calendarObjectInstance.eventComponent.getFirstProperty('Description')
 		if (descriptionProperty) {
 			for (const parameter of descriptionProperty.getParametersIterator()) {

--- a/src/store/calendarObjectInstance.js
+++ b/src/store/calendarObjectInstance.js
@@ -320,14 +320,14 @@ const mutations = {
 	 * @param {string} data.description New description to set
 	 */
 	changeDescription(state, { calendarObjectInstance, description }) {
-		// ALTREP parameter is not set by NC calendar, but by CalDAV clients like Thunderbird.
-		// To avoid inconsistencies, remove ALTREP parameter upon modification.
+		// To avoid inconsistencies, remove all parameters (e.g., ALTREP) upon modification.
 		const descriptionProperty = calendarObjectInstance.eventComponent.getFirstProperty('Description')
 		if (descriptionProperty) {
-			if (descriptionProperty.hasParameter('ALTREP')) {
-				descriptionProperty.deleteParameter('ALTREP')
+			for (const parameter of descriptionProperty.getParametersIterator()) {
+				descriptionProperty.deleteParameter(parameter.name)
 			}
 		}
+
 		calendarObjectInstance.eventComponent.description = description
 		calendarObjectInstance.description = description
 	},


### PR DESCRIPTION
This is a follow-up of #3918. In this old PR only the ALTREP parameter is cleared upon modification of the description property. It therefore solves #3863. However, also all other [possible parameters](https://datatracker.ietf.org/doc/html/rfc5545#section-3.8.1.5) may cause inconsistencies. This PR deletes all parameters of the description property upon modification.