### PR TITLE
Remove blurriness from event participation indicator

### DIFF
--- a/css/app-sidebar.scss
+++ b/css/app-sidebar.scss
@@ -530,7 +530,6 @@
 			background-size: 10px;
 			height: 15px;
 			width: 15px;
-			box-shadow: 0 0 3px grey;
 			border-radius: 50%;
 		}
 


### PR DESCRIPTION
Removed the unnecessary and off-style box-shadow from the participation status indicator, making it look less blurry too:

Before | After
-|-
![avatar-participation-status__indicator current](https://user-images.githubusercontent.com/925062/156620049-d7c4af06-a718-4a66-9de5-26d7d455e409.png)|![avatar-participation-status__indicator unblurred](https://user-images.githubusercontent.com/925062/156620053-b55bec5d-f6c8-420e-a878-4ce092edd04b.png)
