### PR TITLE
Fix translation for default calendar name

### DIFF
--- a/src/views/Calendar.vue
+++ b/src/views/Calendar.vue
@@ -258,8 +258,8 @@ export default {
 				logger.info('User has no writable calendar, a new personal calendar will be created')
 				this.loadingCalendars = true
 				await this.$store.dispatch('appendCalendar', {
-					displayName: this.$t('calendars', 'Personal'),
-					color: uidToHexColor(this.$t('calendars', 'Personal')),
+					displayName: this.$t('calendar', 'Personal'),
+					color: uidToHexColor(this.$t('calendar', 'Personal')),
 					order: 0,
 				})
 			}


### PR DESCRIPTION
This fixes a typo in the translation of the default calendar name. Closes #4046.