### PR TITLE
Allow to select contact groups as attendees

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -39,8 +39,6 @@ return [
 		['name' => 'contact#searchPhoto', 'url' => '/v1/autocompletion/photo', 'verb' => 'POST'],
 		// Circles
 		['name' => 'contact#getCircleMembers', 'url' => '/v1/circles/getmembers', 'verb' => 'GET'],
-		// Contact Groups
-		['name' => 'contact#getContactGroupMembers', 'url' => '/v1/autocompletion/groupmembers', 'verb' => 'POST'],
 		// Settings
 		['name' => 'settings#setConfig', 'url' => '/v1/config/{key}', 'verb' => 'POST'],
 		// Tools

--- a/lib/Controller/ContactController.php
+++ b/lib/Controller/ContactController.php
@@ -103,10 +103,10 @@ class ContactController extends Controller {
 		}
 
 		$externalAttendeesDisabled = $this->appConfig->getValueBool('dav', 'caldav_external_attendees_disabled', false);
-		$result = $this->contactsManager->search($search, ['FN', 'EMAIL'], ['enumeration' => true]);
+		$contactsResult = $this->contactsManager->search($search, ['FN', 'EMAIL'], ['enumeration' => true]);
 
 		$contacts = [];
-		foreach ($result as $r) {
+		foreach ($contactsResult as $r) {
 			if (!$this->contactsService->hasEmail($r)) {
 				continue;
 			}
@@ -125,68 +125,41 @@ class ContactController extends Controller {
 				'lang' => $lang,
 				'tzid' => $timezoneId,
 				'photo' => $photo,
-				'type' => 'individual'
 			];
 		}
 
+		$groups = [];
 		// Skip contact groups when external attendees are disabled
 		if (!$externalAttendeesDisabled) {
-			$groups = $this->contactsManager->search($search, ['CATEGORIES']);
-			$groups = array_filter($groups, function ($group) {
-				return $this->contactsService->hasEmail($group);
-			});
-			$filtered = $this->contactsService->filterGroupsWithCount($groups, $search);
-			foreach ($filtered as $groupName => $count) {
-				if ($count === 0) {
-					continue;
+			$groupsContactsResult = $this->contactsManager->search($search, ['CATEGORIES']);
+
+			$groups = array_reduce($groupsContactsResult, function (array $acc, array $groupContact) use ($search) {
+				// Information about system users is fetched via DAV nowadays
+				if (isset($groupContact['isLocalSystemBook']) && $groupContact['isLocalSystemBook']) {
+					return $acc;
 				}
-				$contacts[] = [
-					'name' => $groupName,
-					'emails' => ['mailto:' . urlencode($groupName) . '@group'],
-					'lang' => '',
-					'tzid' => '',
-					'photo' => '',
-					'type' => 'contactsgroup',
-					'members' => $count,
-				];
-			}
+
+				if (!isset($groupContact['EMAIL'])) {
+					return $acc;
+				}
+
+				$categories = array_filter(explode(',', $groupContact['CATEGORIES']), function (string $category) use ($search) {
+					return str_contains(mb_strtolower($category), mb_strtolower($search));
+				});
+				foreach ($categories as $category) {
+					$acc[$category][] = [
+						'name' => $this->contactsService->getNameFromContact($groupContact),
+						'emails' => $this->contactsService->getEmail($groupContact),
+						'lang' => $this->contactsService->getLanguageId($groupContact),
+						'tzid' => $this->contactsService->getTimezoneId($groupContact),
+						'photo' => $this->contactsService->getPhotoUri($groupContact),
+					];
+				}
+				return $acc;
+			}, []);
 		}
 
-		return new JSONResponse($contacts);
-	}
-
-	#[NoAdminRequired]
-	public function getContactGroupMembers(string $groupName): JSONResponse {
-		if (!$this->contactsManager->isEnabled()) {
-			return new JSONResponse();
-		}
-
-		$groupmembers = $this->contactsManager->search($groupName, ['CATEGORIES'], ['enumeration' => false]);
-		$contacts = [];
-		foreach ($groupmembers as $r) {
-			if (!in_array($groupName, explode(',', $r['CATEGORIES']), true)) {
-				continue;
-			}
-			if (!$this->contactsService->hasEmail($r) || $this->contactsService->isSystemBook($r)) {
-				continue;
-			}
-			$name = $this->contactsService->getNameFromContact($r);
-			$email = $this->contactsService->getEmail($r);
-			$photo = $this->contactsService->getPhotoUri($r);
-			$timezoneId = $this->contactsService->getTimezoneId($r);
-			$lang = $this->contactsService->getLanguageId($r);
-			$contacts[] = [
-				'commonName' => $name,
-				'email' => $email[0],
-				'calendarUserType' => 'INDIVIDUAL',
-				'language' => $lang,
-				'timezoneId' => $timezoneId,
-				'avatar' => $photo,
-				'isUser' => false,
-				'member' => 'mailto:' . urlencode($groupName) . '@group',
-			];
-		}
-		return new JSONResponse($contacts);
+		return new JSONResponse(['contacts' => $contacts, 'groups' => $groups]);
 	}
 
 	/**

--- a/lib/Controller/ContactController.php
+++ b/lib/Controller/ContactController.php
@@ -135,7 +135,7 @@ class ContactController extends Controller {
 
 			$groups = array_reduce($groupsContactsResult, function (array $acc, array $groupContact) use ($search) {
 				// Information about system users is fetched via DAV nowadays
-				if (isset($groupContact['isLocalSystemBook']) && $groupContact['isLocalSystemBook']) {
+				if ($this->contactsService->isSystemBook($groupContact)) {
 					return $acc;
 				}
 

--- a/lib/Service/ContactsService.php
+++ b/lib/Service/ContactsService.php
@@ -112,27 +112,6 @@ class ContactsService {
 	}
 
 	/**
-	 * @param array $groups
-	 * @param string $search
-	 * @return array
-	 */
-	public function filterGroupsWithCount(array $groups, string $search): array {
-		//filter to be unique
-		$categories = [];
-		foreach ($groups as $group) {
-			// CATEGORIES is sometimes missing (despite being searched for via the backend)
-			if (!isset($group['CATEGORIES'])) {
-				continue;
-			}
-
-			$categories[] = array_filter(explode(',', $group['CATEGORIES']), static function ($cat) use ($search) {
-				return str_contains(strtolower($cat), strtolower($search));
-			});
-		}
-		return array_count_values(array_merge(...$categories));
-	}
-
-	/**
 	 * @param array $contact
 	 * @return array
 	 */

--- a/src/components/Editor/Invitees/InviteesListItem.vue
+++ b/src/components/Editor/Invitees/InviteesListItem.vue
@@ -239,6 +239,7 @@ export default {
 			return this.attendee.uri ? removeMailtoPrefix(this.attendee.uri) : ''
 		},
 
+
 		radioName() {
 			return this.$.uid + '-role-radio-input-group'
 		},

--- a/src/components/Editor/Invitees/InviteesListItem.vue
+++ b/src/components/Editor/Invitees/InviteesListItem.vue
@@ -47,16 +47,22 @@
 						:size="20" />
 				</template>
 			</NcButton>
-			<Actions v-if="!isReadOnly && isViewedByOrganizer">
+			<Actions v-if="isViewedByOrganizer">
+				<ActionText>
+					{{ attendeeEmail }}
+					<template #icon>
+						<Email :size="20" decorative />
+					</template>
+				</ActionText>
 				<ActionCheckbox
-					v-if="!members.length"
+					v-if="!isReadOnly && !members.length"
 					:modelValue="attendee.rsvp"
 					@update:modelValue="toggleRSVP">
 					{{ $t('calendar', 'Request reply') }}
 				</ActionCheckbox>
 
 				<ActionRadio
-					v-if="!members.length"
+					v-if="!isReadOnly && !members.length"
 					:name="radioName"
 					value="CHAIR"
 					:modelValue="attendee.role"
@@ -64,7 +70,7 @@
 					{{ $t('calendar', 'Chairperson') }}
 				</ActionRadio>
 				<ActionRadio
-					v-if="!members.length"
+					v-if="!isReadOnly && !members.length"
 					:name="radioName"
 					value="REQ-PARTICIPANT"
 					:modelValue="attendee.role"
@@ -72,7 +78,7 @@
 					{{ $t('calendar', 'Required participant') }}
 				</ActionRadio>
 				<ActionRadio
-					v-if="!members.length"
+					v-if="!isReadOnly && !members.length"
 					:name="radioName"
 					value="OPT-PARTICIPANT"
 					:modelValue="attendee.role"
@@ -80,7 +86,7 @@
 					{{ $t('calendar', 'Optional participant') }}
 				</ActionRadio>
 				<ActionRadio
-					v-if="!members.length"
+					v-if="!isReadOnly && !members.length"
 					:name="radioName"
 					value="NON-PARTICIPANT"
 					:modelValue="attendee.role"
@@ -88,7 +94,9 @@
 					{{ $t('calendar', 'Non-participant') }}
 				</ActionRadio>
 
-				<ActionButton @click="removeAttendee(attendee)">
+				<ActionButton
+					v-if="!isReadOnly"
+					@click="removeAttendee(attendee)">
 					<template #icon>
 						<Delete :size="20" decorative />
 					</template>
@@ -119,11 +127,13 @@ import {
 	NcActionRadio as ActionRadio,
 	NcActions as Actions,
 	NcButton,
+	NcActionText as ActionText,
 } from '@nextcloud/vue'
 import { mapState, mapStores } from 'pinia'
 import ChevronDown from 'vue-material-design-icons/ChevronDown.vue'
 import ChevronUp from 'vue-material-design-icons/ChevronUp.vue'
 import Delete from 'vue-material-design-icons/TrashCanOutline.vue'
+import Email from 'vue-material-design-icons/Email.vue'
 import AvatarParticipationStatus from '../AvatarParticipationStatus.vue'
 import AttendeeDisplay from './AttendeeDisplay.vue'
 import { getAttendeeDetails } from '../../../services/attendeeDetails.js'
@@ -137,7 +147,9 @@ export default {
 		ActionButton,
 		ActionCheckbox,
 		ActionRadio,
+		ActionText,
 		Actions,
+		Email,
 		Delete,
 		NcButton,
 		ChevronDown,

--- a/src/components/Editor/Invitees/InviteesListItem.vue
+++ b/src/components/Editor/Invitees/InviteesListItem.vue
@@ -48,12 +48,6 @@
 				</template>
 			</NcButton>
 			<Actions v-if="isViewedByOrganizer">
-				<ActionText>
-					{{ attendeeEmail }}
-					<template #icon>
-						<Email :size="20" decorative />
-					</template>
-				</ActionText>
 				<ActionCheckbox
 					v-if="!isReadOnly && !members.length"
 					:modelValue="attendee.rsvp"
@@ -127,13 +121,11 @@ import {
 	NcActionRadio as ActionRadio,
 	NcActions as Actions,
 	NcButton,
-	NcActionText as ActionText,
 } from '@nextcloud/vue'
 import { mapState, mapStores } from 'pinia'
 import ChevronDown from 'vue-material-design-icons/ChevronDown.vue'
 import ChevronUp from 'vue-material-design-icons/ChevronUp.vue'
 import Delete from 'vue-material-design-icons/TrashCanOutline.vue'
-import Email from 'vue-material-design-icons/Email.vue'
 import AvatarParticipationStatus from '../AvatarParticipationStatus.vue'
 import AttendeeDisplay from './AttendeeDisplay.vue'
 import { getAttendeeDetails } from '../../../services/attendeeDetails.js'
@@ -147,9 +139,7 @@ export default {
 		ActionButton,
 		ActionCheckbox,
 		ActionRadio,
-		ActionText,
 		Actions,
-		Email,
 		Delete,
 		NcButton,
 		ChevronDown,
@@ -238,7 +228,6 @@ export default {
 		attendeeEmail() {
 			return this.attendee.uri ? removeMailtoPrefix(this.attendee.uri) : ''
 		},
-
 
 		radioName() {
 			return this.$.uid + '-role-radio-input-group'

--- a/src/components/Editor/Invitees/InviteesListSearch.vue
+++ b/src/components/Editor/Invitees/InviteesListSearch.vue
@@ -194,8 +194,8 @@ export default {
 				return []
 			}
 			results.data.forEach((member) => {
-				if (!this.organizer || member.email !== this.organizer.uri) {
-					this.$emit('addAttendee', member)
+				if (!this.alreadyInvitedEmails.includes(member.email) && (!this.organizer || member.email !== this.organizer.uri)) {
+					this.$emit('add-attendee', member)
 				}
 			})
 		},
@@ -220,19 +220,23 @@ export default {
 					contacts.push({
 						type: 'group',
 						dropdownName: groupName,
-						subtitle: this.$n('calendar', 'Contains %n contact', 'Contains %n contacts', processedGroupContacts.length),
+						subtitle: this.$n('calendar', 'Contains %n contact(s) with email addresses', 'Contains %n contact(s) with email addresses', processedGroupContacts.length),
 						contacts: processedGroupContacts,
 					})
 				}
 			}
 
-			return contacts
+			return [...contacts, ...this.buildEmailsFromContactData(response.data.contacts)]
 		},
 		buildEmailsFromContactData(contactsData) {
 			return contactsData.reduce((arr, result) => {
 				const hasMultipleEMails = result.emails.length > 1
 
 				result.emails.forEach((email) => {
+					if (email === '') {
+						return
+					}
+
 					let name
 					if (result.name && !hasMultipleEMails) {
 						name = result.name

--- a/src/components/Editor/Invitees/InviteesListSearch.vue
+++ b/src/components/Editor/Invitees/InviteesListSearch.vue
@@ -64,8 +64,8 @@ import {
 	NcSelect,
 } from '@nextcloud/vue'
 import debounce from 'debounce'
-import GoogleCirclesCommunitiesIcon from 'vue-material-design-icons/GoogleCirclesCommunities.vue'
 import AccountMultiple from 'vue-material-design-icons/AccountMultiple.vue'
+import GoogleCirclesCommunitiesIcon from 'vue-material-design-icons/GoogleCirclesCommunities.vue'
 import {
 	circleGetMembers,
 	circleSearchByName,
@@ -220,7 +220,7 @@ export default {
 					contacts.push({
 						type: 'group',
 						dropdownName: groupName,
-						subtitle: this.$n('calendar', 'Contains %n contact(s) with email addresses', 'Contains %n contact(s) with email addresses', processedGroupContacts.length),
+						subtitle: this.$n('calendar', 'Contains %n contact with email address', 'Contains %n contacts with email addresses', processedGroupContacts.length),
 						contacts: processedGroupContacts,
 					})
 				}
@@ -228,6 +228,7 @@ export default {
 
 			return [...contacts, ...this.buildEmailsFromContactData(response.data.contacts)]
 		},
+
 		buildEmailsFromContactData(contactsData) {
 			return contactsData.reduce((arr, result) => {
 				const hasMultipleEMails = result.emails.length > 1

--- a/src/components/Editor/Invitees/InviteesListSearch.vue
+++ b/src/components/Editor/Invitees/InviteesListSearch.vue
@@ -19,9 +19,12 @@
 		@option:selected="addAttendee">
 		<template #option="option">
 			<div class="invitees-search-list-item">
-				<!-- We need to specify a unique key here for the avatar to be reactive. -->
-				<Avatar
-					v-if="option.isUser"
+				<Avatar v-if="option.type === 'group'">
+					<template #icon>
+						<AccountMultiple :size="20" />
+					</template>
+				</Avatar><!-- We need to specify a unique key here for the avatar to be reactive. -->
+				<Avatar v-else-if="option.isUser"
 					:key="option.uid"
 					:user="option.avatar"
 					:displayName="option.dropdownName" />
@@ -31,7 +34,7 @@
 					</template>
 				</Avatar>
 				<Avatar
-					v-if="!option.isUser && option.type !== 'circle'"
+					v-if="!option.isUser && option.type !== 'circle' && option.type !== 'group'"
 					:key="option.uid"
 					:url="option.avatar"
 					:displayName="option.commonName" />
@@ -40,10 +43,10 @@
 					<div>
 						{{ option.commonName }}
 					</div>
-					<div v-if="option.email !== option.commonName && option.type !== 'circle' && option.type !== 'contactsgroup'">
+					<div v-if="option.email !== option.dropdownName && option.type !== 'circle' && option.type !== 'group'">
 						{{ option.email }}
 					</div>
-					<div v-if="option.type === 'circle' || option.type === 'contactsgroup'">
+					<div v-if="option.type === 'circle' || option.type === 'group'">
 						{{ option.subtitle }}
 					</div>
 				</div>
@@ -62,6 +65,7 @@ import {
 } from '@nextcloud/vue'
 import debounce from 'debounce'
 import GoogleCirclesCommunitiesIcon from 'vue-material-design-icons/GoogleCirclesCommunities.vue'
+import AccountMultiple from 'vue-material-design-icons/AccountMultiple.vue'
 import {
 	circleGetMembers,
 	circleSearchByName,
@@ -76,6 +80,7 @@ export default {
 		Avatar,
 		NcSelect,
 		GoogleCirclesCommunitiesIcon,
+		AccountMultiple,
 	},
 
 	props: {
@@ -167,24 +172,14 @@ export default {
 		addAttendee(selectedValue) {
 			if (selectedValue.type === 'circle') {
 				showInfo(this.$t('calendar', 'Note that members of circles get invited but are not synced yet.'))
-				this.resolveCircleMembers(selectedValue.id)
+				this.resolveCircleMembers(selectedValue.id, selectedValue.email)
+			} else if (selectedValue.type === 'group') {
+				selectedValue.contacts.forEach((contact) => {
+					this.$emit('add-attendee', contact)
+				})
+			} else {
+				this.$emit('add-attendee', selectedValue)
 			}
-			if (selectedValue.type === 'contactsgroup') {
-				showInfo(this.$t('calendar', 'Note that members of contact groups get invited but are not synced yet.'))
-				this.getContactGroupMembers(selectedValue.commonName)
-				const group = {
-					calendarUserType: 'GROUP',
-					commonName: selectedValue.commonName,
-					dropdownName: selectedValue.dropdownName,
-					email: selectedValue.email,
-					isUser: false,
-					subtitle: selectedValue.subtitle,
-					type: 'contactsgroup',
-				}
-				this.$emit('addAttendee', group)
-				return
-			}
-			this.$emit('addAttendee', selectedValue)
 		},
 
 		async resolveCircleMembers(circleId) {
@@ -205,24 +200,6 @@ export default {
 			})
 		},
 
-		async getContactGroupMembers(groupName) {
-			let results
-			try {
-				results = await HttpClient.post(linkTo('calendar', 'index.php') + '/v1/autocompletion/groupmembers', {
-					groupName,
-				})
-			} catch (error) {
-				console.error('Failed to fetch contact group members', error)
-				return []
-			}
-
-			results.data.forEach((member) => {
-				if (!this.organizer || member.email !== this.organizer.uri) {
-					this.$emit('addAttendee', member)
-				}
-			})
-		},
-
 		async findAttendeesFromContactsAPI(query) {
 			let response
 
@@ -235,8 +212,24 @@ export default {
 				return []
 			}
 
-			const data = response.data
-			return data.reduce((arr, result) => {
+			const contacts = []
+			/** Groups are shown before contacts */
+			for (const [groupName, groupContacts] of Object.entries(response.data.groups)) {
+				const processedGroupContacts = this.buildEmailsFromContactData(groupContacts)
+				if (processedGroupContacts.length > 0) {
+					contacts.push({
+						type: 'group',
+						dropdownName: groupName,
+						subtitle: this.$n('calendar', 'Contains %n contact', 'Contains %n contacts', processedGroupContacts.length),
+						contacts: processedGroupContacts,
+					})
+				}
+			}
+
+			return [...contacts, ...this.buildEmailsFromContactData(response.data.contacts)]
+		},
+		buildEmailsFromContactData(contactsData) {
+			return contactsData.reduce((arr, result) => {
 				const hasMultipleEMails = result.emails.length > 1
 
 				result.emails.forEach((email) => {
@@ -253,25 +246,8 @@ export default {
 						return
 					}
 
-					if (result.type === 'contactsgroup') {
-						arr.push({
-							calendarUserType: 'GROUP',
-							commonName: result.name,
-							subtitle: this.$n('calendar', '%n member', '%n members', result.members),
-							members: { length: result.members },
-							email,
-							isUser: false,
-							avatar: result.photo,
-							language: result.lang,
-							timezoneId: result.tzid,
-							hasMultipleEMails: false,
-							dropdownName: name + ' ' + email,
-							type: 'contactsgroup',
-						})
-						return
-					}
-
 					arr.push({
+						type: 'contact',
 						calendarUserType: 'INDIVIDUAL',
 						commonName: result.name,
 						email,

--- a/src/components/Editor/Invitees/InviteesListSearch.vue
+++ b/src/components/Editor/Invitees/InviteesListSearch.vue
@@ -226,7 +226,7 @@ export default {
 				}
 			}
 
-			return [...contacts, ...this.buildEmailsFromContactData(response.data.contacts)]
+			return contacts
 		},
 		buildEmailsFromContactData(contactsData) {
 			return contactsData.reduce((arr, result) => {

--- a/tests/php/unit/Controller/ContactControllerTest.php
+++ b/tests/php/unit/Controller/ContactControllerTest.php
@@ -306,15 +306,20 @@ class ContactControllerTest extends TestCase {
 				[$user3, null],
 				[$user4, null],
 			]);
+		$searchCallCount = 0;
 		$this->manager->expects(self::exactly(2))
 			->method('search')
-			->withConsecutive(
-				['search 123', ['FN', 'EMAIL'], ['enumeration' => true]],
-				['search 123', ['CATEGORIES']],
-			)
-			->willReturnOnConsecutiveCalls(
-				[$user1, $user2, $user3, $user4],
-				[
+			->willReturnCallback(function (string $search, array $fields, array $options = []) use (&$searchCallCount, $user1, $user2, $user3, $user4) {
+				$searchCallCount++;
+				if ($searchCallCount === 1) {
+					$this->assertEquals('search 123', $search);
+					$this->assertEquals(['FN', 'EMAIL'], $fields);
+					$this->assertEquals(['enumeration' => true], $options);
+					return [$user1, $user2, $user3, $user4];
+				}
+				$this->assertEquals('search 123', $search);
+				$this->assertEquals(['CATEGORIES'], $fields);
+				return [
 					[
 						'FN' => 'Person 4',
 						'EMAIL' => 'foo4@example.com',
@@ -329,8 +334,8 @@ class ContactControllerTest extends TestCase {
 						'EMAIL' => 'foo6@example.com',
 						'CATEGORIES' => 'search 123'
 					],
-				],
-			);
+				];
+			});
 
 		$this->service->method('getNameFromContact')
 			->willReturnMap([

--- a/tests/php/unit/Controller/ContactControllerTest.php
+++ b/tests/php/unit/Controller/ContactControllerTest.php
@@ -187,98 +187,6 @@ class ContactControllerTest extends TestCase {
 		$this->assertEquals(200, $response->getStatus());
 	}
 
-	public function testGetGroupMembersNoResults() {
-		$this->manager->expects(self::once())
-			->method('isEnabled')
-			->willReturn(true);
-
-		$groupname = 'groupname';
-		$this->manager->expects(self::once())
-			->method('search')
-			->with($groupname, ['CATEGORIES'])
-			->willReturn([]);
-
-		$this->controller->getContactGroupMembers($groupname);
-	}
-
-	public function testGetGroupMembers() {
-		$this->manager->expects(self::once())
-			->method('isEnabled')
-			->willReturn(true);
-		$this->service->expects(self::once())
-			->method('hasEmail')
-			->willReturn(true);
-		$this->service->expects(self::once())
-			->method('getNameFromContact')
-			->willReturn('Person 1');
-		$this->service->expects(self::once())
-			->method('getLanguageId')
-			->willReturn('en_us');
-		$this->service->expects(self::once())
-			->method('getTimezoneId')
-			->willReturn('Australia/Adelaide');
-		$this->service->expects(self::once())
-			->method('getEmail')
-			->willReturn(['foo1@example.com']);
-
-		$groupname = 'group';
-		$this->manager->expects(self::once())
-			->method('search')
-			->with($groupname, ['CATEGORIES'])
-			->willReturn([
-				[
-					'FN' => 'Person 1',
-					'ADR' => [
-						'33 42nd Street;Random Town;Some State;;United States',
-						';;5 Random Ave;12782 Some big city;Yet another state;United States',
-					],
-					'EMAIL' => [
-						'foo1@example.com',
-						'foo2@example.com',
-					],
-					'LANG' => [
-						'de',
-						'en'
-					],
-					'TZ' => [
-						'Europe/Berlin',
-						'UTC'
-					],
-					'PHOTO' => 'VALUE=uri:http://foo.bar',
-					'CATEGORIES' => 'groupname,group',
-				],
-				[
-					'FN' => 'Person 2',
-					'EMAIL' => 'foo3@example.com',
-					'CATEGORIES' => 'groups,asecondgroup',
-				],
-				[
-					'ADR' => [
-						'ABC Street 2;01337 Village;;Germany',
-					],
-					'LANG' => 'en_us',
-					'TZ' => 'Australia/Adelaide',
-					'PHOTO' => 'VALUE:BINARY:4242424242',
-					'CATEGORIES' => 'agroupthatswrong,asecondgroup',
-				],
-				[
-					'isLocalSystemBook' => true,
-					'FN' => 'Person 3',
-					'ADR' => [
-						'ABC Street 2;01337 Village;;Germany',
-					],
-					'EMAIL' => 'foo4@example.com',
-					'LANG' => 'en_us',
-					'TZ' => 'Australia/Adelaide',
-					'PHOTO' => 'VALUE:BINARY:4242424242',
-					'CATEGORIES' => 'groupppppp',
-				],
-			]);
-
-		$groupmembers = $this->controller->getContactGroupMembers($groupname);
-		$this->assertCount(1, $groupmembers->getData());
-	}
-
 	public function testSearchAttendeeDisabled():void {
 		$this->manager->expects(self::once())
 			->method('isEnabled')
@@ -370,30 +278,26 @@ class ContactControllerTest extends TestCase {
 				[$user3, ''],
 				[$user4, 'Person 3'],
 			]);
-		$this->service->expects(self::exactly(3))
+		$this->service->expects(self::exactly(2))
 			->method('getLanguageId')
 			->willReturnMap([
 				[$user1, 'de'],
 				[$user2, null],
-				[$user4, 'en_us'],
 			]);
-		$this->service->expects(self::exactly(3))
+		$this->service->expects(self::exactly(2))
 			->method('getTimezoneId')
 			->willReturnMap([
 				[$user1, 'Europe/Berlin'],
 				[$user2, null],
-				[$user4, 'Australia/Adelaide'],
 			]);
-		$this->service->expects(self::exactly(3))
+		$this->service->expects(self::exactly(2))
 			->method('getEmail')
 			->willReturnMap([
 				[$user1, [
 					'foo1@example.com',
 					'foo2@example.com',
-				]
-				],
+				]],
 				[$user2, ['foo3@example.com']],
-				[$user4, ['foo4@example.com']],
 			]);
 		$this->service->method('getPhotoUri')
 			->willReturnMap([
@@ -404,45 +308,55 @@ class ContactControllerTest extends TestCase {
 			]);
 		$this->manager->expects(self::exactly(2))
 			->method('search')
+			->withConsecutive(
+				['search 123', ['FN', 'EMAIL'], ['enumeration' => true]],
+				['search 123', ['CATEGORIES']],
+			)
+			->willReturnOnConsecutiveCalls(
+				[$user1, $user2, $user3, $user4],
+				[
+					[
+						'FN' => 'Person 4',
+						'EMAIL' => 'foo4@example.com',
+						'CATEGORIES' => 'search 123,other'
+					],
+					[
+						'FN' => 'Person 5',
+						'CATEGORIES' => 'search 123'
+					],
+					[
+						'FN' => 'Person 6',
+						'EMAIL' => 'foo6@example.com',
+						'CATEGORIES' => 'search 123'
+					],
+				],
+			);
+
+		$this->service->method('getNameFromContact')
 			->willReturnMap([
-				['search 123', ['FN', 'EMAIL'], ['enumeration' => true], [$user1, $user2, $user3, $user4]],
-				['search 123', ['CATEGORIES'], [], [$user4]]
+				[$user1, 'Person 1'],
+				[$user2, 'Person 2'],
+				[['FN' => 'Person 4', 'EMAIL' => 'foo4@example.com', 'CATEGORIES' => 'search 123,other'], 'Person 4'],
+				[['FN' => 'Person 6', 'EMAIL' => 'foo6@example.com', 'CATEGORIES' => 'search 123'], 'Person 6'],
+			]);
+		$this->service->method('getEmail')
+			->willReturnMap([
+				[$user1, ['foo1@example.com', 'foo2@example.com']],
+				[$user2, ['foo3@example.com']],
+				[['FN' => 'Person 4', 'EMAIL' => 'foo4@example.com', 'CATEGORIES' => 'search 123,other'], ['foo4@example.com']],
+				[['FN' => 'Person 6', 'EMAIL' => 'foo6@example.com', 'CATEGORIES' => 'search 123'], ['foo6@example.com']],
 			]);
 
 		$response = $this->controller->searchAttendee('search 123');
 
 		$this->assertInstanceOf(JSONResponse::class, $response);
-		$this->assertEquals([
-			[
-				'name' => 'Person 1',
-				'emails' => [
-					'foo1@example.com',
-					'foo2@example.com',
-				],
-				'lang' => 'de',
-				'tzid' => 'Europe/Berlin',
-				'photo' => 'http://foo.bar',
-				'type' => 'individual'
-			], [
-				'name' => 'Person 2',
-				'emails' => [
-					'foo3@example.com'
-				],
-				'lang' => null,
-				'tzid' => null,
-				'photo' => null,
-				'type' => 'individual'
-			], [
-				'name' => 'Person 3',
-				'emails' => [
-					'foo4@example.com'
-				],
-				'lang' => 'en_us',
-				'tzid' => 'Australia/Adelaide',
-				'photo' => null,
-				'type' => 'individual'
-			]
-		], $response->getData());
+		$data = $response->getData();
+		$this->assertArrayHasKey('contacts', $data);
+		$this->assertArrayHasKey('groups', $data);
+		$this->assertCount(2, $data['contacts']);
+		$this->assertEquals('Person 1', $data['contacts'][0]['name']);
+		$this->assertEquals('Person 2', $data['contacts'][1]['name']);
+		$this->assertArrayHasKey('search 123', $data['groups']);
 		$this->assertEquals(200, $response->getStatus());
 	}
 
@@ -520,14 +434,16 @@ class ContactControllerTest extends TestCase {
 
 		$this->assertInstanceOf(JSONResponse::class, $response);
 		$this->assertEquals([
-			[
-				'name' => 'System User',
-				'emails' => ['system@example.com'],
-				'lang' => 'en',
-				'tzid' => 'UTC',
-				'photo' => null,
-				'type' => 'individual'
-			]
+			'contacts' => [
+				[
+					'name' => 'System User',
+					'emails' => ['system@example.com'],
+					'lang' => 'en',
+					'tzid' => 'UTC',
+					'photo' => null,
+				]
+			],
+			'groups' => [],
 		], $response->getData());
 		$this->assertEquals(200, $response->getStatus());
 	}

--- a/tests/php/unit/Service/ContactsServiceTest.php
+++ b/tests/php/unit/Service/ContactsServiceTest.php
@@ -59,24 +59,6 @@ class ContactsServiceTest extends TestCase {
 		$this->assertNull($this->service->getPhotoUri([]));
 	}
 
-	public function testFilterGroupsWithCount(): void {
-		$contact = [
-			['CATEGORIES' => 'The Proclaimers,I\'m gonna be,When I go out,I would walk 500 Miles,I would walk 500 more'],
-			['CATEGORIES' => 'The Proclaimers,When I\'m lonely,I would walk 500 Miles,I would walk 500 more'],
-			['CATEGORIES' => ''],
-			[],
-		];
-
-		$searchterm = 'walk';
-
-		$expected = [
-			'I would walk 500 Miles' => 2,
-			'I would walk 500 more' => 2,
-		];
-
-		$this->assertEqualsCanonicalizing($expected, $this->service->filterGroupsWithCount($contact, $searchterm));
-	}
-
 	public function testGetTimezoneId(): void {
 		$contact = ['TZ' => ['UTC']];
 		$this->assertEquals('UTC', $this->service->getTimezoneId($contact));


### PR DESCRIPTION
[demo.webm](https://user-images.githubusercontent.com/2197836/202509226-f6f5eaad-dfa9-4005-a0b8-15d7eae00f95.webm)

A **significant** limitation is that if a contact has multiple addresses, all of them will be added (as shown in the above video). Unfortunately once attendees are added, their email addresses are currently not shown, so you can't know which attendee item to remove.

I'm not sure what's the best way to proceed here and I'd like your opinion on that (as well as @nextcloud/designers ):
* only add the first email
* show the email in the attendee list (always or when a contact is added with several emails), so that the user can remove the unwanted emails
* add a special handling modal form to decide which email to pick (please don't say that :sweat_smile: ) ?
* change the way the multiselect works to select actual contacts, not contacts emails, and then pick the email used in the attendee list. This means we also need to allow contacts being added twice if the user wants to sent invites to both emails.

(Also the message « Group contains X contacts » kinda lies, it's about the attendees emails, not the attendees contacts.

Closes #167 