### PR TITLE
Ask Dependabot for GH action updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,6 +27,16 @@ updates:
     versions:
     - ">= 4.a"
     - "< 5"
+- package-ecosystem: github-actions
+  directory: "/"
+  schedule:
+    interval: daily
+    time: "03:00"
+    timezone: Europe/Paris
+  open-pull-requests-limit: 10
+  reviewers:
+    - "miaulalala"
+    - "st3iny"
 
 # stable3.5
 - package-ecosystem: npm


### PR DESCRIPTION
And assign reviewers as per https://github.com/nextcloud/groupware/issues/54.