### PR TITLE
Drop Nextcloud 21 support

### DIFF
--- a/.github/workflows/php-test.yml
+++ b/.github/workflows/php-test.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         php-versions: ['7.3', '7.4']
-        nextcloud-versions: ['stable21', 'stable22', 'stable23']
+        nextcloud-versions: ['stable22', 'stable23']
         include:
           - php-versions: '7.3'
             nextcloud-versions: 'stable20'

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -33,7 +33,7 @@
 	<screenshot>https://raw.githubusercontent.com/nextcloud/calendar/main/screenshots/week_sidebar.png</screenshot>
 	<dependencies>
 		<php min-version="7.3" max-version="8.1" />
-		<nextcloud min-version="21" max-version="25" />
+		<nextcloud min-version="22" max-version="25" />
 	</dependencies>
 	<background-jobs>
 		<job>OCA\Calendar\BackgroundJob\CleanUpOutdatedBookingsJob</job>


### PR DESCRIPTION
It has reached EOL https://github.com/nextcloud/server/wiki/Maintenance-and-Release-Schedule/2b65f8eac077a96428fb778a248bf3b6f4642b9e