### PR TITLE
Fix: Inconsistencies due to Apple's additional location property

### DIFF
--- a/src/store/calendarObjectInstance.js
+++ b/src/store/calendarObjectInstance.js
@@ -307,6 +307,9 @@ const mutations = {
 	 * @param {string} data.location New location to set
 	 */
 	changeLocation(state, { calendarObjectInstance, location }) {
+		// Special case: delete Apple-specific location property to avoid inconsistencies
+		calendarObjectInstance.eventComponent.deleteAllProperties('X-APPLE-STRUCTURED-LOCATION')
+
 		calendarObjectInstance.eventComponent.location = location
 		calendarObjectInstance.location = location
 	},


### PR DESCRIPTION
Similar to #3924, this PR fixes an inconsistency issue. This time it is about the additional location information that Apple applications store in  the `X-APPLE-STRUCTURED-LOCATION` property. This is a supplement to the regular `LOCATION` property. It includes coordinates and a custom map reference. Upon change of `LOCATION` in a non-Apple application, `X-APPLE-STRUCTURED-LOCATION` becomes invalid. This PR solves this inconsistency by removing the `X-APPLE-STRUCTURED-LOCATION` property upon change of the location.

Discussion can be found in #3905.