### PR TITLE
fix hide the 3-dot menu button for new events

### DIFF
--- a/src/views/EditSidebar.vue
+++ b/src/views/EditSidebar.vue
@@ -54,7 +54,7 @@
 			<IllustrationHeader :color="illustrationColor" :illustration-url="backgroundImage" />
 		</template>
 
-		<template v-if="!isLoading && !isError"
+		<template v-if="!isLoading && !isError && !isNew"
 			#secondary-actions>
 			<ActionLink v-if="!hideEventExport && hasDownloadURL"
 				:href="downloadURL">

--- a/src/views/EditSimple.vue
+++ b/src/views/EditSimple.vue
@@ -65,7 +65,7 @@
 						{{ $t('calendar', 'Show more details') }}
 					</ActionButton>
 				</Actions>
-				<Actions v-if="!isLoading && !isError" :force-menu="true">
+				<Actions v-if="!isLoading && !isError && !isNew" :force-menu="true">
 					<ActionLink v-if="!hideEventExport && hasDownloadURL"
 						:href="downloadURL">
 						<template #icon>


### PR DESCRIPTION
Fix https://github.com/nextcloud/calendar/issues/4270

Signed-off-by: szaimen <szaimen@e.mail.de>