### PR TITLE
add ok-button to datetime picker

### DIFF
--- a/src/components/Shared/DatePicker.vue
+++ b/src/components/Shared/DatePicker.vue
@@ -39,7 +39,8 @@
 		v-on="$listeners"
 		@close="close"
 		@change="change"
-		@pick="pickDate">
+		@pick="pickDate"
+		confirm>
 		<template #icon-calendar>
 			<button class="datetime-picker-inline-icon icon"
 				:class="{'icon-timezone': !isAllDay, 'icon-new-calendar': isAllDay, 'datetime-picker-inline-icon--highlighted': highlightTimezone}"


### PR DESCRIPTION
This closes #2936.

The goal is to create a more "guided" user experience by providing explicit actions to confirm an action