### PR TITLE
[stable4.2] chore: cleanup php versions in workflows

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-versions: ['7.4', '8.0', '8.1', '8.2']
+        php-versions: ['7.4', '8.0', '8.1']
     name: php${{ matrix.php-versions }} lint
     steps:
       - name: Checkout

--- a/.github/workflows/php-test.yml
+++ b/.github/workflows/php-test.yml
@@ -6,8 +6,11 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-versions: ['7.4', '8.0', '8.1', '8.2']
+        php-versions: ['8.0', '8.1']
         nextcloud-versions: ['master', 'stable25']
+        include:
+          php-versions: '7.4'
+          nextcloud-versions: 'stable25'
     name: php${{ matrix.php-versions }} on ${{ matrix.nextcloud-versions }} unit tests
     env:
       CI: true
@@ -21,9 +24,6 @@ jobs:
         coverage: xdebug
     - name: Checkout Nextcloud
       run: git clone https://github.com/nextcloud/server.git --recursive --depth 1 -b ${{ matrix.nextcloud-versions }} nextcloud
-    - name: Patch version check for nightly PHP
-      if: ${{ matrix.php-versions == '8.2' }}
-      run: echo "<?php" > nextcloud/lib/versioncheck.php
     - name: Install Nextcloud
       run: php -f nextcloud/occ maintenance:install --database-name oc_autotest --database-user oc_autotest --admin-user admin --admin-pass admin --database sqlite --database-pass=''
     - name: Checkout the app


### PR DESCRIPTION
- PHP 7.4 can't be tested against server master as is it isn't supported anymore. But we can at least test it against server stable25.
- PHP 8.2 doesn't need to be tested against as it isn't supported by this branch.

This also saves some runner time.