### PR TITLE
Hide calendar delete button if ACL is missing

### DIFF
--- a/src/components/AppNavigation/CalendarList/CalendarListItem.vue
+++ b/src/components/AppNavigation/CalendarList/CalendarListItem.vue
@@ -111,14 +111,14 @@
 				</template>
 				{{ $t('calendar', 'Export') }}
 			</ActionLink>
-			<ActionButton v-if="calendar.isSharedWithMe"
+			<ActionButton v-if="calendar.isSharedWithMe && canBeDeleted"
 				@click.prevent.stop="deleteCalendar">
 				<template #icon>
 					<Close :size="20" decorative />
 				</template>
 				{{ $t('calendar', 'Unshare from me') }}
 			</ActionButton>
-			<ActionButton v-if="!calendar.isSharedWithMe"
+			<ActionButton v-if="!calendar.isSharedWithMe && canBeDeleted"
 				@click.prevent.stop="deleteCalendar">
 				<template #icon>
 					<Delete :size="20" decorative />
@@ -326,6 +326,15 @@ export default {
 			}
 
 			return ''
+		},
+
+		/**
+		 * Whether the calendar can be deleted or unshared
+		 *
+		 * @return {boolean}
+		 */
+		canBeDeleted() {
+			return this.calendar.dav.currentUserPrivilegeSet.some(acl => acl === '{DAV:}unbind')
 		},
 	},
 	methods: {


### PR DESCRIPTION
Deleting/unsharing a calendar which was shared to a group fails because the backend doesn't allow it. My PR hides the button entirely if the corresponding ACL is missing.

| Before | After |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/1479486/176186487-1413ce57-1625-4e23-b7c9-c203ea469ede.png) | ![image](https://user-images.githubusercontent.com/1479486/176186388-fa9a5e29-7df9-42da-bf06-db52ca9aa4c4.png) |
