### PR TITLE
show the popover also on smaller screens to a certain degree

### DIFF
--- a/src/fullcalendar/interaction/eventClick.js
+++ b/src/fullcalendar/interaction/eventClick.js
@@ -66,7 +66,9 @@ function handleEventClick(event, store, router, route, window) {
 		? 'EditSidebarView'
 		: 'EditPopoverView'
 
-	if (window.innerWidth <= 768 && desiredRoute === 'EditPopoverView') {
+	// Don't show the popover if the window size is too small (less then its max width of 450 px + a bit)
+	// The mobile breakpoint of the reworked modals is 1024 px / 2 so simply use that.
+	if (window.innerWidth <= 1024 / 2 && desiredRoute === 'EditPopoverView') {
 		desiredRoute = 'EditSidebarView'
 	}
 

--- a/src/fullcalendar/interaction/select.js
+++ b/src/fullcalendar/interaction/select.js
@@ -37,7 +37,9 @@ export default function(store, router, route, window) {
 			? 'NewSidebarView'
 			: 'NewPopoverView'
 
-		if (window.innerWidth <= 768 && name === 'NewPopoverView') {
+		// Don't show the popover if the window size is too small (less then its max width of 450 px + a bit)
+		// The mobile breakpoint of the reworked modals is 1024 px / 2 so simply use that.
+		if (window.innerWidth <= 1024 / 2 && name === 'NewPopoverView') {
 			name = 'NewSidebarView'
 		}
 

--- a/src/utils/router.js
+++ b/src/utils/router.js
@@ -51,7 +51,9 @@ export function getPreferredEditorRoute() {
 		skipPopover = false
 	}
 
-	if (window.innerWidth <= 768) {
+	// Don't show the popover if the window size is too small (less then its max width of 450 px + a bit)
+	// The mobile breakpoint of the reworked modals is 1024 px / 2 so simply use that.
+	if (window.innerWidth <= 1024 / 2) {
 		skipPopover = true
 	}
 

--- a/tests/javascript/unit/fullcalendar/interaction/eventClick.test.js
+++ b/tests/javascript/unit/fullcalendar/interaction/eventClick.test.js
@@ -117,7 +117,7 @@ describe('fullcalendar/eventClick test suite', () => {
 		const store = { state: { settings: { skipPopover: false } } }
 		const router = { push: jest.fn() }
 		const route = { name: 'CalendarView', params: { otherParam: '456' } }
-		const window = { innerWidth: 760 }
+		const window = { innerWidth: 500 }
 
 		getPrefixedRoute
 			.mockReturnValueOnce('EditSidebarView')

--- a/tests/javascript/unit/fullcalendar/interaction/select.test.js
+++ b/tests/javascript/unit/fullcalendar/interaction/select.test.js
@@ -77,7 +77,7 @@ describe('fullcalendar/select test suite', () => {
 		const store = { state: { settings: { skipPopover: false } } }
 		const router = { push: jest.fn() }
 		const route = { name: 'CalendarView', params: { otherParam: '456' } }
-		const window = { innerWidth: 760 }
+		const window = { innerWidth: 500 }
 
 		const start = new Date(Date.UTC(2019, 0, 1, 0, 0, 0, 0))
 		const end = new Date(Date.UTC(2019, 0, 2, 0, 0, 0, 0))

--- a/tests/javascript/unit/utils/router.test.js
+++ b/tests/javascript/unit/utils/router.test.js
@@ -67,7 +67,7 @@ describe('utils/router test suite', () => {
 	})
 
 	it('should get the preferred editor view (small screens)', () => {
-		window.innerWidth = 760
+		window.innerWidth = 500
 
 		loadState
 			.mockReturnValueOnce(true)


### PR DESCRIPTION
| Before | After |
|---|---|
| ![image](https://user-images.githubusercontent.com/42591237/161429831-91430dff-f2b6-439b-9c8e-5fe5bd894cff.png) | ![image](https://user-images.githubusercontent.com/42591237/161431428-dc2ed746-5e9b-457c-9869-c0ef9e524846.png) |

Signed-off-by: szaimen <szaimen@e.mail.de>

<details>
<summary>For my own testing</summary>

```
docker run -it \
-e CALENDAR_BRANCH=enh/noid/show-popover \
-p 8443:443 \
-e TRUSTED_DOMAIN=192.168.146.128 \
--name nextcloud-easy-test \
ghcr.io/szaimen/nextcloud-easy-test:latest
```

</details>