### PR TITLE
Fix the white space on calendar title

### DIFF
--- a/css/fullcalendar.scss
+++ b/css/fullcalendar.scss
@@ -243,7 +243,7 @@
 	}
 
 	.fc-event-title {
-		white-space: initial;
+		white-space: inherit;
 	}
 }
 


### PR DESCRIPTION
on week view
before
![before-whitespace](https://user-images.githubusercontent.com/12728974/174098263-d20c866d-bf49-437c-a59e-a78c55931e2d.png)
after
![after_calendar_whitspace](https://user-images.githubusercontent.com/12728974/174098268-a836d9f2-d44e-4cfb-b4c1-f999c7ae00c6.png)

fixes #4291 