### PR TITLE
Drop Nextcloud 22-24 support

### DIFF
--- a/.github/workflows/php-test.yml
+++ b/.github/workflows/php-test.yml
@@ -12,14 +12,12 @@ jobs:
     strategy:
       matrix:
         php-versions: ['7.4']
-        nextcloud-versions: ['stable22', 'stable23']
+        nextcloud-versions: ['master']
         include:
-          - php-versions: '7.4'
-            nextcloud-versions: 'stable24'
           - php-versions: '8.0'
-            nextcloud-versions: 'stable24'
+            nextcloud-versions: 'master'
           - php-versions: '8.1'
-            nextcloud-versions: 'stable24'
+            nextcloud-versions: 'master'
           - php-versions: '7.4'
             nextcloud-versions: 'master'
           - php-versions: '8.0'

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -33,7 +33,7 @@
 	<screenshot>https://raw.githubusercontent.com/nextcloud/calendar/main/screenshots/week_sidebar.png</screenshot>
 	<dependencies>
 		<php min-version="7.4" max-version="8.1" />
-		<nextcloud min-version="22" max-version="25" />
+		<nextcloud min-version="25" max-version="25" />
 	</dependencies>
 	<background-jobs>
 		<job>OCA\Calendar\BackgroundJob\CleanUpOutdatedBookingsJob</job>

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -15,7 +15,7 @@
 * ☑️ Tasks! See tasks with a due date directly in the calendar
 * 🙈 **We’re not reinventing the wheel!** Based on the great [c-dav library](https://github.com/nextcloud/cdav-library), [ical.js](https://github.com/mozilla-comm/ical.js) and [fullcalendar](https://github.com/fullcalendar/fullcalendar) libraries.
 	]]></description>
-	<version>3.5.0-rc.1</version>
+	<version>4.0.0-alpha.1</version>
 	<licence>agpl</licence>
 	<author>Anna Larch</author>
 	<author homepage="https://github.com/nextcloud/groupware">Nextcloud Groupware Team</author>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "calendar",
-  "version": "3.5.0",
+  "version": "4.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "calendar",
-      "version": "3.5.0",
+      "version": "4.0.0",
       "license": "agpl",
       "dependencies": {
         "@fullcalendar/core": "5.11.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "calendar",
   "description": "A calendar app for Nextcloud. Easily sync events from various devices, share and edit them online.",
-  "version": "3.5.0",
+  "version": "4.0.0",
   "author": "Georg Ehrke <oc.list@georgehrke.com>",
   "contributors": [
     "Georg Ehrke <oc.list@georgehrke.com>",

--- a/src/components/AppNavigation/Settings.vue
+++ b/src/components/AppNavigation/Settings.vue
@@ -95,8 +95,7 @@
 				</template>
 				{{ $t('calendar', 'Copy iOS/macOS CalDAV address') }}
 			</ActionButton>
-			<ActionLink v-if="hasAppointmentsFeature"
-				:href="availabilitySettingsUrl"
+			<ActionLink :href="availabilitySettingsUrl"
 				target="_blank">
 				<template #icon>
 					<OpenInNewIcon :size="20" decorative />
@@ -259,10 +258,6 @@ export default {
 		},
 		selectedDefaultReminderOption() {
 			return this.defaultReminderOptions.find(o => o.value === this.defaultReminder)
-		},
-		hasAppointmentsFeature() {
-			// TODO: Remove me when Calendar doesn't support server < 23
-			return parseInt(OC.config.version.split('.')[0]) >= 23
 		},
 		availabilitySettingsUrl() {
 			return generateUrl('/settings/user/groupware')

--- a/src/components/Editor/Resources/ResourceList.vue
+++ b/src/components/Editor/Resources/ResourceList.vue
@@ -102,10 +102,6 @@ export default {
 				return !['RESOURCE', 'ROOM'].includes(attendee.attendeeProperty.userType)
 			})
 		},
-		hasAdvancedFilters() {
-			// TODO: Remove me when Calendar doesn't support server < 23
-			return parseInt(OC.config.version.split('.')[0]) >= 23
-		},
 		noResourcesMessage() {
 			return this.$t('calendar', 'No rooms or resources yet')
 		},
@@ -154,7 +150,7 @@ export default {
 			})
 		},
 		async loadRoomSuggestions() {
-			if (this.resources.length > 0 || !this.hasAdvancedFilters) {
+			if (this.resources.length > 0) {
 				this.suggestedRooms = []
 				return
 			}

--- a/src/components/Editor/Resources/ResourceListSearch.vue
+++ b/src/components/Editor/Resources/ResourceListSearch.vue
@@ -56,11 +56,10 @@
 			</template>
 		</Multiselect>
 
-		<template v-if="hasAdvancedFilters">
+		<template>
 			<div class="resource-search__capacity">
 				<ResourceSeatingCapacity :value.sync="capacity" />
-				<Actions v-if="hasAdvancedFilters"
-					class="resource-search__capacity__actions">
+				<Actions class="resource-search__capacity__actions">
 					<ActionCheckbox :checked.sync="isAvailable">
 						<!-- Translators room or resource is not yet booked -->
 						{{ $t('calendar', 'Available') }}
@@ -133,10 +132,6 @@ export default {
 		noResult() {
 			return this.$t('calendar', 'No match found')
 		},
-		hasAdvancedFilters() {
-			// TODO: Remove me when Calendar doesn't support server < 23
-			return parseInt(OC.config.version.split('.')[0]) >= 23
-		},
 		features() {
 			const features = []
 			if (this.isAccessible) {
@@ -174,11 +169,9 @@ export default {
 			let results
 			try {
 				const query = { displayName: input }
-				if (this.hasAdvancedFilters) {
-					query.capacity = this.capacity
-					query.features = this.features
-					query.roomType = this.roomType
-				}
+				query.capacity = this.capacity
+				query.features = this.features
+				query.roomType = this.roomType
 				results = await advancedPrincipalPropertySearch(query)
 			} catch (error) {
 				logger.debug('Could not find resources', { error })
@@ -226,17 +219,15 @@ export default {
 				})
 
 			// Check resource availability
-			if (this.hasAdvancedFilters) {
-				await checkResourceAvailability(
-					options,
-					this.$store.getters.getCurrentUserPrincipalEmail,
-					this.calendarObjectInstance.eventComponent.startDate,
-					this.calendarObjectInstance.eventComponent.endDate,
-				)
-			}
+			await checkResourceAvailability(
+				options,
+				this.$store.getters.getCurrentUserPrincipalEmail,
+				this.calendarObjectInstance.eventComponent.startDate,
+				this.calendarObjectInstance.eventComponent.endDate,
+			)
 
 			// Filter by availability
-			if (this.hasAdvancedFilters && this.isAvailable) {
+			if (this.isAvailable) {
 				options = options.filter(option => option.isAvailable)
 			}
 

--- a/src/views/Calendar.vue
+++ b/src/views/Calendar.vue
@@ -34,7 +34,7 @@
 					:disabled="loadingCalendars" />
 
 				<!-- Appointment Configuration List -->
-				<template v-if="hasAppointmentsFeature && isAuthenticatedUser">
+				<template v-if="isAuthenticatedUser">
 					<AppNavigationSpacer />
 					<AppointmentConfigList />
 				</template>
@@ -177,10 +177,6 @@ export default {
 			}
 
 			return null
-		},
-		hasAppointmentsFeature() {
-			// TODO: Remove the end condition when Calendar doesn't support server < 23
-			return !this.disableAppointments && parseInt(OC.config.version.split('.')[0]) >= 23
 		},
 	},
 	created() {


### PR DESCRIPTION
The new UI is only compatible with 25+. So we need to make hard cut unfortunately. We will maintain the `v3.5` line for 24 and older.

Extracted from https://github.com/nextcloud/calendar/pull/4459.

Version checks for older versions removed.