### PR TITLE
Bump @fullcalendar and peers from 5.11.2 to 5.11.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,12 +9,12 @@
       "version": "4.1.0-alpha0",
       "license": "agpl",
       "dependencies": {
-        "@fullcalendar/core": "5.11.2",
-        "@fullcalendar/daygrid": "5.11.2",
-        "@fullcalendar/interaction": "5.11.2",
-        "@fullcalendar/list": "5.11.2",
-        "@fullcalendar/resource-timeline": "5.11.2",
-        "@fullcalendar/timegrid": "5.11.2",
+        "@fullcalendar/core": "5.11.3",
+        "@fullcalendar/daygrid": "5.11.3",
+        "@fullcalendar/interaction": "5.11.3",
+        "@fullcalendar/list": "5.11.3",
+        "@fullcalendar/resource-timeline": "5.11.3",
+        "@fullcalendar/timegrid": "5.11.3",
         "@fullcalendar/vue": "5.11.2",
         "@nextcloud/auth": "^2.0.0",
         "@nextcloud/axios": "^2.1.0",
@@ -1979,39 +1979,39 @@
       }
     },
     "node_modules/@fullcalendar/core": {
-      "version": "5.11.2",
-      "resolved": "https://registry.npmjs.org/@fullcalendar/core/-/core-5.11.2.tgz",
-      "integrity": "sha512-+lO4EWqssONDWF1NO+tiW8KYqKj+MluLAnnRhIKlnFfvNJXEoondWKR6q3jF9Yxe/VmbVFKPq9z6auIxc7zr3A==",
+      "version": "5.11.3",
+      "resolved": "https://registry.npmjs.org/@fullcalendar/core/-/core-5.11.3.tgz",
+      "integrity": "sha512-YUFxCvVJytUwFeXCx4J17kFMM7Ixwn9zBjVRw5NM2bMwgR6VAhSnlZc6yNQSOIy7Hj2TF0vDkO/4JNlTvxyAXw==",
       "dependencies": {
-        "@fullcalendar/common": "~5.11.2",
+        "@fullcalendar/common": "~5.11.3",
         "preact": "^10.0.5",
         "tslib": "^2.1.0"
       }
     },
     "node_modules/@fullcalendar/daygrid": {
-      "version": "5.11.2",
-      "resolved": "https://registry.npmjs.org/@fullcalendar/daygrid/-/daygrid-5.11.2.tgz",
-      "integrity": "sha512-WmR8EAOR8Y9wyxlCK2gBW6lG/dPSN37eM8L7vgc7YgrQE1knL7ISgaUnDfFUNBFztmLakO/ZpeQQFpz3pnJwXg==",
+      "version": "5.11.3",
+      "resolved": "https://registry.npmjs.org/@fullcalendar/daygrid/-/daygrid-5.11.3.tgz",
+      "integrity": "sha512-PCK0y80DRNCzWuC5lGpIWqCgKDvql1ah7rXql5lu+Gn2EeFj15ZQ8diMFjtNIQucEmFaNOXnR05Pgcry1n6Shg==",
       "dependencies": {
-        "@fullcalendar/common": "~5.11.2",
+        "@fullcalendar/common": "~5.11.3",
         "tslib": "^2.1.0"
       }
     },
     "node_modules/@fullcalendar/interaction": {
-      "version": "5.11.2",
-      "resolved": "https://registry.npmjs.org/@fullcalendar/interaction/-/interaction-5.11.2.tgz",
-      "integrity": "sha512-PlUXP9pW62tLgp2DttLC2f8IX5yeRLRboY/knnRKQRlWoX9tUvmIDK2vZPyAHbXikfYcKtL/B91oCaFWF/HrRA==",
+      "version": "5.11.3",
+      "resolved": "https://registry.npmjs.org/@fullcalendar/interaction/-/interaction-5.11.3.tgz",
+      "integrity": "sha512-L955wkDjza62K96ndstvYs2Fd4V0kayTDpqW8W7huFG3Ox8MutpLqKAa2SCaTvcNIlWS4oexGQRiQAaJG7u47A==",
       "dependencies": {
-        "@fullcalendar/common": "~5.11.2",
+        "@fullcalendar/common": "~5.11.3",
         "tslib": "^2.1.0"
       }
     },
     "node_modules/@fullcalendar/list": {
-      "version": "5.11.2",
-      "resolved": "https://registry.npmjs.org/@fullcalendar/list/-/list-5.11.2.tgz",
-      "integrity": "sha512-qzf0LwRif7gxjmoW2jxOARKscsTB//b+9IzQXtbnfGlm00f+YPYP21lUK83O7ztsmvunCWZPSZSFgk2yz72WVQ==",
+      "version": "5.11.3",
+      "resolved": "https://registry.npmjs.org/@fullcalendar/list/-/list-5.11.3.tgz",
+      "integrity": "sha512-6m9rJPzB5XfJZg+MlgVpha1cI3NUDeyV3GOmojJWZuti05NfDP4f0lzFUul8W7m1DQcjGS2UPRNE8HouA3guEA==",
       "dependencies": {
-        "@fullcalendar/common": "~5.11.2",
+        "@fullcalendar/common": "~5.11.3",
         "tslib": "^2.1.0"
       }
     },
@@ -2035,15 +2035,15 @@
       }
     },
     "node_modules/@fullcalendar/resource-timeline": {
-      "version": "5.11.2",
-      "resolved": "https://registry.npmjs.org/@fullcalendar/resource-timeline/-/resource-timeline-5.11.2.tgz",
-      "integrity": "sha512-8cY1h9CV9ZqWL9OMn8frYJNreAwK+BiN8g9g33SF2ygVXfTjqRNeyBpNFaMcH16jZg+9T/bwVPlfQaBRmd2lAg==",
+      "version": "5.11.3",
+      "resolved": "https://registry.npmjs.org/@fullcalendar/resource-timeline/-/resource-timeline-5.11.3.tgz",
+      "integrity": "sha512-iYIXZPfqtiN/qizpGDCYlFVssdDTZv6lU/5N1v0FzvGMZfU2LkHLhCkouQeBQHja8ZCbJisy4sK3kUR9mXh2cg==",
       "dependencies": {
-        "@fullcalendar/common": "~5.11.2",
-        "@fullcalendar/premium-common": "~5.11.2",
-        "@fullcalendar/resource-common": "~5.11.2",
-        "@fullcalendar/scrollgrid": "~5.11.2",
-        "@fullcalendar/timeline": "~5.11.2",
+        "@fullcalendar/common": "~5.11.3",
+        "@fullcalendar/premium-common": "~5.11.3",
+        "@fullcalendar/resource-common": "~5.11.3",
+        "@fullcalendar/scrollgrid": "~5.11.3",
+        "@fullcalendar/timeline": "~5.11.3",
         "tslib": "^2.1.0"
       }
     },
@@ -2058,12 +2058,12 @@
       }
     },
     "node_modules/@fullcalendar/timegrid": {
-      "version": "5.11.2",
-      "resolved": "https://registry.npmjs.org/@fullcalendar/timegrid/-/timegrid-5.11.2.tgz",
-      "integrity": "sha512-Ue/c78Op5FDsHM0DmjZYQ+t1bnd8ZWFZeWhjqCNVV7cgCZnp48BllOZjYCyssFxVpMe+Dj+tS4WcNrrXP8M4Hg==",
+      "version": "5.11.3",
+      "resolved": "https://registry.npmjs.org/@fullcalendar/timegrid/-/timegrid-5.11.3.tgz",
+      "integrity": "sha512-SjIj2ZQ7nTyL1RxZkCPvNbuUQ0xHT+gfYJdUL3FT4bPjPJCxWtQ2CL8hxaeNmVozYYuy0yrGTW5Oup2+9IplbA==",
       "dependencies": {
-        "@fullcalendar/common": "~5.11.2",
-        "@fullcalendar/daygrid": "~5.11.2",
+        "@fullcalendar/common": "~5.11.3",
+        "@fullcalendar/daygrid": "~5.11.3",
         "tslib": "^2.1.0"
       }
     },
@@ -17856,39 +17856,39 @@
       }
     },
     "@fullcalendar/core": {
-      "version": "5.11.2",
-      "resolved": "https://registry.npmjs.org/@fullcalendar/core/-/core-5.11.2.tgz",
-      "integrity": "sha512-+lO4EWqssONDWF1NO+tiW8KYqKj+MluLAnnRhIKlnFfvNJXEoondWKR6q3jF9Yxe/VmbVFKPq9z6auIxc7zr3A==",
+      "version": "5.11.3",
+      "resolved": "https://registry.npmjs.org/@fullcalendar/core/-/core-5.11.3.tgz",
+      "integrity": "sha512-YUFxCvVJytUwFeXCx4J17kFMM7Ixwn9zBjVRw5NM2bMwgR6VAhSnlZc6yNQSOIy7Hj2TF0vDkO/4JNlTvxyAXw==",
       "requires": {
-        "@fullcalendar/common": "~5.11.2",
+        "@fullcalendar/common": "~5.11.3",
         "preact": "^10.0.5",
         "tslib": "^2.1.0"
       }
     },
     "@fullcalendar/daygrid": {
-      "version": "5.11.2",
-      "resolved": "https://registry.npmjs.org/@fullcalendar/daygrid/-/daygrid-5.11.2.tgz",
-      "integrity": "sha512-WmR8EAOR8Y9wyxlCK2gBW6lG/dPSN37eM8L7vgc7YgrQE1knL7ISgaUnDfFUNBFztmLakO/ZpeQQFpz3pnJwXg==",
+      "version": "5.11.3",
+      "resolved": "https://registry.npmjs.org/@fullcalendar/daygrid/-/daygrid-5.11.3.tgz",
+      "integrity": "sha512-PCK0y80DRNCzWuC5lGpIWqCgKDvql1ah7rXql5lu+Gn2EeFj15ZQ8diMFjtNIQucEmFaNOXnR05Pgcry1n6Shg==",
       "requires": {
-        "@fullcalendar/common": "~5.11.2",
+        "@fullcalendar/common": "~5.11.3",
         "tslib": "^2.1.0"
       }
     },
     "@fullcalendar/interaction": {
-      "version": "5.11.2",
-      "resolved": "https://registry.npmjs.org/@fullcalendar/interaction/-/interaction-5.11.2.tgz",
-      "integrity": "sha512-PlUXP9pW62tLgp2DttLC2f8IX5yeRLRboY/knnRKQRlWoX9tUvmIDK2vZPyAHbXikfYcKtL/B91oCaFWF/HrRA==",
+      "version": "5.11.3",
+      "resolved": "https://registry.npmjs.org/@fullcalendar/interaction/-/interaction-5.11.3.tgz",
+      "integrity": "sha512-L955wkDjza62K96ndstvYs2Fd4V0kayTDpqW8W7huFG3Ox8MutpLqKAa2SCaTvcNIlWS4oexGQRiQAaJG7u47A==",
       "requires": {
-        "@fullcalendar/common": "~5.11.2",
+        "@fullcalendar/common": "~5.11.3",
         "tslib": "^2.1.0"
       }
     },
     "@fullcalendar/list": {
-      "version": "5.11.2",
-      "resolved": "https://registry.npmjs.org/@fullcalendar/list/-/list-5.11.2.tgz",
-      "integrity": "sha512-qzf0LwRif7gxjmoW2jxOARKscsTB//b+9IzQXtbnfGlm00f+YPYP21lUK83O7ztsmvunCWZPSZSFgk2yz72WVQ==",
+      "version": "5.11.3",
+      "resolved": "https://registry.npmjs.org/@fullcalendar/list/-/list-5.11.3.tgz",
+      "integrity": "sha512-6m9rJPzB5XfJZg+MlgVpha1cI3NUDeyV3GOmojJWZuti05NfDP4f0lzFUul8W7m1DQcjGS2UPRNE8HouA3guEA==",
       "requires": {
-        "@fullcalendar/common": "~5.11.2",
+        "@fullcalendar/common": "~5.11.3",
         "tslib": "^2.1.0"
       }
     },
@@ -17912,15 +17912,15 @@
       }
     },
     "@fullcalendar/resource-timeline": {
-      "version": "5.11.2",
-      "resolved": "https://registry.npmjs.org/@fullcalendar/resource-timeline/-/resource-timeline-5.11.2.tgz",
-      "integrity": "sha512-8cY1h9CV9ZqWL9OMn8frYJNreAwK+BiN8g9g33SF2ygVXfTjqRNeyBpNFaMcH16jZg+9T/bwVPlfQaBRmd2lAg==",
+      "version": "5.11.3",
+      "resolved": "https://registry.npmjs.org/@fullcalendar/resource-timeline/-/resource-timeline-5.11.3.tgz",
+      "integrity": "sha512-iYIXZPfqtiN/qizpGDCYlFVssdDTZv6lU/5N1v0FzvGMZfU2LkHLhCkouQeBQHja8ZCbJisy4sK3kUR9mXh2cg==",
       "requires": {
-        "@fullcalendar/common": "~5.11.2",
-        "@fullcalendar/premium-common": "~5.11.2",
-        "@fullcalendar/resource-common": "~5.11.2",
-        "@fullcalendar/scrollgrid": "~5.11.2",
-        "@fullcalendar/timeline": "~5.11.2",
+        "@fullcalendar/common": "~5.11.3",
+        "@fullcalendar/premium-common": "~5.11.3",
+        "@fullcalendar/resource-common": "~5.11.3",
+        "@fullcalendar/scrollgrid": "~5.11.3",
+        "@fullcalendar/timeline": "~5.11.3",
         "tslib": "^2.1.0"
       }
     },
@@ -17935,12 +17935,12 @@
       }
     },
     "@fullcalendar/timegrid": {
-      "version": "5.11.2",
-      "resolved": "https://registry.npmjs.org/@fullcalendar/timegrid/-/timegrid-5.11.2.tgz",
-      "integrity": "sha512-Ue/c78Op5FDsHM0DmjZYQ+t1bnd8ZWFZeWhjqCNVV7cgCZnp48BllOZjYCyssFxVpMe+Dj+tS4WcNrrXP8M4Hg==",
+      "version": "5.11.3",
+      "resolved": "https://registry.npmjs.org/@fullcalendar/timegrid/-/timegrid-5.11.3.tgz",
+      "integrity": "sha512-SjIj2ZQ7nTyL1RxZkCPvNbuUQ0xHT+gfYJdUL3FT4bPjPJCxWtQ2CL8hxaeNmVozYYuy0yrGTW5Oup2+9IplbA==",
       "requires": {
-        "@fullcalendar/common": "~5.11.2",
-        "@fullcalendar/daygrid": "~5.11.2",
+        "@fullcalendar/common": "~5.11.3",
+        "@fullcalendar/daygrid": "~5.11.3",
         "tslib": "^2.1.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -35,12 +35,12 @@
     "test:coverage": "jest --coverage"
   },
   "dependencies": {
-    "@fullcalendar/core": "5.11.2",
-    "@fullcalendar/daygrid": "5.11.2",
-    "@fullcalendar/interaction": "5.11.2",
-    "@fullcalendar/list": "5.11.2",
-    "@fullcalendar/resource-timeline": "5.11.2",
-    "@fullcalendar/timegrid": "5.11.2",
+    "@fullcalendar/core": "5.11.3",
+    "@fullcalendar/daygrid": "5.11.3",
+    "@fullcalendar/interaction": "5.11.3",
+    "@fullcalendar/list": "5.11.3",
+    "@fullcalendar/resource-timeline": "5.11.3",
+    "@fullcalendar/timegrid": "5.11.3",
     "@fullcalendar/vue": "5.11.2",
     "@nextcloud/auth": "^2.0.0",
     "@nextcloud/axios": "^2.1.0",


### PR DESCRIPTION
~The release of `@fullcalendar/vue` v5.11.3 is still pending.~

**EDIT:** Turns out that a release of the vue package is not required.