### PR TITLE
List events from selected day to 4 weeks ahead

### DIFF
--- a/src/components/AppNavigation/AppNavigationHeader/AppNavigationHeaderDatePicker.vue
+++ b/src/components/AppNavigation/AppNavigationHeader/AppNavigationHeaderDatePicker.vue
@@ -146,8 +146,13 @@ export default {
 				})
 				break
 
-			case 'dayGridMonth':
 			case 'listMonth':
+				newDate = modifyDate(this.selectedDate, {
+					week: 4,
+				})
+				break
+				
+			case 'dayGridMonth':
 			default: {
 				// modifyDate is just adding one month, so we have to manually
 				// set the date of month to 1. Otherwise if your date is set to

--- a/src/components/AppNavigation/AppNavigationHeader/AppNavigationHeaderDatePicker.vue
+++ b/src/components/AppNavigation/AppNavigationHeader/AppNavigationHeaderDatePicker.vue
@@ -151,7 +151,7 @@ export default {
 					week: 4,
 				})
 				break
-				
+
 			case 'dayGridMonth':
 			default: {
 				// modifyDate is just adding one month, so we have to manually


### PR DESCRIPTION
As suggested in https://github.com/nextcloud/calendar/issues/2632

Add:
- list view lists tasks and events starting from selected day (today) to 4 weeks ahead

Remove:
- list view lists tasks and events starting from the first day of selected month