### PR TITLE
Hide e-mail controls in calendar when e-mail sending is disabled

### DIFF
--- a/lib/Controller/PublicViewController.php
+++ b/lib/Controller/PublicViewController.php
@@ -6,6 +6,7 @@ declare(strict_types=1);
  *
  * @author Georg Ehrke
  * @copyright 2019 Georg Ehrke <oc.list@georgehrke.com>
+ * @copyright Copyright (c) 2022 Informatyka Boguslawski sp. z o.o. sp.k., http://www.ib.pl/
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU AFFERO GENERAL PUBLIC LICENSE
@@ -128,6 +129,7 @@ class PublicViewController extends Controller {
 		$defaultSlotDuration = $this->config->getAppValue($this->appName, 'slotDuration', '00:30:00');
 		$defaultDefaultReminder = $this->config->getAppValue($this->appName, 'defaultReminder', 'none');
 		$defaultShowTasks = $this->config->getAppValue($this->appName, 'showTasks', 'yes');
+		$defaultSendInvitations = $this->config->getAppValue('dav', 'sendInvitations', 'yes');
 
 		$appVersion = $this->config->getAppValue($this->appName, 'installed_version', null);
 
@@ -146,6 +148,7 @@ class PublicViewController extends Controller {
 		$this->initialStateService->provideInitialState($this->appName, 'show_tasks', $defaultShowTasks === 'yes');
 		$this->initialStateService->provideInitialState($this->appName, 'tasks_enabled', false);
 		$this->initialStateService->provideInitialState($this->appName, 'hide_event_export', false);
+		$this->initialStateService->provideInitialState($this->appName, 'send_invitations', $defaultSendInvitations);
 
 		return new TemplateResponse($this->appName, 'main', [
 			'share_url' => $this->getShareURL(),

--- a/lib/Controller/ViewController.php
+++ b/lib/Controller/ViewController.php
@@ -6,6 +6,7 @@ declare(strict_types=1);
  *
  * @author Georg Ehrke
  * @copyright 2019 Georg Ehrke <oc.list@georgehrke.com>
+ * @copyright Copyright (c) 2022 Informatyka Boguslawski sp. z o.o. sp.k., http://www.ib.pl/
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU AFFERO GENERAL PUBLIC LICENSE
@@ -100,6 +101,7 @@ class ViewController extends Controller {
 		if (!in_array($forceEventAlarmType, ['DISPLAY', 'EMAIL'], true)) {
 			$forceEventAlarmType = false;
 		}
+		$sendInvitations = $this->config->getAppValue('dav', 'sendInvitations', 'yes') === 'yes';
 
 		$talkEnabled = $this->appManager->isEnabledForUser('spreed');
 		$talkApiVersion = version_compare($this->appManager->getAppVersion('spreed'), '12.0.0', '>=') ? 'v4' : 'v1';
@@ -121,6 +123,7 @@ class ViewController extends Controller {
 		$this->initialStateService->provideInitialState('tasks_enabled', $tasksEnabled);
 		$this->initialStateService->provideInitialState('hide_event_export', $hideEventExport);
 		$this->initialStateService->provideInitialState('force_event_alarm_type', $forceEventAlarmType);
+		$this->initialStateService->provideInitialState('send_invitations', $sendInvitations);
 		$this->initialStateService->provideInitialState('appointmentConfigs', $this->appointmentConfigService->getAllAppointmentConfigurations($this->userId));
 		$this->initialStateService->provideInitialState('disable_appointments', $disableAppointments);
 

--- a/src/components/Editor/AvatarParticipationStatus.vue
+++ b/src/components/Editor/AvatarParticipationStatus.vue
@@ -1,5 +1,6 @@
 <!--
   - @copyright Copyright (c) 2019 Georg Ehrke <oc.list@georgehrke.com>
+  - @copyright Copyright (c) 2022 Informatyka Boguslawski sp. z o.o. sp.k., http://www.ib.pl/
   -
   - @author Georg Ehrke <oc.list@georgehrke.com>
   -
@@ -145,18 +146,11 @@ export default {
 				}
 			}
 
-			if (this.isViewedByOrganizer) {
-				return {
-					indicatorClass: ['no-response', 'icon', 'icon-invitees-no-response-white'],
-					label: t('calendar', 'Invitation sent'),
-				}
-			} else {
-				return {
-					indicatorClass: ['no-response', 'icon', 'icon-invitees-no-response-white'],
-					label: t('calendar', 'Has not responded to {organizerName}\'s invitation yet', {
-						organizerName: this.organizerDisplayName,
-					}),
-				}
+			return {
+				indicatorClass: ['no-response', 'icon', 'icon-invitees-no-response-white'],
+				label: t('calendar', 'Has not responded to {organizerName}\'s invitation yet', {
+					organizerName: this.organizerDisplayName,
+				}),
 			}
 		},
 	},

--- a/src/components/Editor/Invitees/InviteesListItem.vue
+++ b/src/components/Editor/Invitees/InviteesListItem.vue
@@ -1,5 +1,6 @@
 <!--
   - @copyright Copyright (c) 2019 Georg Ehrke <oc.list@georgehrke.com>
+  - @copyright Copyright (c) 2022 Informatyka Boguslawski sp. z o.o. sp.k., http://www.ib.pl/
   -
   - @author Georg Ehrke <oc.list@georgehrke.com>
   - @author Richard Steinmetz <richard@steinmetz.cloud>
@@ -35,7 +36,7 @@
 		</div>
 		<div class="invitees-list-item__actions">
 			<Actions v-if="isViewedByOrganizer">
-				<ActionCheckbox :checked="attendee.rsvp"
+				<ActionCheckbox v-show="sendInvitations" :checked="attendee.rsvp"
 					@change="toggleRSVP">
 					{{ $t('calendar', 'Send email') }}
 				</ActionCheckbox>
@@ -73,6 +74,7 @@
 </template>
 
 <script>
+import { mapState } from 'vuex'
 import AvatarParticipationStatus from '../AvatarParticipationStatus'
 import Actions from '@nextcloud/vue/dist/Components/Actions'
 import ActionButton from '@nextcloud/vue/dist/Components/ActionButton'
@@ -107,6 +109,9 @@ export default {
 		},
 	},
 	computed: {
+		...mapState({
+			sendInvitations: state => state.settings.sendInvitations,
+		}),
 		/**
 		 * @return {string}
 		 */

--- a/src/components/Editor/Invitees/InviteesListItem.vue
+++ b/src/components/Editor/Invitees/InviteesListItem.vue
@@ -36,7 +36,8 @@
 		</div>
 		<div class="invitees-list-item__actions">
 			<Actions v-if="isViewedByOrganizer">
-				<ActionCheckbox v-show="sendInvitations" :checked="attendee.rsvp"
+				<ActionCheckbox v-show="sendInvitations"
+					:checked="attendee.rsvp"
 					@change="toggleRSVP">
 					{{ $t('calendar', 'Send email') }}
 				</ActionCheckbox>

--- a/src/store/settings.js
+++ b/src/store/settings.js
@@ -1,5 +1,6 @@
 /**
  * @copyright Copyright (c) 2020 Georg Ehrke
+ * @copyright Copyright (c) 2022 Informatyka Boguslawski sp. z o.o. sp.k., http://www.ib.pl/
  *
  * @author Georg Ehrke <oc.list@georgehrke.com>
  *
@@ -45,6 +46,7 @@ const state = {
 	timezone: 'automatic',
 	hideEventExport: false,
 	forceEventAlarmType: false,
+	sendInvitations: true,
 	// user-defined Nextcloud settings
 	momentLocale: 'en',
 }
@@ -149,8 +151,9 @@ const mutations = {
 	 * @param {boolean} data.hideEventExport
 	 * @param {string} data.forceEventAlarmType
 	 * @param {boolean} data.disableAppointments Allow to disable the appointments feature
+	 * @param {boolean} data.sendInvitations
 	 */
-	loadSettingsFromServer(state, { appVersion, eventLimit, firstRun, showWeekNumbers, showTasks, showWeekends, skipPopover, slotDuration, defaultReminder, talkEnabled, tasksEnabled, timezone, hideEventExport, forceEventAlarmType, disableAppointments }) {
+	loadSettingsFromServer(state, { appVersion, eventLimit, firstRun, showWeekNumbers, showTasks, showWeekends, skipPopover, slotDuration, defaultReminder, talkEnabled, tasksEnabled, timezone, hideEventExport, forceEventAlarmType, disableAppointments, sendInvitations }) {
 		logInfo(`
 Initial settings:
 	- AppVersion: ${appVersion}
@@ -168,6 +171,7 @@ Initial settings:
 	- HideEventExport: ${hideEventExport}
 	- ForceEventAlarmType: ${forceEventAlarmType}
 	- disableAppointments: ${disableAppointments}
+	- SendInvitations: ${sendInvitations}
 `)
 
 		state.appVersion = appVersion
@@ -185,6 +189,7 @@ Initial settings:
 		state.hideEventExport = hideEventExport
 		state.forceEventAlarmType = forceEventAlarmType
 		state.disableAppointments = disableAppointments
+		state.sendInvitations = sendInvitations
 	},
 
 	/**

--- a/src/views/Calendar.vue
+++ b/src/views/Calendar.vue
@@ -1,5 +1,6 @@
 <!--
   - @copyright Copyright (c) 2020 Georg Ehrke <oc.list@georgehrke.com>
+  - @copyright Copyright (c) 2022 Informatyka Boguslawski sp. z o.o. sp.k., http://www.ib.pl/
   - @author Georg Ehrke <oc.list@georgehrke.com>
   -
   - @license GNU AGPL version 3 or any later version
@@ -218,6 +219,7 @@ export default {
 			hideEventExport: loadState('calendar', 'hide_event_export'),
 			forceEventAlarmType: loadState('calendar', 'force_event_alarm_type', false),
 			disableAppointments: loadState('calendar', 'disable_appointments', false),
+			sendInvitations: loadState('calendar', 'send_invitations'),
 		})
 		this.$store.dispatch('initializeCalendarJsConfig')
 

--- a/tests/javascript/unit/store/settings.test.js
+++ b/tests/javascript/unit/store/settings.test.js
@@ -1,5 +1,6 @@
 /**
  * @copyright Copyright (c) 2019 Georg Ehrke
+ * @copyright Copyright (c) 2022 Informatyka Boguslawski sp. z o.o. sp.k., http://www.ib.pl/
  *
  * @author Georg Ehrke <oc.list@georgehrke.com>
  *
@@ -63,6 +64,7 @@ describe('store/settings test suite', () => {
 			timezone: 'automatic',
 			momentLocale: 'en',
 			disableAppointments: false,
+			sendInvitations: true,
 		})
 	})
 
@@ -172,6 +174,7 @@ describe('store/settings test suite', () => {
 			hideEventExport: false,
 			forceEventAlarmType: false,
 			disableAppointments: false,
+			sendInvitations: true,
 		}
 
 		const settings = {
@@ -191,6 +194,7 @@ describe('store/settings test suite', () => {
 			hideEventExport: false,
 			forceEventAlarmType: false,
 			disableAppointments: false,
+			sendInvitations: true,
 		}
 
 		settingsStore.mutations.loadSettingsFromServer(state, settings)
@@ -213,6 +217,7 @@ Initial settings:
 	- HideEventExport: false
 	- ForceEventAlarmType: false
 	- disableAppointments: false
+	- SendInvitations: true
 `)
 		expect(state).toEqual({
 			appVersion: '2.1.0',
@@ -232,6 +237,7 @@ Initial settings:
 			hideEventExport: false,
 			forceEventAlarmType: false,
 			disableAppointments: false,
+			sendInvitations: true,
 		})
 	})
 

--- a/tests/php/unit/Controller/PublicViewControllerTest.php
+++ b/tests/php/unit/Controller/PublicViewControllerTest.php
@@ -64,7 +64,7 @@ class PublicViewControllerTest extends TestCase {
 	}
 
 	public function testPublicIndexWithBranding():void {
-		$this->config->expects(self::exactly(10))
+		$this->config->expects(self::exactly(11))
 			->method('getAppValue')
 			->willReturnMap([
 				['calendar', 'eventLimit', 'yes', 'no'],

--- a/tests/php/unit/Controller/ViewControllerTest.php
+++ b/tests/php/unit/Controller/ViewControllerTest.php
@@ -7,6 +7,7 @@ declare(strict_types=1);
  *
  * @author Georg Ehrke
  * @copyright 2019 Georg Ehrke <oc.list@georgehrke.com>
+ * @copyright Copyright (c) 2022 Informatyka Boguslawski sp. z o.o. sp.k., http://www.ib.pl/
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU AFFERO GENERAL PUBLIC LICENSE
@@ -147,6 +148,7 @@ class ViewControllerTest extends TestCase {
 				['tasks_enabled', true],
 				['hide_event_export', true],
 				['force_event_alarm_type', null],
+				['send_invitations', true],
 				['appointmentConfigs', [new AppointmentConfig()]],
 			);
 

--- a/tests/php/unit/Controller/ViewControllerTest.php
+++ b/tests/php/unit/Controller/ViewControllerTest.php
@@ -97,6 +97,7 @@ class ViewControllerTest extends TestCase {
 				['calendar', 'showTasks', 'yes', 'defaultShowTasks'],
 				['calendar', 'hideEventExport', 'no', 'yes'],
 				['calendar', 'forceEventAlarmType', '', ''],
+				['calendar', 'sendInvitations', 'yes', 'defaultSendInvitations'],
 				['calendar', 'installed_version', null, '1.0.0'],
 			]);
 		$this->config
@@ -148,7 +149,7 @@ class ViewControllerTest extends TestCase {
 				['tasks_enabled', true],
 				['hide_event_export', true],
 				['force_event_alarm_type', null],
-				['send_invitations', true],
+				['send_invitations', false],
 				['appointmentConfigs', [new AppointmentConfig()]],
 			);
 


### PR DESCRIPTION
This mod hides `Send email` checkbox from attendee context menu if
`dav.sendInvitations` is disabled. It also replaces misleading status
message about invitations already sent when adding attendee to event.

Author-Change-Id: IB#1121918
Signed-off-by: Pawel Boguslawski <pawel.boguslawski@ib.pl>