### PR TITLE
Fix black calendar icon on dashboard widget in dark mode

### DIFF
--- a/css/dashboard.css
+++ b/css/dashboard.css
@@ -1,3 +1,4 @@
 .app-icon-calendar {
 	background-image: url('../img/calendar-dark.svg');
+  filter: var(--background-invert-if-dark);
 }


### PR DESCRIPTION
Second attempt. ;-)
This should fix the black calendar icon and leave the icon in the customization modal untouched.