### PR TITLE
[WIP] Move event rendering to vue

### DIFF
--- a/src/components/CalendarGrid.vue
+++ b/src/components/CalendarGrid.vue
@@ -23,7 +23,11 @@
 <template>
 	<FullCalendar
 		ref="fullCalendar"
-		:options="options" />
+		:options="options">
+		<template #eventContent="arg">
+			<EventRender :event-details="arg" />
+		</template>
+	</FullCalendar>
 </template>
 
 <script>
@@ -56,6 +60,7 @@ import dayHeaderDidMount from '../fullcalendar/rendering/dayHeaderDidMount.js'
 import eventDidMount from '../fullcalendar/rendering/eventDidMount.js'
 import eventOrder from '../fullcalendar/rendering/eventOrder.js'
 import noEventsDidMount from '../fullcalendar/rendering/noEventsDidMount.js'
+import EventRender from './EventRender.vue'
 
 // Import timezone plugins
 import VTimezoneNamedTimezone from '../fullcalendar/timezones/vtimezoneNamedTimezoneImpl.js'
@@ -71,6 +76,7 @@ export default {
 	name: 'CalendarGrid',
 	components: {
 		FullCalendar,
+	  EventRender,
 	},
 	props: {
 		/**

--- a/src/components/EventRender.vue
+++ b/src/components/EventRender.vue
@@ -1,0 +1,53 @@
+<!--
+  - @copyright Copyright (c) 2022 Thomas Citharel <nextcloud@tcit.fr>
+  -
+  - @author Thomas Citharel <nextcloud@tcit.fr>
+  -
+  - @license GNU AGPL version 3 or any later version
+  -
+  - This program is free software: you can redistribute it and/or modify
+  - it under the terms of the GNU Affero General Public License as
+  - published by the Free Software Foundation, either version 3 of the
+  - License, or (at your option) any later version.
+  -
+  - This program is distributed in the hope that it will be useful,
+  - but WITHOUT ANY WARRANTY; without even the implied warranty of
+  - MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  - GNU Affero General Public License for more details.
+  -
+  - You should have received a copy of the GNU Affero General Public License
+  - along with this program. If not, see <http://www.gnu.org/licenses/>.
+  -
+  -->
+<template>
+	<div>
+		<Bell v-if="hasAlarms" />
+		<b>{{ eventDetails.timeText }}</b>
+		<span class="fc-event-title">{{ eventDetails.event.title }}</span>
+	</div>
+</template>
+
+<script>
+import Bell from 'vue-material-design-icons/Bell.vue'
+
+export default {
+	name: 'EventRender',
+	components: {
+		Bell,
+	},
+	props: {
+		eventDetails: {
+			type: Object,
+			required: true,
+		},
+	},
+	computed: {
+		viewType() {
+			return this.eventDetails?.view?.type
+		},
+		hasAlarms() {
+			return this.eventDetails?.event?._def?.extendedProps?.hasAlarms
+		},
+	},
+}
+</script>

--- a/src/fullcalendar/eventSources/eventSourceFunction.js
+++ b/src/fullcalendar/eventSources/eventSourceFunction.js
@@ -52,6 +52,7 @@ export function eventSourceFunction(calendarObjects, calendar, start, end, timez
 
 		for (const object of allObjectsInTimeRange) {
 			const classNames = []
+			let hasAlarms = false
 
 			if (object.status === 'CANCELLED') {
 				classNames.push('fc-event-nc-cancelled')
@@ -60,6 +61,7 @@ export function eventSourceFunction(calendarObjects, calendar, start, end, timez
 			}
 
 			if (object.hasComponent('VALARM')) {
+				hasAlarms = true
 				classNames.push('fc-event-nc-alarms')
 			}
 
@@ -143,6 +145,7 @@ export function eventSourceFunction(calendarObjects, calendar, start, end, timez
 					davUrl: calendarObject.dav.url,
 					location: object.location,
 					description: object.description,
+					hasAlarms,
 				},
 			}
 


### PR DESCRIPTION
Full calendar has a slot named `eventContent` that we can use to render the event.

Previously the rendering was handled using classes in `src/fullcalendar/eventSources/eventSourceFunction.js` and `src/fullcalendar/rendering/eventDidMount.js`.

- [x] Show the bell icon when the event has alarms
- [ ] Add the attendee icon from #3994
- [ ] Show the checkbox icon when the event is a task
   - [ ] Adapt to the view (check logic in `eventDidMount.js`)
   - [ ] Adapt to the task being done
- [ ] Add the location and description content in the event in the list view
- [ ] Set the event text color to `eventDetails.textColor` and background to `eventDetails.backgroundColor`
- [ ] Adapt the CSS to make the icons look right
- [ ] Remove the addition of now unneeded classes in both `eventSourceFunction.js` and `eventDidMount.js` files (some need to be kept, such as `fc-event-nc-cancelled`)
- [ ] Clear the corresponding classes from the SCSS code

Addresses #3162 and replaces #3994