### PR TITLE
Fix and harden logic to extract an avatar link in invitee list

### DIFF
--- a/src/components/Editor/Invitees/InviteesListItem.vue
+++ b/src/components/Editor/Invitees/InviteesListItem.vue
@@ -2,6 +2,7 @@
   - @copyright Copyright (c) 2019 Georg Ehrke <oc.list@georgehrke.com>
   -
   - @author Georg Ehrke <oc.list@georgehrke.com>
+  - @author Richard Steinmetz <richard@steinmetz.cloud>
   -
   - @license GNU AGPL version 3 or any later version
   -
@@ -106,10 +107,18 @@ export default {
 		},
 	},
 	computed: {
+		/**
+		 * @return {string}
+		 */
 		avatarLink() {
 			// return this.$store.getters.getAvatarForContact(this.uri) || this.commonName
 			return this.commonName
 		},
+		/**
+		 * Common name of the organizer or the uri without the 'mailto:' prefix.
+		 *
+		 * @return {string}
+		 */
 		commonName() {
 			if (this.attendee.commonName) {
 				return this.attendee.commonName
@@ -119,7 +128,7 @@ export default {
 				return removeMailtoPrefix(this.attendee.uri)
 			}
 
-			return this.attendee.uri
+			return ''
 		},
 		radioName() {
 			return this._uid + '-role-radio-input-group'

--- a/src/components/Editor/Invitees/OrganizerListItem.vue
+++ b/src/components/Editor/Invitees/OrganizerListItem.vue
@@ -2,6 +2,7 @@
   - @copyright Copyright (c) 2019 Georg Ehrke <oc.list@georgehrke.com>
   -
   - @author Georg Ehrke <oc.list@georgehrke.com>
+  - @author Richard Steinmetz <richard@steinmetz.cloud>
   -
   - @license GNU AGPL version 3 or any later version
   -
@@ -40,6 +41,7 @@
 
 <script>
 import AvatarParticipationStatus from '../AvatarParticipationStatus'
+import { removeMailtoPrefix } from '../../../utils/attendee'
 
 export default {
 	name: 'OrganizerListItem',
@@ -57,20 +59,28 @@ export default {
 		},
 	},
 	computed: {
+		/**
+		 * @return {string}
+		 */
 		avatarLink() {
 			// return this.$store.getters.getAvatarForContact(this.uri) || this.commonName
-			return this.organizer.commonName
+			return this.commonName
 		},
+		/**
+		 * Common name of the attendee or the uri without the 'mailto:' prefix.
+		 *
+		 * @return {string}
+		 */
 		commonName() {
 			if (this.organizer.commonName) {
 				return this.organizer.commonName
 			}
 
-			if (this.organizer.uri && this.organizer.uri.startsWith('mailto:')) {
-				return this.organizer.uri.substr(7)
+			if (this.organizer.uri) {
+				return removeMailtoPrefix(this.organizer.uri)
 			}
 
-			return this.organizer.uri
+			return ''
 		},
 		isViewedByOrganizer() {
 			return true


### PR DESCRIPTION
Fix #3979

The bug can be reproduced by editing an event with an organizer who is not a user, e.g. `ORGANIZER:mailto:other@domain.tld`.

| Before | After |
| --- | --- |
| ![155034429-8c8e62da-22be-480c-8476-b8c132031e12](https://user-images.githubusercontent.com/1479486/170726112-c06f4bef-7e37-4f89-924e-368357b5ec24.png) | ![image](https://user-images.githubusercontent.com/1479486/170725777-fbd1087b-baf4-4ea3-a197-49b22b812474.png) |
