### PR TITLE
perf(autoloader): Use Composer's authoritative classmap

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,15 @@
         "platform": {
             "php": "8.0"
         },
-        "sort-packages": true
+        "sort-packages": true,
+        "optimize-autoloader": true,
+        "classmap-authoritative": true,
+        "autoloader-suffix": "Calendar"
+    },
+    "autoload": {
+        "psr-4": {
+            "OCA\\Calendar\\": "lib/"
+        }
     },
     "require": {
         "php": ">=8.0 <=8.2"

--- a/composer/autoload.php
+++ b/composer/autoload.php
@@ -1,0 +1,5 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../vendor/autoload.php';


### PR DESCRIPTION
Theoretically this could speed things up but I'm not able to proof that with blackfire nor simple timings.

## Before optimizing all four Groupware apps

![Bildschirmfoto vom 2023-01-20 13-21-55](https://user-images.githubusercontent.com/1374172/213693980-e3112c33-568b-44c3-ba0c-71bfe8e52d90.png)

## After optimizing all four Groupware apps

![Bildschirmfoto vom 2023-01-20 13-22-06](https://user-images.githubusercontent.com/1374172/213693976-c15ddc30-1f20-4f65-859a-3da7603e270f.png)