### PR TITLE
Move calendar sharing and settings to a modal

### DIFF
--- a/src/components/AppNavigation/EditCalendarModal.vue
+++ b/src/components/AppNavigation/EditCalendarModal.vue
@@ -1,0 +1,318 @@
+<!--
+  - @copyright Copyright (c) 2022 Richard Steinmetz <richard@steinmetz.cloud>
+  -
+  - @author Richard Steinmetz <richard@steinmetz.cloud>
+  -
+  - @license AGPL-3.0-or-later
+  -
+  - This program is free software: you can redistribute it and/or modify
+  - it under the terms of the GNU Affero General Public License as
+  - published by the Free Software Foundation, either version 3 of the
+  - License, or (at your option) any later version.
+  -
+  - This program is distributed in the hope that it will be useful,
+  - but WITHOUT ANY WARRANTY; without even the implied warranty of
+  - MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  - GNU Affero General Public License for more details.
+  -
+  - You should have received a copy of the GNU Affero General Public License
+  - along with this program. If not, see <http://www.gnu.org/licenses/>.
+  -
+  -->
+
+<template>
+	<NcModal v-if="!!editCalendarModal && calendar" size="normal" @close="saveAndClose">
+		<div class="edit-calendar-modal">
+			<h2>{{ $t('calendar', 'Edit calendar') }}</h2>
+
+			<div class="edit-calendar-modal__name-and-color">
+				<div class="edit-calendar-modal__name-and-color__color">
+					<div v-if="loading"
+						class="edit-calendar-modal__name-and-color__color__dot"
+						:style="{'background-color': calendarColor}" />
+					<NcColorPicker v-else v-model="calendarColor">
+						<div class="edit-calendar-modal__name-and-color__color__dot"
+							:style="{'background-color': calendarColor}" />
+					</NcColorPicker>
+				</div>
+
+				<input v-model="calendarName"
+					class="edit-calendar-modal__name-and-color__name"
+					type="text"
+					:disabled="loading"
+					:placeholder="$t('calendar', 'Calendar name …')">
+			</div>
+
+			<template v-if="canBeShared">
+				<h2 class="edit-calendar-modal__sharing-header">
+					{{ $t('calendar', 'Share calendar') }}
+				</h2>
+
+				<div class="edit-calendar-modal__sharing">
+					<SharingSearch :calendar="calendar" />
+					<PublishCalendar :calendar="calendar" />
+					<ShareItem v-for="sharee in calendar.shares"
+						:key="sharee.uri"
+						:sharee="sharee"
+						:calendar="calendar" />
+				</div>
+			</template>
+			<div class="edit-calendar-modal__actions">
+				<NcButton @click="copyLink">
+					<template #icon>
+						<LinkVariantIcon :size="20" />
+					</template>
+					{{ $t('calendar', 'Copy private link') }}
+				</NcButton>
+				<NcButton :to="downloadUrl">
+					<template #icon>
+						<DownloadIcon :size="20" />
+					</template>
+					{{ $t('calendar', 'Export') }}
+				</NcButton>
+				<NcButton v-if="calendar.isSharedWithMe" type="error" @click="deleteCalendar">
+					<template #icon>
+						<CloseIcon :size="20" />
+					</template>
+					{{ $t('calendar', 'Unshare from me') }}
+				</NcButton>
+				<NcButton v-else type="error" @click="deleteCalendar">
+					<template #icon>
+						<DeleteIcon :size="20" />
+					</template>
+					{{ $t('calendar', 'Delete') }}
+				</NcButton>
+			</div>
+		</div>
+	</NcModal>
+</template>
+
+<script>
+import NcModal from '@nextcloud/vue/dist/Components/NcModal.js'
+import NcColorPicker from '@nextcloud/vue/dist/Components/NcColorPicker.js'
+import NcButton from '@nextcloud/vue/dist/Components/NcButton.js'
+import PublishCalendar from './EditCalendarModal/PublishCalendar.vue'
+import SharingSearch from './EditCalendarModal/SharingSearch.vue'
+import ShareItem from './EditCalendarModal/ShareItem.vue'
+import { mapGetters } from 'vuex'
+import logger from '../../utils/logger.js'
+import debounce from 'debounce'
+import DeleteIcon from 'vue-material-design-icons/Delete.vue'
+import DownloadIcon from 'vue-material-design-icons/Download.vue'
+import LinkVariantIcon from 'vue-material-design-icons/LinkVariant.vue'
+import CloseIcon from 'vue-material-design-icons/Close.vue'
+import { showError, showSuccess } from '@nextcloud/dialogs'
+import { generateRemoteUrl } from '@nextcloud/router'
+
+export default {
+	name: 'EditCalendarModal',
+	components: {
+		NcModal,
+		NcColorPicker,
+		NcButton,
+		PublishCalendar,
+		SharingSearch,
+		ShareItem,
+		DeleteIcon,
+		DownloadIcon,
+		LinkVariantIcon,
+		CloseIcon,
+	},
+	props: {
+	},
+	data() {
+		return {
+			loading: false,
+			calendarColor: undefined,
+			calendarColorChanged: false,
+			calendarName: undefined,
+			calendarNameChanged: false,
+		}
+	},
+	computed: {
+		...mapGetters(['editCalendarModal']),
+		calendar() {
+			const id = this.editCalendarModal?.calendarId
+			if (!id) {
+				return undefined
+			}
+
+			return this.$store.getters.getCalendarById(id)
+		},
+
+		/**
+		 * Whether to show the sharing section
+		 *
+		 * @return {boolean}
+		 */
+		canBeShared() {
+			return this.calendar.canBeShared || this.calendar.canBePublished
+		},
+
+		/**
+		 * Download url of the calendar
+		 *
+		 * @return {string}
+		 */
+		downloadUrl() {
+			return this.calendar.url + '?export'
+		},
+	},
+	watch: {
+		async calendarColor() {
+			await this.saveColor()
+		},
+		async calendarName() {
+			await this.saveName()
+		},
+		editCalendarModal(value) {
+			if (!value) {
+				return
+			}
+
+			this.calendarName = this.calendar.displayName
+			this.calendarColor = this.calendar.color
+		},
+	},
+	created() {
+		// debounce.flush() only works if the functions are added here (or in data())
+		this.saveColorDebounced = debounce(() => this.saveColor(), 1000)
+		this.saveNameDebounced = debounce(() => this.saveName(), 1000)
+	},
+	methods: {
+		/**
+		 * Close the modal (without saving).
+		 */
+		closeModal() {
+			this.$store.commit('hideEditCalendarModal')
+		},
+
+		/**
+		 * Save the calendar color.
+		 */
+		async saveColor() {
+			this.loading = true
+
+			try {
+				await this.$store.dispatch('changeCalendarColor', {
+					calendar: this.calendar,
+					newColor: this.calendarColor,
+				})
+			} catch (error) {
+				logger.error('Failed to save calendar color', {
+					calendar: this.calendar,
+					newColor: this.calendarColor,
+				})
+			} finally {
+				this.loading = false
+			}
+		},
+
+		/**
+		 * Save the calendar name.
+		 */
+		async saveName() {
+			this.loading = true
+
+			try {
+				await this.$store.dispatch('renameCalendar', {
+					calendar: this.calendar,
+					newName: this.calendarName,
+				})
+			} catch (error) {
+				logger.error('Failed to save calendar name', {
+					calendar: this.calendar,
+					newName: this.calendarName,
+				})
+			} finally {
+				this.loading = false
+			}
+		},
+
+		/**
+		 * Save unsaved changes and close the modal.
+		 *
+		 * @return {Promise<void>}
+		 */
+		async saveAndClose() {
+			await this.saveColorDebounced.flush()
+			await this.saveNameDebounced.flush()
+			this.closeModal()
+		},
+
+		/**
+		 * Copies the private calendar link
+		 * to be used with clients like Thunderbird
+		 */
+		async copyLink() {
+			const rootUrl = generateRemoteUrl('dav')
+			const url = new URL(this.calendar.url, rootUrl)
+
+			try {
+				await navigator.clipboard.writeText(url)
+				showSuccess(this.$t('calendar', 'Calendar link copied to clipboard.'))
+			} catch (error) {
+				console.debug(error)
+				showError(this.$t('calendar', 'Calendar link could not be copied to clipboard.'))
+			}
+		},
+
+		/**
+		 * Deletes or unshares the calendar
+		 */
+		deleteCalendar() {
+			this.$store.dispatch('deleteCalendarAfterTimeout', {
+				calendar: this.calendar,
+			})
+			this.closeModal()
+		},
+	},
+}
+</script>
+
+<style lang="scss" scoped>
+.edit-calendar-modal {
+	padding: 20px;
+	display: flex;
+	flex-direction: column;
+
+	&__name-and-color {
+		display: flex;
+		align-items: center;
+		gap: 10px;
+		margin-bottom: 10px;
+
+		&__color {
+			::v-deep &__dot {
+				width: 24px;
+				height: 24px;
+				border-radius: 12px;
+			}
+		}
+
+		&__name {
+			flex: 1 auto;
+		}
+	}
+
+	&__actions {
+		display: flex;
+		gap: 10px;
+		margin-top: 10px;
+
+		button {
+			flex: 1 auto;
+		}
+	}
+
+	&__sharing-header {
+		margin-top: 10px;
+	}
+
+	&__sharing {
+		display: flex;
+		flex-direction: column;
+		gap: 5px;
+	}
+}
+</style>

--- a/src/components/AppNavigation/EditCalendarModal/PublishCalendar.vue
+++ b/src/components/AppNavigation/EditCalendarModal/PublishCalendar.vue
@@ -1,6 +1,8 @@
 <!--
   - @copyright Copyright (c) 2019 Georg Ehrke <oc.list@georgehrke.com>
+  -
   - @author Georg Ehrke <oc.list@georgehrke.com>
+  - @author Richard Steinmetz <richard@steinmetz.cloud>
   -
   - @license AGPL-3.0-or-later
   -
@@ -20,135 +22,127 @@
   -->
 
 <template>
-	<AppNavigationItem :title="$t('calendar', 'Share link')"
-		:menu-open.sync="menuOpen">
-		<template slot="icon">
-			<LinkVariant :class="{published: isPublished}"
-				:size="18"
-				decorative
-				class="avatar" />
-		</template>
+	<div class="publish-calendar">
+		<div class="publish-calendar__icon">
+			<LinkVariant :size="20" />
+		</div>
 
-		<template v-if="!isPublished" slot="actions">
-			<ActionButton v-if="!publishingCalendar"
-				key="publish"
-				@click.prevent.stop="publishCalendar">
-				<template #icon>
-					<Plus :size="20" decorative />
-				</template>
-				{{ $t('calendar', 'Publish calendar') }}
-			</ActionButton>
-			<ActionButton v-else
-				key="publishing"
-				icon="icon-loading-small"
-				:disabled="true">
-				{{ $t('calendar', 'Publishing calendar') }}
-			</ActionButton>
-		</template>
+		<p class="publish-calendar__label">
+			{{ $t('calendar', 'Share link') }}
+		</p>
 
-		<template v-if="isPublished" slot="counter">
-			<Actions>
-				<ActionButton @click.prevent.stop="copyPublicLink">
+		<template v-if="isPublished">
+			<NcActions>
+				<NcActionButton @click.prevent.stop="copyPublicLink">
 					<template #icon>
 						<ClipboardArrowLeftOutline :size="20" decorative />
 					</template>
 					{{ $t('calendar', 'Copy public link') }}
-				</ActionButton>
-			</Actions>
+				</NcActionButton>
+			</NcActions>
+
+			<NcActions>
+				<NcActionButton v-if="showEMailLabel"
+					@click.prevent.stop="openEMailLinkInput">
+					<template #icon>
+						<Email :size="20" decorative />
+					</template>
+					{{ $t('calendar', 'Send link to calendar via email') }}
+				</NcActionButton>
+				<NcActionInput v-if="showEMailInput"
+					@submit.prevent.stop="sendLinkViaEMail">
+					<template #icon>
+						<Email :size="20" decorative />
+					</template>
+					{{ $t('calendar', 'Enter one address') }}
+				</NcActionInput>
+				<NcActionText v-if="showEMailSending"
+					icon="icon-loading-small">
+					<!-- eslint-disable-next-line no-irregular-whitespace -->
+					{{ $t('calendar', 'Sending email …') }}
+				</NcActionText>
+
+				<NcActionButton v-if="showCopySubscriptionLinkLabel"
+					@click.prevent.stop="copySubscriptionLink">
+					<template #icon>
+						<CalendarBlank :size="20" decorative />
+					</template>
+					{{ $t('calendar', 'Copy subscription link') }}
+				</NcActionButton>
+				<NcActionText v-if="showCopySubscriptionLinkSpinner"
+					icon="icon-loading-small">
+					<!-- eslint-disable-next-line no-irregular-whitespace -->
+					{{ $t('calendar', 'Copying link …') }}
+				</NcActionText>
+				<NcActionText v-if="showCopySubscriptionLinkSuccess">
+					<template #icon>
+						<CalendarBlank :size="20" decorative />
+					</template>
+					{{ $t('calendar', 'Copied link') }}
+				</NcActionText>
+				<NcActionText v-if="showCopySubscriptionLinkError">
+					<template #icon>
+						<CalendarBlank :size="20" decorative />
+					</template>
+					{{ $t('calendar', 'Could not copy link') }}
+				</NcActionText>
+
+				<NcActionButton v-if="showCopyEmbedCodeLinkLabel"
+					@click.prevent.stop="copyEmbedCode">
+					<template #icon>
+						<CodeBrackets :size="20" decorative />
+					</template>
+					{{ $t('calendar', 'Copy embedding code') }}
+				</NcActionButton>
+				<NcActionText v-if="showCopyEmbedCodeLinkSpinner"
+					icon="icon-loading-small">
+					<!-- eslint-disable-next-line no-irregular-whitespace -->
+					{{ $t('calendar', 'Copying code …') }}
+				</NcActionText>
+				<NcActionText v-if="showCopyEmbedCodeLinkSuccess">
+					<template #icon>
+						<CodeBrackets :size="20" decorative />
+					</template>
+					{{ $t('calendar', 'Copied code') }}
+				</NcActionText>
+				<NcActionText v-if="showCopyEmbedCodeLinkError">
+					<template #icon>
+						<CodeBrackets :size="20" decorative />
+					</template>
+					{{ $t('calendar', 'Could not copy code') }}
+				</NcActionText>
+
+				<NcActionButton v-if="!unpublishingCalendar"
+					@click.prevent.stop="unpublishCalendar">
+					<template #icon>
+						<Delete :size="20" decorative />
+					</template>
+					{{ $t('calendar', 'Delete share link') }}
+				</NcActionButton>
+				<NcActionText v-if="unpublishingCalendar"
+					icon="icon-loading-small">
+					<!-- eslint-disable-next-line no-irregular-whitespace -->
+					{{ $t('calendar', 'Deleting share link …') }}
+				</NcActionText>
+			</NcActions>
 		</template>
-		<template v-if="isPublished" slot="actions">
-			<ActionButton v-if="showEMailLabel"
-				@click.prevent.stop="openEMailLinkInput">
+		<NcActions v-else>
+			<NcActionButton aria-label="$t('calendar', 'Share link')"
+				:disabled="publishingCalendar"
+				@click.prevent.stop="publishCalendar">
 				<template #icon>
-					<Email :size="20" decorative />
+					<PlusIcon :size="20" />
 				</template>
-				{{ $t('calendar', 'Send link to calendar via email') }}
-			</ActionButton>
-			<ActionInput v-if="showEMailInput"
-				@submit.prevent.stop="sendLinkViaEMail">
-				<template #icon>
-					<Email :size="20" decorative />
-				</template>
-				{{ $t('calendar', 'Enter one address') }}
-			</ActionInput>
-			<ActionText v-if="showEMailSending"
-				icon="icon-loading-small">
-				<!-- eslint-disable-next-line no-irregular-whitespace -->
-				{{ $t('calendar', 'Sending email …') }}
-			</ActionText>
-
-			<ActionButton v-if="showCopySubscriptionLinkLabel"
-				@click.prevent.stop="copySubscriptionLink">
-				<template #icon>
-					<CalendarBlank :size="20" decorative />
-				</template>
-				{{ $t('calendar', 'Copy subscription link') }}
-			</ActionButton>
-			<ActionText v-if="showCopySubscriptionLinkSpinner"
-				icon="icon-loading-small">
-				<!-- eslint-disable-next-line no-irregular-whitespace -->
-				{{ $t('calendar', 'Copying link …') }}
-			</ActionText>
-			<ActionText v-if="showCopySubscriptionLinkSuccess">
-				<template #icon>
-					<CalendarBlank :size="20" decorative />
-				</template>
-				{{ $t('calendar', 'Copied link') }}
-			</ActionText>
-			<ActionText v-if="showCopySubscriptionLinkError">
-				<template #icon>
-					<CalendarBlank :size="20" decorative />
-				</template>
-				{{ $t('calendar', 'Could not copy link') }}
-			</ActionText>
-
-			<ActionButton v-if="showCopyEmbedCodeLinkLabel"
-				@click.prevent.stop="copyEmbedCode">
-				<template #icon>
-					<CodeBrackets :size="20" decorative />
-				</template>
-				{{ $t('calendar', 'Copy embedding code') }}
-			</ActionButton>
-			<ActionText v-if="showCopyEmbedCodeLinkSpinner"
-				icon="icon-loading-small">
-				<!-- eslint-disable-next-line no-irregular-whitespace -->
-				{{ $t('calendar', 'Copying code …') }}
-			</ActionText>
-			<ActionText v-if="showCopyEmbedCodeLinkSuccess">
-				<template #icon>
-					<CodeBrackets :size="20" decorative />
-				</template>
-				{{ $t('calendar', 'Copied code') }}
-			</ActionText>
-			<ActionText v-if="showCopyEmbedCodeLinkError">
-				<template #icon>
-					<CodeBrackets :size="20" decorative />
-				</template>
-				{{ $t('calendar', 'Could not copy code') }}
-			</ActionText>
-
-			<ActionButton v-if="!unpublishingCalendar"
-				@click.prevent.stop="unpublishCalendar">
-				<template #icon>
-					<Delete :size="20" decorative />
-				</template>
-				{{ $t('calendar', 'Delete share link') }}
-			</ActionButton>
-			<ActionText v-if="unpublishingCalendar"
-				icon="icon-loading-small">
-				<!-- eslint-disable-next-line no-irregular-whitespace -->
-				{{ $t('calendar', 'Deleting share link …') }}
-			</ActionText>
-		</template>
-	</AppNavigationItem>
+			</NcActionButton>
+		</NcActions>
+	</div>
 </template>
 
 <script>
-import Actions from '@nextcloud/vue/dist/Components/NcActions.js'
-import ActionButton from '@nextcloud/vue/dist/Components/NcActionButton.js'
-import ActionInput from '@nextcloud/vue/dist/Components/NcActionInput.js'
-import ActionText from '@nextcloud/vue/dist/Components/NcActionText.js'
-import AppNavigationItem from '@nextcloud/vue/dist/Components/NcAppNavigationItem.js'
+import NcActions from '@nextcloud/vue/dist/Components/NcActions.js'
+import NcActionButton from '@nextcloud/vue/dist/Components/NcActionButton.js'
+import NcActionInput from '@nextcloud/vue/dist/Components/NcActionInput.js'
+import NcActionText from '@nextcloud/vue/dist/Components/NcActionText.js'
 import ClickOutside from 'vue-click-outside'
 import {
 	generateRemoteUrl,
@@ -167,23 +161,22 @@ import CodeBrackets from 'vue-material-design-icons/CodeBrackets.vue'
 import Delete from 'vue-material-design-icons/Delete.vue'
 import Email from 'vue-material-design-icons/Email.vue'
 import LinkVariant from 'vue-material-design-icons/LinkVariant.vue'
-import Plus from 'vue-material-design-icons/Plus.vue'
+import PlusIcon from 'vue-material-design-icons/Plus.vue'
 
 export default {
-	name: 'CalendarListItemSharingPublishItem',
+	name: 'PublishCalendar',
 	components: {
-		Actions,
-		ActionButton,
-		ActionInput,
-		ActionText,
-		AppNavigationItem,
+		NcActions,
+		NcActionButton,
+		NcActionInput,
+		NcActionText,
 		CalendarBlank,
 		ClipboardArrowLeftOutline,
 		CodeBrackets,
 		Delete,
 		Email,
 		LinkVariant,
-		Plus,
+		PlusIcon,
 	},
 	directives: {
 		ClickOutside,
@@ -385,3 +378,26 @@ export default {
 	},
 }
 </script>
+
+<style lang="scss" scoped>
+.publish-calendar {
+	display: flex;
+	align-items: center;
+	gap: 10px;
+
+	&__icon {
+		display: flex;
+		width: 32px;
+		height: 32px;
+		border-radius: 16px;
+		color: white;
+		background-color: var(--color-primary);
+		align-items: center;
+		justify-content: center;
+	}
+
+	&__label {
+		flex: 1 auto;
+	}
+}
+</style>

--- a/src/components/AppNavigation/EditCalendarModal/ShareItem.vue
+++ b/src/components/AppNavigation/EditCalendarModal/ShareItem.vue
@@ -1,6 +1,8 @@
 <!--
   - @copyright Copyright (c) 2019 Georg Ehrke <oc.list@georgehrke.com>
+  -
   - @author Georg Ehrke <oc.list@georgehrke.com>
+  - @author Richard Steinmetz <richard@steinmetz.cloud>
   -
   - @license AGPL-3.0-or-later
   -
@@ -20,56 +22,53 @@
   -->
 
 <template>
-	<AppNavigationItem :title="sharee.displayName">
-		<template slot="icon">
-			<AccountMultiple v-if="sharee.isGroup"
-				:size="18"
-				decorative
-				class="avatar" />
-			<IconCircle v-else-if="sharee.isCircle" />
-			<Avatar v-else :user="sharee.id" :display-name="sharee.displayName" />
-		</template>
+	<div class="share-item">
+		<AccountMultiple v-if="sharee.isGroup" :size="20" class="share-item__group-icon" />
+		<IconCircle v-else-if="sharee.isCircle" />
+		<NcAvatar v-else :user="sharee.userId" :display-name="sharee.displayName" />
 
-		<template slot="counter">
-			<ActionCheckbox :disabled="updatingSharee"
-				:checked="sharee.writeable"
-				@update:checked="updatePermission">
-				{{ $t('calendar', 'can edit') }}
-			</ActionCheckbox>
-		</template>
+		<p class="share-item__label">
+			{{ sharee.displayName }}
+		</p>
 
-		<template slot="actions">
-			<ActionButton :disabled="updatingSharee"
+		<input :id="`${id}-can-edit`"
+			:disabled="updatingSharee"
+			:checked="sharee.writeable"
+			type="checkbox"
+			class="checkbox"
+			@change="updatePermission">
+		<label :for="`${id}-can-edit`">{{ $t('calendar', 'can edit') }}</label>
+
+		<NcActions>
+			<NcActionButton :disabled="updatingSharee"
 				@click.prevent.stop="unshare">
 				<template #icon>
 					<Delete :size="20" decorative />
 				</template>
 				{{ $t('calendar', 'Unshare with {displayName}', { displayName: sharee.displayName }) }}
-			</ActionButton>
-		</template>
-	</AppNavigationItem>
+			</NcActionButton>
+		</NcActions>
+	</div>
 </template>
 
 <script>
-import ActionButton from '@nextcloud/vue/dist/Components/NcActionButton.js'
-import ActionCheckbox from '@nextcloud/vue/dist/Components/NcActionCheckbox.js'
-import AppNavigationItem from '@nextcloud/vue/dist/Components/NcAppNavigationItem.js'
-import Avatar from '@nextcloud/vue/dist/Components/NcAvatar.js'
-import {
-	showInfo,
-} from '@nextcloud/dialogs'
-
+import NcActions from '@nextcloud/vue/dist/Components/NcActions.js'
+import NcActionButton from '@nextcloud/vue/dist/Components/NcActionButton.js'
+import NcAvatar from '@nextcloud/vue/dist/Components/NcAvatar.js'
 import AccountMultiple from 'vue-material-design-icons/AccountMultiple.vue'
 import IconCircle from '../../Icons/IconCircles.vue'
 import Delete from 'vue-material-design-icons/Delete.vue'
+import {
+	showInfo,
+} from '@nextcloud/dialogs'
+import { randomId } from '../../../utils/randomId.js'
 
 export default {
-	name: 'CalendarListItemSharingShareItem',
+	name: 'ShareItem',
 	components: {
-		ActionButton,
-		ActionCheckbox,
-		AppNavigationItem,
-		Avatar,
+		NcActions,
+		NcActionButton,
+		NcAvatar,
 	  IconCircle,
 		AccountMultiple,
 		Delete,
@@ -86,6 +85,7 @@ export default {
 	},
 	data() {
 		return {
+			id: randomId(),
 			updatingSharee: false,
 		}
 	},
@@ -138,3 +138,23 @@ export default {
 	},
 }
 </script>
+
+<style lang="scss" scoped>
+.share-item {
+	display: flex;
+	align-items: center;
+	gap: 10px;
+
+	&__group-icon {
+		width: 32px;
+		height: 32px;
+		border-radius: 16px;
+		color: white;
+		background-color: var(--color-text-maxcontrast);
+	}
+
+	&__label {
+		flex: 1 auto;
+	}
+}
+</style>

--- a/src/components/AppNavigation/EditCalendarModal/SharingSearch.vue
+++ b/src/components/AppNavigation/EditCalendarModal/SharingSearch.vue
@@ -4,6 +4,7 @@
   -
   - @author Georg Ehrke <oc.list@georgehrke.com>
   - @author Jakob Röhrl <jakob.roehrl@web.de>
+  - @author Richard Steinmetz <richard@steinmetz.cloud>
   -
   - @license AGPL-3.0-or-later
   -
@@ -23,23 +24,24 @@
   -->
 
 <template>
-	<li class="app-navigation-entry__multiselect">
+	<div class="sharing-search">
 		<Multiselect :options="usersOrGroups"
 			:searchable="true"
 			:internal-search="false"
 			:max-height="600"
 			:show-no-results="true"
 			:placeholder="$t('calendar', 'Share with users or groups')"
+			class="sharing-search__select"
 			:class="{ 'showContent': inputGiven, 'icon-loading': isLoading }"
 			:user-select="true"
-			open-direction="bottom"
+			open-direction="above"
 			track-by="user"
 			label="displayName"
 			@search-change="findSharee"
 			@change="shareCalendar">
 			<span slot="noResult">{{ $t('calendar', 'No users or groups') }}</span>
 		</Multiselect>
-	</li>
+	</div>
 </template>
 
 <script>
@@ -51,7 +53,7 @@ import { generateOcsUrl } from '@nextcloud/router'
 import { urldecode } from '../../../utils/url.js'
 
 export default {
-	name: 'CalendarListItemSharingSearch',
+	name: 'SharingSearch',
 	components: {
 		Multiselect,
 	},
@@ -232,3 +234,18 @@ export default {
 	},
 }
 </script>
+
+<style lang="scss" scoped>
+.sharing-search {
+	display: flex;
+
+	&__select {
+		flex: 1 auto;
+
+		// Fix weird height of multiselect
+		::v-deep .multiselect__tags {
+			box-sizing: border-box;
+		}
+	}
+}
+</style>

--- a/src/views/Calendar.vue
+++ b/src/views/Calendar.vue
@@ -33,6 +33,7 @@
 					:loading-calendars="loadingCalendars" />
 				<CalendarListNew v-if="!loadingCalendars && isAuthenticatedUser"
 					:disabled="loadingCalendars" />
+				<EditCalendarModal />
 
 				<!-- Appointment Configuration List -->
 				<template v-if="isAuthenticatedUser">
@@ -73,6 +74,7 @@ import CalendarListNew from '../components/AppNavigation/CalendarList/CalendarLi
 import EmbedTopNavigation from '../components/AppNavigation/EmbedTopNavigation.vue'
 import EmptyCalendar from '../components/EmptyCalendar.vue'
 import CalendarGrid from '../components/CalendarGrid.vue'
+import EditCalendarModal from '../components/AppNavigation/EditCalendarModal.vue'
 
 // Import CalDAV related methods
 import {
@@ -118,6 +120,7 @@ export default {
 		AppNavigationSpacer,
 		CalendarListNew,
 		Trashbin,
+		EditCalendarModal,
 	},
 	data() {
 		return {


### PR DESCRIPTION
Fix #4124  
Fix #4711 

**WIP**

## First iteration

| Calendar list item | Modal |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/1479486/201921138-40c9da58-07a1-4231-94bc-29454fe1ee6b.png) | ![image](https://user-images.githubusercontent.com/1479486/201912057-cfd44336-9fdb-4bb5-b986-155aba47e155.png) |

## Second iteration

There is no three dot menu anymore in the calendar list. There will be a single pencil icon/button which opens the modal.

![image](https://user-images.githubusercontent.com/1479486/202751438-cf53085f-9b0b-4630-9074-bdaf891bd3dd.png)