### PR TITLE
Added option to remove Resources tab

### DIFF
--- a/lib/Controller/PublicViewController.php
+++ b/lib/Controller/PublicViewController.php
@@ -6,6 +6,7 @@ declare(strict_types=1);
  *
  * @author Georg Ehrke
  * @copyright 2019 Georg Ehrke <oc.list@georgehrke.com>
+ * @copyright Copyright (c) 2022 Informatyka Boguslawski sp. z o.o. sp.k., http://www.ib.pl/
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU AFFERO GENERAL PUBLIC LICENSE
@@ -128,6 +129,7 @@ class PublicViewController extends Controller {
 		$defaultSlotDuration = $this->config->getAppValue($this->appName, 'slotDuration', '00:30:00');
 		$defaultDefaultReminder = $this->config->getAppValue($this->appName, 'defaultReminder', 'none');
 		$defaultShowTasks = $this->config->getAppValue($this->appName, 'showTasks', 'yes');
+		$defaultShowResources = $this->config->getAppValue($this->appName, 'showResources', 'yes');
 
 		$appVersion = $this->config->getAppValue($this->appName, 'installed_version', null);
 
@@ -146,6 +148,7 @@ class PublicViewController extends Controller {
 		$this->initialStateService->provideInitialState($this->appName, 'show_tasks', $defaultShowTasks === 'yes');
 		$this->initialStateService->provideInitialState($this->appName, 'tasks_enabled', false);
 		$this->initialStateService->provideInitialState($this->appName, 'hide_event_export', false);
+		$this->initialStateService->provideInitialState($this->appName, 'show_resources', false);
 
 		return new TemplateResponse($this->appName, 'main', [
 			'share_url' => $this->getShareURL(),

--- a/lib/Controller/ViewController.php
+++ b/lib/Controller/ViewController.php
@@ -6,6 +6,7 @@ declare(strict_types=1);
  *
  * @author Georg Ehrke
  * @copyright 2019 Georg Ehrke <oc.list@georgehrke.com>
+ * @copyright Copyright (c) 2022 Informatyka Boguslawski sp. z o.o. sp.k., http://www.ib.pl/
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU AFFERO GENERAL PUBLIC LICENSE
@@ -100,6 +101,7 @@ class ViewController extends Controller {
 		if (!in_array($forceEventAlarmType, ['DISPLAY', 'EMAIL'], true)) {
 			$forceEventAlarmType = false;
 		}
+		$showResources = $this->config->getAppValue($this->appName, 'showResources', 'yes') === 'yes';
 
 		$talkEnabled = $this->appManager->isEnabledForUser('spreed');
 		$talkApiVersion = version_compare($this->appManager->getAppVersion('spreed'), '12.0.0', '>=') ? 'v4' : 'v1';
@@ -121,6 +123,7 @@ class ViewController extends Controller {
 		$this->initialStateService->provideInitialState('tasks_enabled', $tasksEnabled);
 		$this->initialStateService->provideInitialState('hide_event_export', $hideEventExport);
 		$this->initialStateService->provideInitialState('force_event_alarm_type', $forceEventAlarmType);
+		$this->initialStateService->provideInitialState('show_resources', $showResources);
 		$this->initialStateService->provideInitialState('appointmentConfigs', $this->appointmentConfigService->getAllAppointmentConfigurations($this->userId));
 		$this->initialStateService->provideInitialState('disable_appointments', $disableAppointments);
 

--- a/src/store/settings.js
+++ b/src/store/settings.js
@@ -1,5 +1,6 @@
 /**
  * @copyright Copyright (c) 2020 Georg Ehrke
+ * @copyright Copyright (c) 2022 Informatyka Boguslawski sp. z o.o. sp.k., http://www.ib.pl/
  *
  * @author Georg Ehrke <oc.list@georgehrke.com>
  *
@@ -45,6 +46,7 @@ const state = {
 	timezone: 'automatic',
 	hideEventExport: false,
 	forceEventAlarmType: false,
+	showResources: true,
 	// user-defined Nextcloud settings
 	momentLocale: 'en',
 }
@@ -149,8 +151,9 @@ const mutations = {
 	 * @param {boolean} data.hideEventExport
 	 * @param {string} data.forceEventAlarmType
 	 * @param {boolean} data.disableAppointments Allow to disable the appointments feature
+	 * @param {boolean} data.showResources
 	 */
-	loadSettingsFromServer(state, { appVersion, eventLimit, firstRun, showWeekNumbers, showTasks, showWeekends, skipPopover, slotDuration, defaultReminder, talkEnabled, tasksEnabled, timezone, hideEventExport, forceEventAlarmType, disableAppointments }) {
+	loadSettingsFromServer(state, { appVersion, eventLimit, firstRun, showWeekNumbers, showTasks, showWeekends, skipPopover, slotDuration, defaultReminder, talkEnabled, tasksEnabled, timezone, hideEventExport, forceEventAlarmType, disableAppointments, showResources }) {
 		logInfo(`
 Initial settings:
 	- AppVersion: ${appVersion}
@@ -168,6 +171,7 @@ Initial settings:
 	- HideEventExport: ${hideEventExport}
 	- ForceEventAlarmType: ${forceEventAlarmType}
 	- disableAppointments: ${disableAppointments}
+	- ShowResources: ${showResources}
 `)
 
 		state.appVersion = appVersion
@@ -185,6 +189,7 @@ Initial settings:
 		state.hideEventExport = hideEventExport
 		state.forceEventAlarmType = forceEventAlarmType
 		state.disableAppointments = disableAppointments
+		state.showResources = showResources
 	},
 
 	/**

--- a/src/views/Calendar.vue
+++ b/src/views/Calendar.vue
@@ -1,5 +1,6 @@
 <!--
   - @copyright Copyright (c) 2020 Georg Ehrke <oc.list@georgehrke.com>
+  - @copyright Copyright (c) 2022 Informatyka Boguslawski sp. z o.o. sp.k., http://www.ib.pl/
   - @author Georg Ehrke <oc.list@georgehrke.com>
   -
   - @license GNU AGPL version 3 or any later version
@@ -218,6 +219,7 @@ export default {
 			hideEventExport: loadState('calendar', 'hide_event_export'),
 			forceEventAlarmType: loadState('calendar', 'force_event_alarm_type', false),
 			disableAppointments: loadState('calendar', 'disable_appointments', false),
+			showResources: loadState('calendar', 'show_resources'),
 		})
 		this.$store.dispatch('initializeCalendarJsConfig')
 

--- a/src/views/EditSidebar.vue
+++ b/src/views/EditSidebar.vue
@@ -1,6 +1,7 @@
 <!--
   - @copyright Copyright (c) 2019 Georg Ehrke <oc.list@georgehrke.com>
   - @copyright Copyright (c) 2019 Jakob Röhrl <jakob.roehrl@web.de>
+  - @copyright Copyright (c) 2022 Informatyka Boguslawski sp. z o.o. sp.k., http://www.ib.pl/
   -
   - @author Georg Ehrke <oc.list@georgehrke.com>
   - @author Jakob Röhrl <jakob.roehrl@web.de>
@@ -204,7 +205,7 @@
 				@save-this-only="saveAndLeave(false)"
 				@save-this-and-all-future="saveAndLeave(true)" />
 		</AppSidebarTab>
-		<AppSidebarTab v-if="!isLoading && !isError"
+		<AppSidebarTab v-if="!isLoading && !isError && showResources"
 			id="app-sidebar-tab-resources"
 			class="app-sidebar-tab"
 			:name="$t('calendar', 'Resources')"
@@ -298,6 +299,7 @@ export default {
 		...mapState({
 			locale: (state) => state.settings.momentLocale,
 			hideEventExport: (state) => state.settings.hideEventExport,
+			showResources: (state) => state.settings.showResources,
 		}),
 		accessClass() {
 			return this.calendarObjectInstance?.accessClass || null

--- a/tests/javascript/unit/store/settings.test.js
+++ b/tests/javascript/unit/store/settings.test.js
@@ -1,5 +1,6 @@
 /**
  * @copyright Copyright (c) 2019 Georg Ehrke
+ * @copyright Copyright (c) 2022 Informatyka Boguslawski sp. z o.o. sp.k., http://www.ib.pl/
  *
  * @author Georg Ehrke <oc.list@georgehrke.com>
  *
@@ -63,6 +64,7 @@ describe('store/settings test suite', () => {
 			timezone: 'automatic',
 			momentLocale: 'en',
 			disableAppointments: false,
+			enableResources: true,
 		})
 	})
 
@@ -172,6 +174,7 @@ describe('store/settings test suite', () => {
 			hideEventExport: false,
 			forceEventAlarmType: false,
 			disableAppointments: false,
+			enableResources: true,
 		}
 
 		const settings = {
@@ -191,6 +194,7 @@ describe('store/settings test suite', () => {
 			hideEventExport: false,
 			forceEventAlarmType: false,
 			disableAppointments: false,
+			enableResources: true,
 		}
 
 		settingsStore.mutations.loadSettingsFromServer(state, settings)
@@ -213,6 +217,7 @@ Initial settings:
 	- HideEventExport: false
 	- ForceEventAlarmType: false
 	- disableAppointments: false
+	- ShowResources: true
 `)
 		expect(state).toEqual({
 			appVersion: '2.1.0',
@@ -232,6 +237,7 @@ Initial settings:
 			hideEventExport: false,
 			forceEventAlarmType: false,
 			disableAppointments: false,
+			showResources: true,
 		})
 	})
 

--- a/tests/php/unit/Controller/PublicViewControllerTest.php
+++ b/tests/php/unit/Controller/PublicViewControllerTest.php
@@ -6,6 +6,7 @@ declare(strict_types=1);
  *
  * @author Georg Ehrke
  * @copyright 2019 Georg Ehrke <oc.list@georgehrke.com>
+ * @copyright Copyright (c) 2022 Informatyka Boguslawski sp. z o.o. sp.k., http://www.ib.pl/
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU AFFERO GENERAL PUBLIC LICENSE
@@ -64,7 +65,7 @@ class PublicViewControllerTest extends TestCase {
 	}
 
 	public function testPublicIndexWithBranding():void {
-		$this->config->expects(self::exactly(10))
+		$this->config->expects(self::exactly(11))
 			->method('getAppValue')
 			->willReturnMap([
 				['calendar', 'eventLimit', 'yes', 'no'],

--- a/tests/php/unit/Controller/ViewControllerTest.php
+++ b/tests/php/unit/Controller/ViewControllerTest.php
@@ -7,6 +7,7 @@ declare(strict_types=1);
  *
  * @author Georg Ehrke
  * @copyright 2019 Georg Ehrke <oc.list@georgehrke.com>
+ * @copyright Copyright (c) 2022 Informatyka Boguslawski sp. z o.o. sp.k., http://www.ib.pl/
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU AFFERO GENERAL PUBLIC LICENSE
@@ -96,6 +97,7 @@ class ViewControllerTest extends TestCase {
 				['calendar', 'showTasks', 'yes', 'defaultShowTasks'],
 				['calendar', 'hideEventExport', 'no', 'yes'],
 				['calendar', 'forceEventAlarmType', '', ''],
+				['calendar', 'showResources', 'yes', 'defaultShowResources'],
 				['calendar', 'installed_version', null, '1.0.0'],
 			]);
 		$this->config
@@ -147,6 +149,7 @@ class ViewControllerTest extends TestCase {
 				['tasks_enabled', true],
 				['hide_event_export', true],
 				['force_event_alarm_type', null],
+				['show_resources', true],
 				['appointmentConfigs', [new AppointmentConfig()]],
 			);
 


### PR DESCRIPTION
This mod allows one to remove `Resources` tab from event sidebar editor using
new app parameter `calendar.showResources` (i.e. when resources feature should
not be used there). By default `Resources` tab is displayed; when
`calendar.showResources` is set to `no`, tab is not rendered.

Author-Change-Id: IB#1122150
Signed-off-by: Pawel Boguslawski <pawel.boguslawski@ib.pl>