### PR TITLE
feat(caldav): Add calendar timezone picker

### DIFF
--- a/src/store/calendars.js
+++ b/src/store/calendars.js
@@ -175,6 +175,18 @@ const mutations = {
 	},
 
 	/**
+	 * Set a calendar's timezone
+	 *
+	 * @param {object} state the store mutations
+	 * @param {object} data destructuring object
+	 * @param {object} data.calendar the calendar to modify
+	 * @param {string} data.timezone the new timezone of the calendar
+	 */
+	setCalendarTimezone(state, { calendar, timezone }) {
+		state.calendarsById[calendar.id].timezone = timezone
+	},
+
+	/**
 	 * Changes calendar's color
 	 *
 	 * @param {object} state the store mutations
@@ -866,6 +878,28 @@ const actions = {
 
 		await calendar.dav.update()
 		context.commit('renameCalendar', { calendar, newName })
+	},
+
+	/**
+	 * Set a calendar's timezone
+	 *
+	 * @param {object} context the store mutations Current context
+	 * @param {object} data destructuring object
+	 * @param {object} data.calendar the calendar to modify
+	 * @param {string} data.timezone the new timezone of the calendar
+	 * @return {Promise}
+	 */
+	async setCalendarTimezone(context, { calendar, timezone }) {
+		let timezoneIcs = null
+		const timezoneObject = getTimezoneManager().getTimezoneForId(timezone)
+		if (timezoneObject !== Timezone.utc && timezoneObject !== Timezone.floating) {
+			const calendar = CalendarComponent.fromEmpty()
+			calendar.addComponent(TimezoneComponent.fromICALJs(timezoneObject.toICALJs()))
+			timezoneIcs = calendar.toICS(false)
+		}
+		calendar.dav.timezone = timezoneIcs
+		await calendar.dav.update()
+		context.commit('setCalendarTimezone', { calendar, timezone: timezoneIcs })
 	},
 
 	/**


### PR DESCRIPTION
https://www.rfc-editor.org/rfc/rfc4791#section-5.2.2

>    Description:  The CALDAV:calendar-timezone property is used to
>       specify the time zone the server should rely on to resolve "date"
>       values and "date with local time" values (i.e., floating time) to
>       "date with UTC time" values.  The server will require this
>       information to determine if a calendar component scheduled with
>       "date" values or "date with local time" values overlaps a CALDAV:
>       time-range specified in a CALDAV:calendar-query REPORT.  The
>       server will also require this information to compute the proper
>       FREEBUSY time period as "date with UTC time" in the VFREEBUSY
>       component returned in a response to a CALDAV:free-busy-query
>       REPORT request that takes into account calendar components
>       scheduled with "date" values or "date with local time" values.  In
>       the absence of this property, the server MAY rely on the time zone
>       of their choice.

Ref https://github.com/nextcloud/calendar/issues/4778#issuecomment-1385407475

## Todo

- [x] Make it work
- [ ] Make it pretty

![Bildschirmfoto vom 2023-01-30 20-13-27](https://user-images.githubusercontent.com/1374172/215574177-8401ad7f-bf44-4e52-b475-0d7a6e514836.png)
