### PR TITLE
Optionally enforce a event alarm type

### DIFF
--- a/lib/Controller/ViewController.php
+++ b/lib/Controller/ViewController.php
@@ -30,6 +30,7 @@ use OCP\AppFramework\Http\TemplateResponse;
 use OCP\AppFramework\Services\IInitialState;
 use OCP\IConfig;
 use OCP\IRequest;
+use function in_array;
 
 class ViewController extends Controller {
 
@@ -94,6 +95,10 @@ class ViewController extends Controller {
 		$defaultReminder = $this->config->getUserValue($this->userId, $this->appName, 'defaultReminder', $defaultDefaultReminder);
 		$showTasks = $this->config->getUserValue($this->userId, $this->appName, 'showTasks', $defaultShowTasks) === 'yes';
 		$hideEventExport = $this->config->getAppValue($this->appName, 'hideEventExport', 'no') === 'yes';
+		$forceEventAlarmType = $this->config->getAppValue($this->appName, 'forceEventAlarmType', '');
+		if (!in_array($forceEventAlarmType, ['DISPLAY', 'EMAIL'], true)) {
+			$forceEventAlarmType = null;
+		}
 
 		$talkEnabled = $this->appManager->isEnabledForUser('spreed');
 		$talkApiVersion = version_compare($this->appManager->getAppVersion('spreed'), '12.0.0', '>=') ? 'v4' : 'v1';
@@ -114,6 +119,7 @@ class ViewController extends Controller {
 		$this->initialStateService->provideInitialState('show_tasks', $showTasks);
 		$this->initialStateService->provideInitialState('tasks_enabled', $tasksEnabled);
 		$this->initialStateService->provideInitialState('hide_event_export', $hideEventExport);
+		$this->initialStateService->provideInitialState('force_event_alarm_type', $forceEventAlarmType);
 		$this->initialStateService->provideInitialState('appointmentConfigs',$this->appointmentConfigService->getAllAppointmentConfigurations($this->userId));
 
 		return new TemplateResponse($this->appName, 'main');

--- a/src/components/Editor/Alarm/AlarmList.vue
+++ b/src/components/Editor/Alarm/AlarmList.vue
@@ -43,6 +43,7 @@
 <script>
 import AlarmListNew from './AlarmListNew'
 import AlarmListItem from './AlarmListItem'
+import { mapState } from 'vuex'
 
 export default {
 	name: 'AlarmList',
@@ -61,6 +62,9 @@ export default {
 		},
 	},
 	computed: {
+	  ...mapState({
+		  forceEventAlarmType: (state) => state.settings.forceEventAlarmType,
+	  }),
 		alarms() {
 			return this.calendarObjectInstance.alarms
 		},
@@ -74,7 +78,7 @@ export default {
 		addAlarm(totalSeconds) {
 			this.$store.commit('addAlarmToCalendarObjectInstance', {
 				calendarObjectInstance: this.calendarObjectInstance,
-				type: 'DISPLAY',
+				type: this.forceEventAlarmType ?? 'DISPLAY',
 				totalSeconds,
 			})
 		},

--- a/src/components/Editor/Alarm/AlarmListItem.vue
+++ b/src/components/Editor/Alarm/AlarmListItem.vue
@@ -98,33 +98,35 @@
 			class="property-alarm-item__options">
 			<Actions>
 				<ActionRadio
+					v-if="canChangeAlarmType && (isAlarmTypeDisplay || forceEventAlarmType === null || forceEventAlarmType === 'DISPLAY')"
 					:name="alarmTypeName"
 					:checked="isAlarmTypeDisplay"
 					@change="changeType('DISPLAY')">
 					{{ $t('calendar', 'Notification') }}
 				</ActionRadio>
 				<ActionRadio
+					v-if="canChangeAlarmType && (isAlarmTypeEmail || forceEventAlarmType === null || forceEventAlarmType === 'EMAIL')"
 					:name="alarmTypeName"
 					:checked="isAlarmTypeEmail"
 					@change="changeType('EMAIL')">
 					{{ $t('calendar', 'Email') }}
 				</ActionRadio>
 				<ActionRadio
-					v-if="isAlarmTypeAudio"
+					v-if="canChangeAlarmType && isAlarmTypeAudio"
 					:name="alarmTypeName"
 					:checked="isAlarmTypeAudio"
 					@change="changeType('AUDIO')">
 					{{ $t('calendar', 'Audio notification') }}
 				</ActionRadio>
 				<ActionRadio
-					v-if="isAlarmTypeOther"
+					v-if="canChangeAlarmType && isAlarmTypeOther"
 					:name="alarmTypeName"
 					:checked="isAlarmTypeOther"
 					@change="changeType(alarm.type)">
 					{{ $t('calendar', 'Other notification') }}
 				</ActionRadio>
 
-				<ActionSeparator v-if="!isRecurring" />
+				<ActionSeparator v-if="canChangeAlarmType && !isRecurring" />
 
 				<ActionRadio
 					v-if="!isRecurring"
@@ -236,6 +238,7 @@ export default {
 	computed: {
 		...mapState({
 			locale: (state) => state.settings.momentLocale,
+			forceEventAlarmType: (state) => state.settings.forceEventAlarmType,
 		}),
 		canEdit() {
 			// You can always edit an alarm if it's absolute
@@ -262,6 +265,9 @@ export default {
 			}
 
 			return true
+		},
+		canChangeAlarmType() {
+		  return this.forceEventAlarmType !== null && this.alarm.type !== this.forceEventAlarmType
 		},
 		alarmTypeName() {
 			return this._uid + '-radio-type-name'

--- a/src/store/settings.js
+++ b/src/store/settings.js
@@ -42,6 +42,7 @@ const state = {
 	tasksEnabled: false,
 	timezone: 'automatic',
 	hideEventExport: false,
+	forceEventAlarmType: null,
 	// user-defined Nextcloud settings
 	momentLocale: 'en',
 }
@@ -143,9 +144,10 @@ const mutations = {
 	 * @param {boolean} data.talkEnabled Whether or not the talk app is enabled
 	 * @param {boolean} data.tasksEnabled Whether ot not the tasks app is enabled
 	 * @param {string} data.timezone The timezone to view the calendar in. Either an Olsen timezone or "automatic"
-	 * @param data.hideEventExport
+	 * @param {boolean} data.hideEventExport
+	 * @param {string} data.forceEventAlarmType
 	 */
-	loadSettingsFromServer(state, { appVersion, eventLimit, firstRun, showWeekNumbers, showTasks, showWeekends, skipPopover, slotDuration, defaultReminder, talkEnabled, tasksEnabled, timezone, hideEventExport }) {
+	loadSettingsFromServer(state, { appVersion, eventLimit, firstRun, showWeekNumbers, showTasks, showWeekends, skipPopover, slotDuration, defaultReminder, talkEnabled, tasksEnabled, timezone, hideEventExport, forceEventAlarmType }) {
 		logInfo(`
 Initial settings:
 	- AppVersion: ${appVersion}
@@ -175,6 +177,7 @@ Initial settings:
 		state.tasksEnabled = tasksEnabled
 		state.timezone = timezone
 		state.hideEventExport = hideEventExport
+		state.forceEventAlarmType = forceEventAlarmType
 	},
 
 	/**

--- a/src/views/Calendar.vue
+++ b/src/views/Calendar.vue
@@ -219,6 +219,7 @@ export default {
 			timezone: loadState('calendar', 'timezone'),
 			showTasks: loadState('calendar', 'show_tasks'),
 			hideEventExport: loadState('calendar', 'hide_event_export'),
+			forceEventAlarmType: loadState('calendar', 'force_event_alarm_type', null),
 		})
 		this.$store.dispatch('initializeCalendarJsConfig')
 

--- a/tests/javascript/unit/store/settings.test.js
+++ b/tests/javascript/unit/store/settings.test.js
@@ -49,6 +49,7 @@ describe('store/settings test suite', () => {
 		expect(settingsStore.state).toEqual({
 			appVersion: null,
 			firstRun: null,
+			forceEventAlarmType: null,
 			hideEventExport: false,
 			talkEnabled: false,
 			eventLimit: null,

--- a/tests/php/unit/Controller/ViewControllerTest.php
+++ b/tests/php/unit/Controller/ViewControllerTest.php
@@ -95,6 +95,7 @@ class ViewControllerTest extends TestCase {
 				['calendar', 'defaultReminder', 'none', 'defaultDefaultReminder'],
 				['calendar', 'showTasks', 'yes', 'defaultShowTasks'],
 				['calendar', 'hideEventExport', 'no', 'yes'],
+				['calendar', 'forceEventAlarmType', '', ''],
 				['calendar', 'installed_version', null, '1.0.0'],
 			]);
 		$this->config
@@ -145,6 +146,7 @@ class ViewControllerTest extends TestCase {
 				['show_tasks', false],
 				['tasks_enabled', true],
 				['hide_event_export', true],
+				['force_event_alarm_type', null],
 				['appointmentConfigs', [new AppointmentConfig()]],
 			);
 


### PR DESCRIPTION
This contributes the second part of https://github.com/nextcloud/calendar/issues/3993.

* Admins can enforce `DISPLAY` or `EMAIL` as alarm type
* The value is used as new default for an reminder
* If a reminder matches the enforced type, we hide the radio group all together (there would only be one option after all)
  ![Bildschirmfoto von 2022-02-25 11-49-12](https://user-images.githubusercontent.com/1374172/155702526-6850da50-300d-40c4-ae43-6b01ce8ef3af.png)
* If a reminder doesn't match the enforced type (event created before enforcement or another client) then the user decide to stay on the old value or switch to the enforced one
  ![Bildschirmfoto von 2022-02-25 11-49-05](https://user-images.githubusercontent.com/1374172/155702560-0b2b1846-971b-40ed-8139-0dbccfc6ebb4.png)

I will update the Calendar admin docs for this.

```shell
occ config:app:set calendar forceEventAlarm_type --value=EMAIL
```