### PR TITLE
Add missing stylelint.config.js to .nextcloudignore

### DIFF
--- a/.nextcloudignore
+++ b/.nextcloudignore
@@ -26,6 +26,7 @@ phpunit.unit.xml
 README.md
 screenshots
 src
+stylelint.config.js
 tests
 timezones
 webpack.*


### PR DESCRIPTION
I did a build and saw that stylelint.config.js is included.