### PR TITLE
fix auto scroll when clicking on any event in week view

### DIFF
--- a/src/components/CalendarGrid.vue
+++ b/src/components/CalendarGrid.vue
@@ -146,6 +146,8 @@ export default {
 				unselectAuto: false,
 				// Timezones:
 				timeZone: this.timezoneId,
+				// Disable jumping in week view and day view when clicking on any event using the simple editor
+				scrollTimeReset: false,
 			}
 		},
 		eventSources() {


### PR DESCRIPTION
Summary: Disable jumping in week view and day view when clicking on any event
(as it was seen in https://user-images.githubusercontent.com/42591237/146625491-3b64b552-e0f5-4ee8-8c19-beb51d4785c7.mp4)

Signed-off-by: szaimen <szaimen@e.mail.de>

<details>
<summary>For my own testing</summary>

```
docker run -it \
-e CALENDAR_BRANCH=enh/noid/fix-scrolling \
-p 8443:443 \
-e TRUSTED_DOMAIN=192.168.146.128 \
--name nextcloud-easy-test \
ghcr.io/szaimen/nextcloud-easy-test:latest
```

</details>