### PR TITLE
Use CircleOutline for disabled calendar icon

### DIFF
--- a/src/components/AppNavigation/CalendarList/CalendarListItem.vue
+++ b/src/components/AppNavigation/CalendarList/CalendarListItem.vue
@@ -31,9 +31,15 @@
 				<ActionButton @click.prevent.stop="toggleEnabled">
 					<template #icon>
 						<CheckboxBlankCircle
-							:title="calendar.enabled ? $t('calendar', 'Disable calendar') : $t('calendar', 'Enable calendar') "
+							v-if="calendar.enabled"
+							:title="$t('calendar', 'Disable calendar')"
 							:size="20"
-							:fill-color="calendar.enabled ? calendar.color : 'var(--color-text-lighter)'" />
+							:fill-color="calendar.color" />
+						<CheckboxBlankCircleOutline
+							v-else
+							:title="$t('calendar', 'Enable calendar')"
+							:size="20"
+							fill-color="var(--color-text-lighter)" />
 					</template>
 				</ActionButton>
 			</Actions>
@@ -189,6 +195,7 @@ import CalendarListItemSharingSearch from './CalendarListItemSharingSearch.vue'
 import CalendarListItemSharingPublishItem from './CalendarListItemSharingPublishItem.vue'
 import CalendarListItemSharingShareItem from './CalendarListItemSharingShareItem.vue'
 import CheckboxBlankCircle from 'vue-material-design-icons/CheckboxBlankCircle.vue'
+import CheckboxBlankCircleOutline from 'vue-material-design-icons/CheckboxBlankCircleOutline.vue'
 import Close from 'vue-material-design-icons/Close.vue'
 import Delete from 'vue-material-design-icons/Delete.vue'
 import Download from 'vue-material-design-icons/Download.vue'
@@ -211,6 +218,7 @@ export default {
 		CalendarListItemSharingPublishItem,
 		CalendarListItemSharingShareItem,
 		CheckboxBlankCircle,
+		CheckboxBlankCircleOutline,
 		Close,
 		Delete,
 		Download,

--- a/src/components/AppNavigation/CalendarList/CalendarListItem.vue
+++ b/src/components/AppNavigation/CalendarList/CalendarListItem.vue
@@ -39,7 +39,7 @@
 							v-else
 							:title="$t('calendar', 'Enable calendar')"
 							:size="20"
-							fill-color="var(--color-text-lighter)" />
+							:fill-color="calendar.color" />
 					</template>
 				</ActionButton>
 			</Actions>


### PR DESCRIPTION
This PR changes the icon for disabled calendars to `CheckboxBlankCircleOutline` so it can be better distinguished from enabled calendars. Since the color is not needed anymore as a difference, I figured we can keep it the same, even if the calendar is disabled. This is how it looks now:
![2022 - Calendar - Nextcloud](https://user-images.githubusercontent.com/2496460/156235641-fb39c9fc-0f69-494f-8850-c13646ce671b.png)

Compared to before:
![Screenshot 2022-03-01 at 20-34-45 Week 10 of 2022 - Calendar - Nextcloud](https://user-images.githubusercontent.com/2496460/156236320-60dfa48b-7e00-4f2a-8b2b-be2b1b3f14af.png)

@jancborchardt @nimishavijay In case you prefer to still have disabled calendars using `var(--color-text-lighter)` instead of the calendar color, let me know, and I will change it.

Closes #4005.
