### PR TITLE
fix: debounce calendar modal save and edit methods

### DIFF
--- a/src/components/AppNavigation/EditCalendarModal.vue
+++ b/src/components/AppNavigation/EditCalendarModal.vue
@@ -160,10 +160,10 @@ export default {
 	},
 	watch: {
 		async calendarColor() {
-			await this.saveColor()
+			await this.saveColorDebounced()
 		},
 		async calendarName() {
-			await this.saveName()
+			await this.saveNameDebounced()
 		},
 		editCalendarModal(value) {
 			if (!value) {


### PR DESCRIPTION
Fix https://github.com/nextcloud/calendar/issues/4890

Thanks to @raimund-schluessler for spotting the issue.