### PR TITLE
Fix timezone multi-select popup

### DIFF
--- a/src/components/Shared/DatePicker.vue
+++ b/src/components/Shared/DatePicker.vue
@@ -423,4 +423,8 @@ export default {
 ::v-deep .mx-icon-calendar {
 	right: 0;
 }
+::v-deep .multiselect__content-wrapper {
+	border: none !important;
+	position: relative !important;
+}
 </style>


### PR DESCRIPTION
hack approved by John 
before
![Screenshot from 2022-12-01 11-41-02](https://user-images.githubusercontent.com/12728974/205032139-4c904662-035f-4bf6-9fac-5243c421e124.png)
after
![Screenshot from 2022-12-01 11-39-51](https://user-images.githubusercontent.com/12728974/205032146-6f6be92b-5e90-4df7-9705-bae6a174bd44.png)

the popover jumps a bit when clicking, that is fixed on vue 7.1.0
needs 

- [x] https://github.com/nextcloud/calendar/pull/4776
