### PR TITLE
Fix regression caused by #4296

### DIFF
--- a/css/fullcalendar.scss
+++ b/css/fullcalendar.scss
@@ -237,6 +237,10 @@
 	:not(.fc-timegrid-event-short) > .fc-event-main .fc-event-title-container {
 		width: 100%;
 	}
+
+	.fc-event-main {
+		flex-wrap: wrap;
+	}
 }
 
 .fc-v-event {
@@ -247,7 +251,7 @@
 	}
 
 	.fc-event-title {
-		white-space: inherit;
+		white-space: initial;
 	}
 }
 

--- a/src/components/EventRender.vue
+++ b/src/components/EventRender.vue
@@ -95,7 +95,6 @@ export default {
 <style lang="scss" scoped>
 .fc-event-main-frame {
 	display: flex;
-	flex-wrap: wrap;
 	width: 100%;
 
 	.fc-daygrid-event-dot {


### PR DESCRIPTION
This brings back https://github.com/nextcloud/calendar/pull/3814 while maintaining the fix from #4296.

This does not need to be backported because #4296 wasn't backported.

## Before 
![image](https://user-images.githubusercontent.com/1479486/174832820-37361171-eae4-4846-9867-041eb59e2cb5.png)

## After
![image](https://user-images.githubusercontent.com/1479486/174832707-d0a0a4e2-0cba-4def-8a5a-e83306642c4f.png) | 