### PR TITLE
Replace deprecated String.prototype.substr()

### DIFF
--- a/src/components/AppNavigation/CalendarList/PublicCalendarListItem.vue
+++ b/src/components/AppNavigation/CalendarList/PublicCalendarListItem.vue
@@ -141,7 +141,7 @@ export default {
 			}
 
 			// 'dav/principals/users/'.length => 21
-			const userId = this.calendar.owner.substr(lastIndex + 21)
+			const userId = this.calendar.owner.slice(lastIndex + 21)
 			if (userId.endsWith('/')) {
 				return userId.slice(0, -1)
 			}

--- a/src/components/Editor/FreeBusy/FreeBusy.vue
+++ b/src/components/Editor/FreeBusy/FreeBusy.vue
@@ -167,7 +167,7 @@ export default {
 			const resources = []
 
 			for (const attendee of [this.organizer, ...this.attendees]) {
-				let title = attendee.commonName || attendee.uri.substr(7)
+				let title = attendee.commonName || attendee.uri.slice(7)
 				if (attendee === this.organizer) {
 					title = this.$t('calendar', '{organizer} (organizer)', {
 						organizer: title,

--- a/src/models/calendarShare.js
+++ b/src/models/calendarShare.js
@@ -62,9 +62,9 @@ const mapDavShareeToCalendarShareObject = (sharee) => {
 	if (sharee['common-name'] && sharee['common-name'].trim() !== '') {
 		displayName = sharee['common-name']
 	} else if (sharee.href.startsWith(PRINCIPAL_PREFIX_GROUP)) {
-		displayName = decodeURIComponent(sharee.href.substr(28))
+		displayName = decodeURIComponent(sharee.href.slice(28))
 	} else if (sharee.href.startsWith(PRINCIPAL_PREFIX_USER)) {
-		displayName = decodeURIComponent(sharee.href.substr(27))
+		displayName = decodeURIComponent(sharee.href.slice(27))
 	} else {
 		displayName = sharee.href
 	}

--- a/src/store/calendars.js
+++ b/src/store/calendars.js
@@ -477,7 +477,7 @@ const getters = {
 		const calendarUriMap = {}
 		state.calendars.forEach(calendar => {
 			const withoutTrail = calendar.url.replace(/\/$/, '')
-			const uri = withoutTrail.substr(withoutTrail.lastIndexOf('/') + 1)
+			const uri = withoutTrail.slice(withoutTrail.lastIndexOf('/') + 1)
 			calendarUriMap[uri] = calendar
 		})
 
@@ -532,7 +532,7 @@ const getters = {
 		for (const calendar of state.calendars) {
 			const url = calendar.url.slice(0, -1)
 			const lastSlash = url.lastIndexOf('/')
-			const uri = url.substr(lastSlash + 1)
+			const uri = url.slice(lastSlash + 1)
 
 			if (uri === CALDAV_BIRTHDAY_CALENDAR) {
 				return calendar
@@ -1031,8 +1031,8 @@ const actions = {
 		// calling this action to properly handle it
 		const objectPath = atob(objectId)
 		const lastSlashIndex = objectPath.lastIndexOf('/')
-		const calendarPath = objectPath.substr(0, lastSlashIndex + 1)
-		const objectFileName = objectPath.substr(lastSlashIndex + 1)
+		const calendarPath = objectPath.slice(0, lastSlashIndex + 1)
+		const objectFileName = objectPath.slice(lastSlashIndex + 1)
 
 		const calendarId = btoa(calendarPath)
 		if (!context.state.calendarsById[calendarId]) {

--- a/src/utils/attendee.js
+++ b/src/utils/attendee.js
@@ -28,7 +28,7 @@
  */
 export function removeMailtoPrefix(uri) {
 	if (uri.startsWith('mailto:')) {
-		return uri.substr(7)
+		return uri.slice(7)
 	}
 
 	return uri

--- a/src/utils/color.js
+++ b/src/utils/color.js
@@ -71,7 +71,7 @@ export function hexToRGB(hexColor) {
 	if (hexColor == null) {
 		return { red: 0, green: 0, blue: 0 }
 	}
-	const [red, green, blue] = convert.hex.rgb(hexColor.substr(1))
+	const [red, green, blue] = convert.hex.rgb(hexColor.slice(1))
 	return { red, green, blue }
 }
 
@@ -98,9 +98,9 @@ export function detectColor(color) {
 	} else if (/^((?:[A-Fa-f0-9]{3}){1,2})$/.test(color)) { // ff00ff and f0f
 		return '#' + color
 	} else if (/^(#)((?:[A-Fa-f0-9]{8}))$/.test(color)) { // #ff00ffff and #f0ff
-		return color.substr(0, 7)
+		return color.slice(0, 7)
 	} else if (/^((?:[A-Fa-f0-9]{8}))$/.test(color)) { // ff00ffff and f0ff
-		return '#' + color.substr(0, 6)
+		return '#' + color.slice(0, 6)
 	}
 
 	return false


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.