### PR TITLE
Generate optimized autoloaders in krankerl config

### DIFF
--- a/krankerl.toml
+++ b/krankerl.toml
@@ -1,6 +1,6 @@
 [package]
 before_cmds = [
-    "composer install --no-dev",
+    "composer install --no-dev -o",
     "npm install",
     "npm run build",
 ]


### PR DESCRIPTION
Is there a reason we don't generate optimized autoloaders?