### PR TITLE
fix the color of the list item and improve the add icons

### DIFF
--- a/css/app-navigation.scss
+++ b/css/app-navigation.scss
@@ -104,6 +104,10 @@
 		text-overflow: ellipsis;
 		white-space: nowrap;
 		overflow: hidden;
+
+		span {
+			padding-right: 10px;
+		}
 	}
 
 	.today {

--- a/src/components/AppNavigation/CalendarList/CalendarListItem.vue
+++ b/src/components/AppNavigation/CalendarList/CalendarListItem.vue
@@ -27,7 +27,7 @@
 		@click.prevent.stop="toggleEnabled">
 		<template slot="icon">
 			<Actions>
-				<ActionButton @click.prevent.stop="toggleEnabled">
+				<ActionButton @click.prevent.stop="toggleEnabled" class="list-item__button">
 					<template #icon>
 						<CheckboxBlankCircle v-if="calendar.enabled"
 							:title="$t('calendar', 'Disable calendar')"
@@ -509,5 +509,9 @@ export default {
 <style lang="scss" scoped>
 	.app-navigation-entry__counter-wrapper .action-item.sharing .material-design-icon.share {
 		opacity: .3;
+	}
+
+	.list-item__button {
+		opacity: 1 !important;
 	}
 </style>

--- a/src/components/AppNavigation/CalendarList/CalendarListNew.vue
+++ b/src/components/AppNavigation/CalendarList/CalendarListNew.vue
@@ -22,11 +22,10 @@
 <template>
 	<AppNavigationItem class="app-navigation-entry-new-calendar"
 		:class="{'app-navigation-entry-new-calendar--open': isOpen}"
-		:title="$t('calendar', '+ New calendar')"
+		:title="$t('calendar', 'New calendar')"
 		:menu-open.sync="isOpen"
-		menu-icon="icon-add"
 		@click.prevent.stop="toggleDialog">
-		<template #menu-icon>
+		<template #icon>
 			<Plus :size="20" decorative />
 		</template>
 		<template slot="actions">


### PR DESCRIPTION
| Before | After |
|---|---|
| ![image](https://user-images.githubusercontent.com/42591237/174410666-29f6110b-3a65-4bab-acb8-7a80b3fd8314.png) | ![image](https://user-images.githubusercontent.com/42591237/174410529-9e998b73-8c89-4b38-98fe-3315fcf00b3e.png) |

Signed-off-by: szaimen <szaimen@e.mail.de>

<details>
<summary>For my own testing</summary>

```
docker run -it \
-e CALENDAR_BRANCH=enh/noid/list-item-color \
-p 8443:443 \
-e TRUSTED_DOMAIN=192.168.146.130 \
--name nextcloud-easy-test \
ghcr.io/szaimen/nextcloud-easy-test:latest
```

</details>