### PR TITLE
Add a config appsetting to allow to disable appointments

### DIFF
--- a/lib/Controller/ViewController.php
+++ b/lib/Controller/ViewController.php
@@ -95,6 +95,7 @@ class ViewController extends Controller {
 		$defaultReminder = $this->config->getUserValue($this->userId, $this->appName, 'defaultReminder', $defaultDefaultReminder);
 		$showTasks = $this->config->getUserValue($this->userId, $this->appName, 'showTasks', $defaultShowTasks) === 'yes';
 		$hideEventExport = $this->config->getAppValue($this->appName, 'hideEventExport', 'no') === 'yes';
+		$disableAppointments = $this->config->getAppValue($this->appName, 'disableAppointments', 'no') === 'yes';
 		$forceEventAlarmType = $this->config->getAppValue($this->appName, 'forceEventAlarmType', '');
 		if (!in_array($forceEventAlarmType, ['DISPLAY', 'EMAIL'], true)) {
 			$forceEventAlarmType = false;
@@ -120,7 +121,8 @@ class ViewController extends Controller {
 		$this->initialStateService->provideInitialState('tasks_enabled', $tasksEnabled);
 		$this->initialStateService->provideInitialState('hide_event_export', $hideEventExport);
 		$this->initialStateService->provideInitialState('force_event_alarm_type', $forceEventAlarmType);
-		$this->initialStateService->provideInitialState('appointmentConfigs',$this->appointmentConfigService->getAllAppointmentConfigurations($this->userId));
+		$this->initialStateService->provideInitialState('appointmentConfigs', $this->appointmentConfigService->getAllAppointmentConfigurations($this->userId));
+		$this->initialStateService->provideInitialState('disable_appointments', $disableAppointments);
 
 		return new TemplateResponse($this->appName, 'main');
 	}

--- a/src/store/settings.js
+++ b/src/store/settings.js
@@ -32,6 +32,7 @@ const state = {
 	appVersion: null,
 	firstRun: null,
 	talkEnabled: false,
+	disableAppointments: false,
 	// user-defined calendar settings
 	eventLimit: null,
 	showTasks: null,
@@ -147,8 +148,9 @@ const mutations = {
 	 * @param {string} data.timezone The timezone to view the calendar in. Either an Olsen timezone or "automatic"
 	 * @param {boolean} data.hideEventExport
 	 * @param {string} data.forceEventAlarmType
+	 * @param {boolean} data.disableAppointments Allow to disable the appointments feature
 	 */
-	loadSettingsFromServer(state, { appVersion, eventLimit, firstRun, showWeekNumbers, showTasks, showWeekends, skipPopover, slotDuration, defaultReminder, talkEnabled, tasksEnabled, timezone, hideEventExport, forceEventAlarmType }) {
+	loadSettingsFromServer(state, { appVersion, eventLimit, firstRun, showWeekNumbers, showTasks, showWeekends, skipPopover, slotDuration, defaultReminder, talkEnabled, tasksEnabled, timezone, hideEventExport, forceEventAlarmType, disableAppointments }) {
 		logInfo(`
 Initial settings:
 	- AppVersion: ${appVersion}
@@ -165,6 +167,7 @@ Initial settings:
 	- Timezone: ${timezone}
 	- HideEventExport: ${hideEventExport}
 	- ForceEventAlarmType: ${forceEventAlarmType}
+	- disableAppointments: ${disableAppointments}
 `)
 
 		state.appVersion = appVersion
@@ -181,6 +184,7 @@ Initial settings:
 		state.timezone = timezone
 		state.hideEventExport = hideEventExport
 		state.forceEventAlarmType = forceEventAlarmType
+		state.disableAppointments = disableAppointments
 	},
 
 	/**

--- a/src/views/Calendar.vue
+++ b/src/views/Calendar.vue
@@ -141,6 +141,7 @@ export default {
 			showTasks: state => state.settings.showTasks,
 			timezone: state => state.settings.timezone,
 			modificationCount: state => state.calendarObjects.modificationCount,
+			disableAppointments: state => state.settings.disableAppointments,
 		}),
 		defaultDate() {
 			return getYYYYMMDDFromFirstdayParam(this.$route.params?.firstDay ?? 'now')
@@ -178,8 +179,8 @@ export default {
 			return null
 		},
 		hasAppointmentsFeature() {
-			// TODO: Remove me when Calendar doesn't support server < 23
-			return parseInt(OC.config.version.split('.')[0]) >= 23
+			// TODO: Remove the end condition when Calendar doesn't support server < 23
+			return !this.disableAppointments && parseInt(OC.config.version.split('.')[0]) >= 23
 		},
 	},
 	created() {
@@ -216,6 +217,7 @@ export default {
 			showTasks: loadState('calendar', 'show_tasks'),
 			hideEventExport: loadState('calendar', 'hide_event_export'),
 			forceEventAlarmType: loadState('calendar', 'force_event_alarm_type', false),
+			disableAppointments: loadState('calendar', 'disable_appointments', false),
 		})
 		this.$store.dispatch('initializeCalendarJsConfig')
 

--- a/tests/javascript/unit/store/settings.test.js
+++ b/tests/javascript/unit/store/settings.test.js
@@ -62,6 +62,7 @@ describe('store/settings test suite', () => {
 			tasksEnabled: false,
 			timezone: 'automatic',
 			momentLocale: 'en',
+			disableAppointments: false,
 		})
 	})
 
@@ -170,6 +171,7 @@ describe('store/settings test suite', () => {
 			otherProp: 'bar',
 			hideEventExport: false,
 			forceEventAlarmType: false,
+			disableAppointments: false,
 		}
 
 		const settings = {
@@ -188,6 +190,7 @@ describe('store/settings test suite', () => {
 			otherUnknownSetting: 'foo',
 			hideEventExport: false,
 			forceEventAlarmType: false,
+			disableAppointments: false,
 		}
 
 		settingsStore.mutations.loadSettingsFromServer(state, settings)
@@ -209,6 +212,7 @@ Initial settings:
 	- Timezone: Europe/Berlin
 	- HideEventExport: false
 	- ForceEventAlarmType: false
+	- disableAppointments: false
 `)
 		expect(state).toEqual({
 			appVersion: '2.1.0',
@@ -227,6 +231,7 @@ Initial settings:
 			otherProp: 'bar',
 			hideEventExport: false,
 			forceEventAlarmType: false,
+			disableAppointments: false,
 		})
 	})
 
@@ -249,7 +254,7 @@ Initial settings:
 
 		settingsStore.mutations.setMomentLocale(state, { locale: 'de' })
 		expect(logInfo).toHaveBeenCalledTimes(1)
-		expect(logInfo).toHaveBeenNthCalledWith(1, `Updated moment locale: de`)
+		expect(logInfo).toHaveBeenNthCalledWith(1, 'Updated moment locale: de')
 
 		expect(state).toEqual({
 			appVersion: null,
@@ -270,7 +275,7 @@ Initial settings:
 
 	it('should provide a getter the get the resolved timezone - automatic', () => {
 		const state = {
-			timezone: 'automatic'
+			timezone: 'automatic',
 		}
 
 		detectTimezone
@@ -283,7 +288,7 @@ Initial settings:
 
 	it('should provide a getter the get the resolved timezone - non-automatic', () => {
 		const state = {
-			timezone: 'Europe/Berlin'
+			timezone: 'Europe/Berlin',
 		}
 
 		expect(settingsStore.getters.getResolvedTimezone(state)).toEqual('Europe/Berlin')
@@ -297,8 +302,8 @@ Initial settings:
 		const getters = {
 			hasBirthdayCalendar: true,
 			getBirthdayCalendar: {
-				id: 'contact_birthdays'
-			}
+				id: 'contact_birthdays',
+			},
 		}
 		const commit = jest.fn()
 		const dispatch = jest.fn()
@@ -323,12 +328,12 @@ Initial settings:
 		const dispatch = jest.fn()
 
 		const davCalendar = {
-			davCalendar: true
+			davCalendar: true,
 		}
 		enableBirthdayCalendar.mockResolvedValueOnce(davCalendar)
 
 		const calendar = {
-			id: 'new-birthday-calendar'
+			id: 'new-birthday-calendar',
 		}
 		mapDavCollectionToCalendar.mockReturnValueOnce(calendar)
 
@@ -531,7 +536,7 @@ Initial settings:
 		expect.assertions(2)
 
 		const state = {
-			slotDuration: '00:15:00'
+			slotDuration: '00:15:00',
 		}
 		const commit = jest.fn()
 
@@ -545,7 +550,7 @@ Initial settings:
 		expect.assertions(4)
 
 		const state = {
-			slotDuration: '00:15:00'
+			slotDuration: '00:15:00',
 		}
 		const commit = jest.fn()
 
@@ -563,7 +568,7 @@ Initial settings:
 		expect.assertions(2)
 
 		const state = {
-			defaultReminder: 'none'
+			defaultReminder: 'none',
 		}
 		const commit = jest.fn()
 
@@ -577,7 +582,7 @@ Initial settings:
 		expect.assertions(4)
 
 		const state = {
-			defaultReminder: 'none'
+			defaultReminder: 'none',
 		}
 		const commit = jest.fn()
 
@@ -595,7 +600,7 @@ Initial settings:
 		expect.assertions(2)
 
 		const state = {
-			timezone: 'automatic'
+			timezone: 'automatic',
 		}
 		const commit = jest.fn()
 
@@ -609,7 +614,7 @@ Initial settings:
 		expect.assertions(4)
 
 		const state = {
-			timezone: 'automatic'
+			timezone: 'automatic',
 		}
 		const commit = jest.fn()
 
@@ -625,7 +630,7 @@ Initial settings:
 
 	it('should provide an action to initialize the calendar-js config', () => {
 		const state = {
-			appVersion: '2.3.4'
+			appVersion: '2.3.4',
 		}
 
 		settingsStore.actions.initializeCalendarJsConfig({ state })


### PR DESCRIPTION
Context: on a production instance I administer (~100k users, ~15M events), the search for available slots systematically timeouts. A smaller instance (~6k) works great.

As there's no loading or error feedback on the loading page, the experience isn't great. There's probably room for improvement in the booking filters implementation.

In any case, I'd like to be able to disable this feature for the meantime, and there's probably some admins that don't care about this feature anyway.