### PR TITLE
Fix appointment details styling when in a small screen 

### DIFF
--- a/src/components/Appointments/AppointmentDetails.vue
+++ b/src/components/Appointments/AppointmentDetails.vue
@@ -148,6 +148,7 @@ export default {
 	display: flex;
 	flex-direction: row;
 	padding: 30px;
+	flex-wrap: wrap;
 }
 
 .booking-details {


### PR DESCRIPTION
fixes #4614 
after
![Screenshot from 2022-10-18 14-44-42](https://user-images.githubusercontent.com/12728974/196434211-e2a37cbd-0c19-4895-99a8-62ae4013115f.png)
