### PR TITLE
Fix missing events in week view

### DIFF
--- a/src/components/CalendarGrid.vue
+++ b/src/components/CalendarGrid.vue
@@ -130,7 +130,8 @@ export default {
 				dayHeaderDidMount,
 				eventDidMount,
 				noEventsDidMount,
-				eventOrder: ['start', '-duration', 'allDay', eventOrder],
+				// FIXME: remove title if upstream is fixed (https://github.com/fullcalendar/fullcalendar/issues/6608#issuecomment-954241059)
+				eventOrder: ['title', 'start', '-duration', 'allDay', eventOrder],
 				forceEventDuration: false,
 				headerToolbar: false,
 				height: '100%',

--- a/src/fullcalendar/rendering/eventOrder.js
+++ b/src/fullcalendar/rendering/eventOrder.js
@@ -41,9 +41,11 @@ export default function(firstEvent, secondEvent) {
 		return (firstEvent.extendedProps.calendarId < secondEvent.extendedProps.calendarId) ? -1 : 1
 	}
 
+	/* FIXME: uncomment this if upstream is fixed (https://github.com/fullcalendar/fullcalendar/issues/6608#issuecomment-954241059)
 	if (firstEvent.title !== secondEvent.title) {
 		return (firstEvent.title < secondEvent.title) ? -1 : 1
 	}
+	 */
 
 	return 0
 }

--- a/tests/javascript/unit/fullcalendar/rendering/eventOrder.test.js
+++ b/tests/javascript/unit/fullcalendar/rendering/eventOrder.test.js
@@ -19,7 +19,7 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  *
  */
-import eventOrder from "../../../../../src/fullcalendar/rendering/eventOrder.js";
+import eventOrder from '../../../../../src/fullcalendar/rendering/eventOrder.js'
 
 describe('fullcalendar/eventOrder test suite', () => {
 
@@ -107,8 +107,10 @@ describe('fullcalendar/eventOrder test suite', () => {
 			title: 'Title 456',
 		}
 
+		/* FIXME: uncomment if upstream is fixed (https://github.com/fullcalendar/fullcalendar/issues/6608#issuecomment-954241059)
 		expect(eventOrder(firstEvent, secondEvent)).toEqual(-1)
 		expect(eventOrder(secondEvent, firstEvent)).toEqual(1)
+		 */
 	})
 
 	it('should return zero if all properties are equal', () => {


### PR DESCRIPTION
If there are too many events on the last day of a week (e.g. Sunday), some might be hidden when the "limit events per view" checkbox is checked. 

There already is an ongoing upstream ticket at https://github.com/fullcalendar/fullcalendar/issues/6608. The bug is not yet solved by the FC maintainers but there is a (dirty) quick fix available (ref https://github.com/fullcalendar/fullcalendar/issues/6608#issuecomment-954241059). Unfortunately, this fix introduces some visual regressions because it changes the ordering of events inside the view. Take a look at my screenshots below (basically events are primarily ordered by title now). If there is a proper solution/fix for the ticket we may revert our changes.

In my opinion, missing events are more severe than having a slightly different event order so I strongly recommend moving on with this.

Thanks to @miaulalala for helping me debug this and finding the mentioned issue.

## Before
![Screenshot_20220819_122902](https://user-images.githubusercontent.com/1479486/185599881-8a9b168f-5808-4c31-bdf3-0bb4adf70577.png)

## After
![Screenshot_20220819_122809](https://user-images.githubusercontent.com/1479486/185599824-f568ac04-f20e-4cd9-bd86-8dd3cfb2b09e.png)

# Visual regressions

## Before

![Screenshot_20220819_122831](https://user-images.githubusercontent.com/1479486/185600013-1521dcfb-072b-4c32-8ff5-d5b539d96eb7.png)

## After

![Screenshot_20220819_122749](https://user-images.githubusercontent.com/1479486/185600020-568ad2e2-745d-4ea5-aa88-1ba3e29a7dd4.png)