### PR TITLE
Fix alarm type selection if forceAlarmType is null

### DIFF
--- a/lib/Controller/ViewController.php
+++ b/lib/Controller/ViewController.php
@@ -97,7 +97,7 @@ class ViewController extends Controller {
 		$hideEventExport = $this->config->getAppValue($this->appName, 'hideEventExport', 'no') === 'yes';
 		$forceEventAlarmType = $this->config->getAppValue($this->appName, 'forceEventAlarmType', '');
 		if (!in_array($forceEventAlarmType, ['DISPLAY', 'EMAIL'], true)) {
-			$forceEventAlarmType = null;
+			$forceEventAlarmType = false;
 		}
 
 		$talkEnabled = $this->appManager->isEnabledForUser('spreed');

--- a/src/components/Editor/Alarm/AlarmList.vue
+++ b/src/components/Editor/Alarm/AlarmList.vue
@@ -78,7 +78,7 @@ export default {
 		addAlarm(totalSeconds) {
 			this.$store.commit('addAlarmToCalendarObjectInstance', {
 				calendarObjectInstance: this.calendarObjectInstance,
-				type: this.forceEventAlarmType ?? 'DISPLAY',
+				type: this.forceEventAlarmType || 'DISPLAY',
 				totalSeconds,
 			})
 		},

--- a/src/components/Editor/Alarm/AlarmListItem.vue
+++ b/src/components/Editor/Alarm/AlarmListItem.vue
@@ -98,14 +98,14 @@
 			class="property-alarm-item__options">
 			<Actions>
 				<ActionRadio
-					v-if="canChangeAlarmType && (isAlarmTypeDisplay || forceEventAlarmType === null || forceEventAlarmType === 'DISPLAY')"
+					v-if="canChangeAlarmType || (!isAlarmTypeDisplay && forceEventAlarmType === 'DISPLAY')"
 					:name="alarmTypeName"
 					:checked="isAlarmTypeDisplay"
 					@change="changeType('DISPLAY')">
 					{{ $t('calendar', 'Notification') }}
 				</ActionRadio>
 				<ActionRadio
-					v-if="canChangeAlarmType && (isAlarmTypeEmail || forceEventAlarmType === null || forceEventAlarmType === 'EMAIL')"
+					v-if="canChangeAlarmType || (!isAlarmTypeEmail && forceEventAlarmType === 'EMAIL')"
 					:name="alarmTypeName"
 					:checked="isAlarmTypeEmail"
 					@change="changeType('EMAIL')">
@@ -266,8 +266,15 @@ export default {
 
 			return true
 		},
+		/**
+		 * Changing the alarm type is allowed if the alarm type does
+		 * not match the forceEventAlarmType (yet).
+		 *
+		 * If no alarm type is forced (forceEventAlarmType === false),
+		 * this will return true as well.
+		 */
 		canChangeAlarmType() {
-		  return this.forceEventAlarmType !== null && this.alarm.type !== this.forceEventAlarmType
+			return this.alarm.type !== this.forceEventAlarmType
 		},
 		alarmTypeName() {
 			return this._uid + '-radio-type-name'

--- a/src/store/settings.js
+++ b/src/store/settings.js
@@ -42,7 +42,7 @@ const state = {
 	tasksEnabled: false,
 	timezone: 'automatic',
 	hideEventExport: false,
-	forceEventAlarmType: null,
+	forceEventAlarmType: false,
 	// user-defined Nextcloud settings
 	momentLocale: 'en',
 }
@@ -162,6 +162,8 @@ Initial settings:
 	- TalkEnabled: ${talkEnabled}
 	- TasksEnabled: ${tasksEnabled}
 	- Timezone: ${timezone}
+	- HideEventExport: ${hideEventExport}
+	- ForceEventAlarmType: ${forceEventAlarmType}
 `)
 
 		state.appVersion = appVersion

--- a/src/views/Calendar.vue
+++ b/src/views/Calendar.vue
@@ -219,7 +219,7 @@ export default {
 			timezone: loadState('calendar', 'timezone'),
 			showTasks: loadState('calendar', 'show_tasks'),
 			hideEventExport: loadState('calendar', 'hide_event_export'),
-			forceEventAlarmType: loadState('calendar', 'force_event_alarm_type', null),
+			forceEventAlarmType: loadState('calendar', 'force_event_alarm_type', false),
 		})
 		this.$store.dispatch('initializeCalendarJsConfig')
 

--- a/tests/javascript/unit/store/settings.test.js
+++ b/tests/javascript/unit/store/settings.test.js
@@ -49,7 +49,7 @@ describe('store/settings test suite', () => {
 		expect(settingsStore.state).toEqual({
 			appVersion: null,
 			firstRun: null,
-			forceEventAlarmType: null,
+			forceEventAlarmType: false,
 			hideEventExport: false,
 			talkEnabled: false,
 			eventLimit: null,
@@ -168,6 +168,8 @@ describe('store/settings test suite', () => {
 			timezone: 'automatic',
 			momentLocale: 'en',
 			otherProp: 'bar',
+			hideEventExport: false,
+			forceEventAlarmType: false,
 		}
 
 		const settings = {
@@ -184,6 +186,8 @@ describe('store/settings test suite', () => {
 			tasksEnabled: true,
 			timezone: 'Europe/Berlin',
 			otherUnknownSetting: 'foo',
+			hideEventExport: false,
+			forceEventAlarmType: false,
 		}
 
 		settingsStore.mutations.loadSettingsFromServer(state, settings)
@@ -203,6 +207,8 @@ Initial settings:
 	- TalkEnabled: false
 	- TasksEnabled: true
 	- Timezone: Europe/Berlin
+	- HideEventExport: false
+	- ForceEventAlarmType: false
 `)
 		expect(state).toEqual({
 			appVersion: '2.1.0',
@@ -219,6 +225,8 @@ Initial settings:
 			timezone: 'Europe/Berlin',
 			momentLocale: 'en',
 			otherProp: 'bar',
+			hideEventExport: false,
+			forceEventAlarmType: false,
 		})
 	})
 


### PR DESCRIPTION
This fixes selecting an alarm type if `forceEventAlarmType` is not set. The tricky thing is that it was not clear to me what the desired outcome of the code was. Hence, I interpreted it in a way that made most sense to me, but I might be wrong. This is how it looks now:

`forceEventAlarmType` is not set (or not `DISPLAY` or `EMAIL`):
![Screenshot 2022-03-14 at 11-40-31 Week 12 of 2022 - Calendar - Nextcloud](https://user-images.githubusercontent.com/2496460/158156306-3a803d23-adbe-4bb5-8b54-79d4d38b040a.png)
One can select the alarm type. If it's `AUDIO` or something else, this will be shown.

`forceEventAlarmType` is `DISPLAY` or `EMAIL`:
![Screenshot 2022-03-14 at 11-42-44 Week 12 of 2022 - Calendar - Nextcloud](https://user-images.githubusercontent.com/2496460/158156617-88a9e9ae-1d93-4353-9a17-ca99373063a4.png)
No selection is possible, the alarm is created with the forced type.

Fixes #4032 and #4051.