### PR TITLE
Compare userId instead of email to exclude current user

### DIFF
--- a/src/components/Editor/Invitees/InviteesList.vue
+++ b/src/components/Editor/Invitees/InviteesList.vue
@@ -132,14 +132,7 @@ export default {
 			return !this.calendarObjectInstance.organizer && this.invitees.length === 0
 		},
 		alreadyInvitedEmails() {
-			const emails = this.invitees.map(attendee => removeMailtoPrefix(attendee.uri))
-
-			const principal = this.$store.getters.getCurrentUserPrincipal
-			if (principal) {
-				emails.push(principal.emailAddress)
-			}
-
-			return emails
+			return this.invitees.map(attendee => removeMailtoPrefix(attendee.uri))
 		},
 		hasUserEmailAddress() {
 			const principal = this.$store.getters.getCurrentUserPrincipal

--- a/src/components/Editor/Invitees/InviteesListSearch.vue
+++ b/src/components/Editor/Invitees/InviteesListSearch.vue
@@ -213,6 +213,10 @@ export default {
 					return false
 				}
 
+				if (this.$store.getters.getCurrentUserPrincipal?.userId === principal.userId) {
+					return false
+				}
+
 				// We do not support GROUPS for now
 				if (principal.calendarUserType === 'GROUP') {
 					return false


### PR DESCRIPTION
Right now, if Alice and Bob share the same address email, Alice won't be able to find Bob in the invitee list.

This PR improves the cleaning of the list by comparing userIds instead of email address.