### PR TITLE
Hide sharing calendar via link in UI when sharing via link is disabled

### DIFF
--- a/lib/Controller/PublicViewController.php
+++ b/lib/Controller/PublicViewController.php
@@ -6,6 +6,7 @@ declare(strict_types=1);
  *
  * @author Georg Ehrke
  * @copyright 2019 Georg Ehrke <oc.list@georgehrke.com>
+ * @copyright Copyright (c) 2022 Informatyka Boguslawski sp. z o.o. sp.k., http://www.ib.pl/
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU AFFERO GENERAL PUBLIC LICENSE
@@ -128,6 +129,7 @@ class PublicViewController extends Controller {
 		$defaultSlotDuration = $this->config->getAppValue($this->appName, 'slotDuration', '00:30:00');
 		$defaultDefaultReminder = $this->config->getAppValue($this->appName, 'defaultReminder', 'none');
 		$defaultShowTasks = $this->config->getAppValue($this->appName, 'showTasks', 'yes');
+		$defaultCanSharePublicLink = $this->config->getAppValue('core', 'shareapi_allow_links', 'yes');
 
 		$appVersion = $this->config->getAppValue($this->appName, 'installed_version', null);
 
@@ -146,6 +148,7 @@ class PublicViewController extends Controller {
 		$this->initialStateService->provideInitialState($this->appName, 'show_tasks', $defaultShowTasks === 'yes');
 		$this->initialStateService->provideInitialState($this->appName, 'tasks_enabled', false);
 		$this->initialStateService->provideInitialState($this->appName, 'hide_event_export', false);
+		$this->initialStateService->provideInitialState($this->appName, 'can_share_public_link', $defaultCanSharePublicLink);
 
 		return new TemplateResponse($this->appName, 'main', [
 			'share_url' => $this->getShareURL(),

--- a/lib/Controller/ViewController.php
+++ b/lib/Controller/ViewController.php
@@ -6,6 +6,7 @@ declare(strict_types=1);
  *
  * @author Georg Ehrke
  * @copyright 2019 Georg Ehrke <oc.list@georgehrke.com>
+ * @copyright Copyright (c) 2022 Informatyka Boguslawski sp. z o.o. sp.k., http://www.ib.pl/
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU AFFERO GENERAL PUBLIC LICENSE
@@ -100,6 +101,7 @@ class ViewController extends Controller {
 		if (!in_array($forceEventAlarmType, ['DISPLAY', 'EMAIL'], true)) {
 			$forceEventAlarmType = false;
 		}
+		$canSharePublicLink = $this->config->getAppValue('core', 'shareapi_allow_links', 'yes') === 'yes';
 
 		$talkEnabled = $this->appManager->isEnabledForUser('spreed');
 		$talkApiVersion = version_compare($this->appManager->getAppVersion('spreed'), '12.0.0', '>=') ? 'v4' : 'v1';
@@ -123,6 +125,7 @@ class ViewController extends Controller {
 		$this->initialStateService->provideInitialState('force_event_alarm_type', $forceEventAlarmType);
 		$this->initialStateService->provideInitialState('appointmentConfigs', $this->appointmentConfigService->getAllAppointmentConfigurations($this->userId));
 		$this->initialStateService->provideInitialState('disable_appointments', $disableAppointments);
+		$this->initialStateService->provideInitialState('can_share_public_link', $canSharePublicLink);
 
 		return new TemplateResponse($this->appName, 'main');
 	}

--- a/src/components/AppNavigation/CalendarList/CalendarListItem.vue
+++ b/src/components/AppNavigation/CalendarList/CalendarListItem.vue
@@ -1,5 +1,6 @@
 <!--
   - @copyright Copyright (c) 2019 Georg Ehrke <oc.list@georgehrke.com>
+  - @copyright Copyright (c) 2022 Informatyka Boguslawski sp. z o.o. sp.k., http://www.ib.pl/
   - @author Georg Ehrke <oc.list@georgehrke.com>
   -
   - @license GNU AGPL version 3 or any later version
@@ -140,7 +141,7 @@
 		<template v-if="!deleteTimeout">
 			<div v-show="shareMenuOpen" class="sharing-section">
 				<CalendarListItemSharingSearch v-if="calendar.canBeShared" :calendar="calendar" />
-				<CalendarListItemSharingPublishItem v-if="calendar.canBePublished" :calendar="calendar" />
+				<CalendarListItemSharingPublishItem v-if="calendar.canBePublished && canSharePublicLink" :calendar="calendar" />
 				<CalendarListItemSharingShareItem v-for="sharee in calendar.shares"
 					v-show="shareMenuOpen"
 					:key="sharee.uri"
@@ -181,6 +182,7 @@ import LinkVariant from 'vue-material-design-icons/LinkVariant.vue'
 import Pencil from 'vue-material-design-icons/Pencil.vue'
 import ShareVariant from 'vue-material-design-icons/ShareVariant.vue'
 import Undo from 'vue-material-design-icons/Undo.vue'
+import { mapState } from 'vuex'
 
 export default {
 	name: 'CalendarListItem',
@@ -233,6 +235,9 @@ export default {
 		}
 	},
 	computed: {
+        ...mapState({
+            canSharePublicLink: state => state.settings.canSharePublicLink,
+        }),
 		/**
 		 * Download url of the calendar
 		 *

--- a/src/store/settings.js
+++ b/src/store/settings.js
@@ -1,5 +1,6 @@
 /**
  * @copyright Copyright (c) 2020 Georg Ehrke
+ * @copyright Copyright (c) 2022 Informatyka Boguslawski sp. z o.o. sp.k., http://www.ib.pl/
  *
  * @author Georg Ehrke <oc.list@georgehrke.com>
  *
@@ -45,6 +46,7 @@ const state = {
 	timezone: 'automatic',
 	hideEventExport: false,
 	forceEventAlarmType: false,
+	canSharePublicLink: true,
 	// user-defined Nextcloud settings
 	momentLocale: 'en',
 }
@@ -149,8 +151,9 @@ const mutations = {
 	 * @param {boolean} data.hideEventExport
 	 * @param {string} data.forceEventAlarmType
 	 * @param {boolean} data.disableAppointments Allow to disable the appointments feature
+	 * @param {boolean} data.canSharePublicLink
 	 */
-	loadSettingsFromServer(state, { appVersion, eventLimit, firstRun, showWeekNumbers, showTasks, showWeekends, skipPopover, slotDuration, defaultReminder, talkEnabled, tasksEnabled, timezone, hideEventExport, forceEventAlarmType, disableAppointments }) {
+	loadSettingsFromServer(state, { appVersion, eventLimit, firstRun, showWeekNumbers, showTasks, showWeekends, skipPopover, slotDuration, defaultReminder, talkEnabled, tasksEnabled, timezone, hideEventExport, forceEventAlarmType, disableAppointments, canSharePublicLink }) {
 		logInfo(`
 Initial settings:
 	- AppVersion: ${appVersion}
@@ -168,6 +171,7 @@ Initial settings:
 	- HideEventExport: ${hideEventExport}
 	- ForceEventAlarmType: ${forceEventAlarmType}
 	- disableAppointments: ${disableAppointments}
+	- CanSharePublicLink: ${canSharePublicLink}
 `)
 
 		state.appVersion = appVersion
@@ -185,6 +189,7 @@ Initial settings:
 		state.hideEventExport = hideEventExport
 		state.forceEventAlarmType = forceEventAlarmType
 		state.disableAppointments = disableAppointments
+		state.canSharePublicLink = canSharePublicLink
 	},
 
 	/**

--- a/src/views/Calendar.vue
+++ b/src/views/Calendar.vue
@@ -1,5 +1,6 @@
 <!--
   - @copyright Copyright (c) 2020 Georg Ehrke <oc.list@georgehrke.com>
+  - @copyright Copyright (c) 2022 Informatyka Boguslawski sp. z o.o. sp.k., http://www.ib.pl/
   - @author Georg Ehrke <oc.list@georgehrke.com>
   -
   - @license GNU AGPL version 3 or any later version
@@ -218,6 +219,7 @@ export default {
 			hideEventExport: loadState('calendar', 'hide_event_export'),
 			forceEventAlarmType: loadState('calendar', 'force_event_alarm_type', false),
 			disableAppointments: loadState('calendar', 'disable_appointments', false),
+			canSharePublicLink: loadState('calendar', 'can_share_public_link'),
 		})
 		this.$store.dispatch('initializeCalendarJsConfig')
 

--- a/tests/javascript/unit/store/settings.test.js
+++ b/tests/javascript/unit/store/settings.test.js
@@ -1,5 +1,6 @@
 /**
  * @copyright Copyright (c) 2019 Georg Ehrke
+ * @copyright Copyright (c) 2022 Informatyka Boguslawski sp. z o.o. sp.k., http://www.ib.pl/
  *
  * @author Georg Ehrke <oc.list@georgehrke.com>
  *
@@ -213,6 +214,7 @@ Initial settings:
 	- HideEventExport: false
 	- ForceEventAlarmType: false
 	- disableAppointments: false
+	- CanSharePublicLink: true
 `)
 		expect(state).toEqual({
 			appVersion: '2.1.0',
@@ -232,6 +234,7 @@ Initial settings:
 			hideEventExport: false,
 			forceEventAlarmType: false,
 			disableAppointments: false,
+			canSharePublicLink: true,
 		})
 	})
 


### PR DESCRIPTION
This mod hides sharing calendar via link in UI when `shareapi_allow_links` is disabled. Should be applied together with https://github.com/nextcloud/server/pull/34372

Related: https://github.com/nextcloud/server/pull/34372
Related: https://github.com/nextcloud/calendar/issues/525
Related: https://github.com/nextcloud/calendar/issues/4399
Author-Change-Id: IB#1126264
Signed-off-by: Pawel Boguslawski <pawel.boguslawski@ib.pl>