### PR TITLE
fix: bring back advanced color picker fields

### DIFF
--- a/src/components/AppNavigation/EditCalendarModal.vue
+++ b/src/components/AppNavigation/EditCalendarModal.vue
@@ -30,7 +30,9 @@
 					<div v-if="loading"
 						class="edit-calendar-modal__name-and-color__color__dot"
 						:style="{'background-color': calendarColor}" />
-					<NcColorPicker v-else v-model="calendarColor">
+					<NcColorPicker v-else
+						v-model="calendarColor"
+						:advanced-fields="true">
 						<div class="edit-calendar-modal__name-and-color__color__dot"
 							:style="{'background-color': calendarColor}" />
 					</NcColorPicker>

--- a/src/components/Editor/Properties/PropertyColor.vue
+++ b/src/components/Editor/Properties/PropertyColor.vue
@@ -40,6 +40,7 @@
 			class="property-color__input">
 			<ColorPicker :value="selectedColor"
 				:open.sync="isColorPickerOpen"
+				:advanced-fields="true"
 				@input="changeColor">
 				<NcButton class="property-color__color-preview"
 					:style="{'background-color': selectedColor }" />


### PR DESCRIPTION
Fix #5013

| Before | After | 
| --- | --- |
| ![grafik](https://user-images.githubusercontent.com/1479486/220873850-f56f5658-1b1a-4e5b-8001-7a6fcb77248d.png) | ![grafik](https://user-images.githubusercontent.com/1479486/220873519-84e608ff-9e9b-42ca-9168-ec8cbf3d835c.png) |
