### PR TITLE
Make days labels more readable

### DIFF
--- a/css/fullcalendar.scss
+++ b/css/fullcalendar.scss
@@ -61,6 +61,12 @@
 	color: var(--color-text-lighter) !important;
 }
 
+// Make labels more readable
+.fc-col-header-cell a.fc-col-header-cell-cushion {
+	padding: 20px 4px;
+	font-size: 1.3em;
+}
+
 // Remove dotted half-lines
 .fc .fc-timegrid-slot-minor {
 	border-top-style: none !important;

--- a/css/fullcalendar.scss
+++ b/css/fullcalendar.scss
@@ -146,8 +146,8 @@
 
 // ### FullCalendar Event adjustments
 .fc-event {
-	padding-left: 3px;
-
+	padding: 0 !important;
+	margin: 0 !important;
 	&.fc-event-nc-task-completed,
 	&.fc-event-nc-tentative,
 	&.fc-event-nc-cancelled {
@@ -267,9 +267,6 @@
 	.fc-daygrid-more-link {
 		word-break: break-word;
 		white-space: normal;
-	}
-	.fc-daygrid-day-frame {
-		min-height: 150px !important;
 	}
 }
 .fc-daygrid-day-events {


### PR DESCRIPTION
Signed-off-by: Jérôme Herbinet <33763786+Jerome-Herbinet@users.noreply.github.com>

Signed-off-by: Jérôme Herbinet <33763786+Jerome-Herbinet@users.noreply.github.com>

**This PR would affect day, week and month view**

Before : 
![2023-01-31_11-25](https://user-images.githubusercontent.com/33763786/215767821-3127c3e9-f9fb-4460-84de-618dd3d67372.png)

After : 
![2023-01-31_11-23](https://user-images.githubusercontent.com/33763786/215767857-c5daa326-5307-454e-a807-5ca3cfbec4d8.png)

**In the "After" screenshot, you'll see other changes that I haven't made for the moment in this PR :** 
- decrease height of the events title blocks and remove days' block 150px min-height : **What do you think about it ... ton compensate increased height of above labels.**
- vertically align the burger button (left panel toggle button) : **I wonder if I can target it in this scss file.**
