### PR TITLE
Add primary light background to month week and header

### DIFF
--- a/css/fullcalendar.scss
+++ b/css/fullcalendar.scss
@@ -93,8 +93,6 @@
 	}
 
 	.fc-daygrid-day-top {
-		background-color: var(--color-main-background);
-
 		.fc-daygrid-day-number {
 			margin: 4px;
 			width: 24px;
@@ -115,6 +113,7 @@
 // highlight current day (exclude day view)
 .fc-timeGridWeek-view,
 .fc-dayGridMonth-view {
+	.fc-col-header-cell.fc-day-today,
 	.fc-daygrid-day.fc-day-today,
 	.fc-timegrid-col.fc-day-today {
 		background-color: var(--color-primary-light) !important;


### PR DESCRIPTION
Ref https://github.com/nextcloud/calendar/pull/4540#issuecomment-1257918178

## Week view

| Before | After |
| --- | --- |
| ![week-before](https://user-images.githubusercontent.com/1479486/192484696-7c9536ea-6735-4c9f-823b-4d75a60cc58f.png) | ![week-after](https://user-images.githubusercontent.com/1479486/192484694-85333232-50b2-4a1f-8ee2-e0b267d6a17e.png) |

## Month view

| Before | After |
| --- | --- |
| ![month-before](https://user-images.githubusercontent.com/1479486/192484646-5535ae7d-f943-4807-bf96-1e5ac4ec9129.png) | ![month-after](https://user-images.githubusercontent.com/1479486/192484640-07466e07-52d3-4790-8a0f-b8ae2ca3248b.png) |