### PR TITLE
Change Appointment Config 'name' label

### DIFF
--- a/src/components/AppointmentConfigModal.vue
+++ b/src/components/AppointmentConfigModal.vue
@@ -34,7 +34,7 @@
 				<div class="appointment-config-modal__form">
 					<fieldset>
 						<TextInput class="appointment-config-modal__form__row"
-							:label="t('calendar', 'Name')"
+							:label="t('calendar', 'Appointment name')"
 							:value.sync="editing.name" />
 						<TextInput class="appointment-config-modal__form__row"
 							:label="t('calendar', 'Location')"


### PR DESCRIPTION
to 'Appointment Name' to avoid translation errors to 'Surname' in UK English
| Before: | After |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/7427347/199976005-3e7c027e-1968-4a31-bde1-cc86e24dbdb2.png) | ![image](https://user-images.githubusercontent.com/7427347/199976516-e2df7e45-0c0b-455e-bd85-98c089469314.png)|

