### PR TITLE
fix: calendar export button

### DIFF
--- a/src/components/AppNavigation/EditCalendarModal.vue
+++ b/src/components/AppNavigation/EditCalendarModal.vue
@@ -64,7 +64,7 @@
 					</template>
 					{{ $t('calendar', 'Copy private link') }}
 				</NcButton>
-				<NcButton :to="downloadUrl">
+				<NcButton :href="downloadUrl">
 					<template #icon>
 						<DownloadIcon :size="20" />
 					</template>


### PR DESCRIPTION
Fix #4844

We shouldn't use a vue-router link (`:to`) if we just want to trigger a download.