### PR TITLE
Compare lower case email when checking invitees

### DIFF
--- a/src/components/Editor/Invitees/InviteesListSearch.vue
+++ b/src/components/Editor/Invitees/InviteesListSearch.vue
@@ -115,7 +115,7 @@ export default {
 				// eslint-disable-next-line
 				const emailRegex = /^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/
 				if (emailRegex.test(query)) {
-					const alreadyInList = matches.find((attendee) => attendee.email === query)
+					const alreadyInList = matches.find((attendee) => attendee.email.toLowerCase() === query.toLowerCase())
 					if (!alreadyInList) {
 						matches.unshift({
 							calendarUserType: 'INDIVIDUAL',


### PR DESCRIPTION
When comparing email to check if it is present in the invitees list, we do not normalize the value.
This leads to inconsistencies:
1. the user will see two options when searching for Alice@exampe.com if the stored email is alice@example.com
2. the user will see one option when searching for alice@exampe.com if the stored email is alice@example.com

1 | 2
-- | --
![Screenshot from 2022-05-05 16-19-37](https://user-images.githubusercontent.com/6653109/166944510-1000e7d9-1f75-4747-a279-bb79def2fa36.png) | ![Screenshot from 2022-05-05 16-20-40](https://user-images.githubusercontent.com/6653109/166944513-26532304-f6c6-4612-8725-a158b91e954a.png)

This PR transform the values to lower cases to consolidate the number of options offered to the user.