### PR TITLE
Fix dashboard calendar icon in dark mode

### DIFF
--- a/css/dashboard.css
+++ b/css/dashboard.css
@@ -1,3 +1,3 @@
 .app-icon-calendar {
-	background-image: url('../img/calendar-dark.svg');
+	background-image: var(--icon-calendar-dark);
 }


### PR DESCRIPTION
The fix enables dynamic switching to a white icon in dark mode. It is stuck to the black icon at the moment.

Signed-off-by: Bernhard Rohloff <rohloff.bernhard@gmail.com>