### PR TITLE
[stable3.5] Fix contrast issue with share icon

### DIFF
--- a/src/components/AppNavigation/CalendarList/CalendarListItem.vue
+++ b/src/components/AppNavigation/CalendarList/CalendarListItem.vue
@@ -517,6 +517,6 @@ export default {
 
 <style lang="scss" scoped>
 	.app-navigation-entry__counter-wrapper .action-item.sharing .material-design-icon.share {
-		opacity: .3;
+		opacity: .7;
 	}
 </style>


### PR DESCRIPTION
Before | After
-|-
![icon opacity before](https://user-images.githubusercontent.com/925062/179729334-33c90b56-7d23-4a39-a53f-49b965a1fb52.png)|![icon opacity after](https://user-images.githubusercontent.com/925062/179729331-c346130f-ece0-49e3-8b5f-0f33e65f0b6d.png)

Please review @raimund-schluessler @JuliaKirschenheuter @nimishavijay :)

Resulting color & contrast:
![image](https://user-images.githubusercontent.com/925062/179729619-05ef2201-cbfa-4efc-acb2-acbb919dd383.png)
