### PR TITLE
Migrate icon of emptycontent dashboard to material design

### DIFF
--- a/src/components/AppNavigation/CalendarList/CalendarListItemSharingPublishItem.vue
+++ b/src/components/AppNavigation/CalendarList/CalendarListItemSharingPublishItem.vue
@@ -89,8 +89,7 @@
 				<!-- eslint-disable-next-line no-irregular-whitespace -->
 				{{ $t('calendar', 'Copying link …') }}
 			</ActionText>
-			<ActionText v-if="showCopySubscriptionLinkSuccess"
-				icon="icon-calendar-dark">
+			<ActionText v-if="showCopySubscriptionLinkSuccess">
 				<template #icon>
 					<CalendarBlank :size="20" decorative />
 				</template>

--- a/src/views/Dashboard.vue
+++ b/src/views/Dashboard.vue
@@ -50,8 +50,10 @@
 			</DashboardWidgetItem>
 		</template>
 		<template #empty-content>
-			<EmptyContent id="calendar-widget-empty-content"
-				icon="icon-calendar-dark">
+			<EmptyContent id="calendar-widget-empty-content">
+				<template #icon>
+					<EmptyCalendar />
+				</template>
 				<template #desc>
 					{{ t('calendar', 'No upcoming events') }}
 					<div class="empty-label">
@@ -66,6 +68,7 @@
 <script>
 import { DashboardWidget, DashboardWidgetItem } from '@nextcloud/vue-dashboard'
 import EmptyContent from '@nextcloud/vue/dist/Components/EmptyContent'
+import EmptyCalendar from 'vue-material-design-icons/CalendarBlankOutline'
 import { loadState } from '@nextcloud/initial-state'
 import moment from '@nextcloud/moment'
 import { imagePath, generateUrl } from '@nextcloud/router'
@@ -83,6 +86,7 @@ export default {
 	  DashboardWidget,
 		DashboardWidgetItem,
 		EmptyContent,
+	  EmptyCalendar,
 	},
 	data() {
 		return {


### PR DESCRIPTION
i removed also a leftover from CalendarListItemSharingPublishItem.vue
before
![before_empty_dashboard](https://user-images.githubusercontent.com/12728974/173857569-2f6786eb-e10b-45ee-8c93-56858f12cd2a.png)
after
![after_empty_dashboard](https://user-images.githubusercontent.com/12728974/173857561-43162d77-2c20-459f-b523-72aa23b9dc59.png)
