### PR TITLE
Drop php 7.3 for php-test workflow on master

### DIFF
--- a/.github/workflows/php-test.yml
+++ b/.github/workflows/php-test.yml
@@ -12,10 +12,12 @@ jobs:
     strategy:
       matrix:
         php-versions: ['7.3', '7.4']
-        nextcloud-versions: ['stable21', 'stable22', 'stable23', 'master']
+        nextcloud-versions: ['stable21', 'stable22', 'stable23']
         include:
           - php-versions: '7.3'
             nextcloud-versions: 'stable20'
+          - php-versions: '7.4'
+            nextcloud-versions: 'master'
           - php-versions: '8.0'
             nextcloud-versions: 'master'
     name: php${{ matrix.php-versions }} on ${{ matrix.nextcloud-versions }} unit tests


### PR DESCRIPTION
PHP v7.3 was dropped and thus breaking our master workflow.