### PR TITLE
Respect locale when displaying date and time in calendar

### DIFF
--- a/src/components/CalendarGrid.vue
+++ b/src/components/CalendarGrid.vue
@@ -63,9 +63,7 @@ import VTimezoneNamedTimezone from '../fullcalendar/timezones/vtimezoneNamedTime
 // Import other dependencies
 import { mapGetters, mapState } from 'vuex'
 import debounce from 'debounce'
-import { getLocale } from '@nextcloud/l10n'
 import { getYYYYMMDDFromFirstdayParam } from '../utils/date.js'
-import { getFirstDayOfWeekFromMomentLocale } from '../utils/moment.js'
 
 export default {
 	name: 'CalendarGrid',
@@ -124,8 +122,7 @@ export default {
 				navLinks: true,
 				// Localization
 				...getDateFormattingConfig(),
-				locale: getFullCalendarLocale(getLocale(), this.locale),
-				firstDay: getFirstDayOfWeekFromMomentLocale(this.locale),
+				...getFullCalendarLocale(),
 				// Rendering
 				dayHeaderDidMount,
 				eventDidMount,

--- a/src/components/Editor/FreeBusy/FreeBusy.vue
+++ b/src/components/Editor/FreeBusy/FreeBusy.vue
@@ -74,8 +74,6 @@ import {
 import Modal from '@nextcloud/vue/dist/Components/NcModal.js'
 import DatePicker from '../../Shared/DatePicker.vue'
 import { getColorForFBType } from '../../../utils/freebusy.js'
-import { getLocale } from '@nextcloud/l10n'
-import { getFirstDayOfWeekFromMomentLocale } from '../../../utils/moment.js'
 
 export default {
 	name: 'FreeBusy',
@@ -238,8 +236,7 @@ export default {
 				selectable: false,
 				// Localization:
 				...getDateFormattingConfig(),
-				locale: getFullCalendarLocale(getLocale(), this.locale),
-				firstDay: getFirstDayOfWeekFromMomentLocale(this.locale),
+				...getFullCalendarLocale(),
 				// Rendering
 				height: 'auto',
 				loading: this.loading,

--- a/src/fullcalendar/localization/dateFormattingConfig.js
+++ b/src/fullcalendar/localization/dateFormattingConfig.js
@@ -26,22 +26,22 @@
  * @return {object}
  */
 const getDateFormattingConfig = () => {
+	const defaultConfig = {
+		dayHeaderFormat: 'ddd l',
+		titleFormat: 'll',
+		slotLabelFormat: 'LT',
+	}
+
 	return {
 		// Date formatting:
 		eventTimeFormat: 'LT',
 		views: {
 			dayGridMonth: {
+				...defaultConfig,
 				dayHeaderFormat: 'ddd',
-				titleFormat: 'll',
 			},
-			timeGridDay: {
-				dayHeaderFormat: 'ddd l',
-				titleFormat: 'll',
-			},
-			timeGridWeek: {
-				dayHeaderFormat: 'ddd l',
-				titleFormat: 'll',
-			},
+			timeGridDay: defaultConfig,
+			timeGridWeek: defaultConfig,
 		},
 	}
 }

--- a/src/fullcalendar/localization/localeProvider.js
+++ b/src/fullcalendar/localization/localeProvider.js
@@ -22,35 +22,17 @@
 import { translate as t } from '@nextcloud/l10n'
 import {
 	getFirstDayOfWeekFromMomentLocale,
-	getFirstDayOfYearFromMomentLocale,
 } from '../../utils/moment.js'
 
 /**
+ * Returns localization settings for the FullCalender package.
  *
- * @param {string} userLocale The user-selected locale
- * @param {string} momentLocale Our merged locale-language based moment locale
+ * @see https://fullcalendar.io/docs
  * @return {object}
  */
-const getFullCalendarLocale = (userLocale, momentLocale) => {
+const getFullCalendarLocale = () => {
 	return {
-		code: userLocale.replace(/_/g, '-').toLowerCase(),
-		week: {
-			dow: getFirstDayOfWeekFromMomentLocale(momentLocale),
-			doy: getFirstDayOfYearFromMomentLocale(momentLocale),
-		},
-		direction: 'ltr', // TODO - fix me
-		buttonText: {
-			prev: t('calendar', 'Prev'),
-			next: t('calendar', 'Next'),
-			prevYear: t('calendar', 'Prev year'),
-			nextYear: t('calendar', 'Next year'),
-			year: t('calendar', 'Year'),
-			today: t('calendar', 'Today'),
-			month: t('calendar', 'Month'),
-			week: t('calendar', 'Week'),
-			day: t('calendar', 'Day'),
-			list: t('calendar', 'List'),
-		},
+		firstDay: getFirstDayOfWeekFromMomentLocale(),
 		// TRANSLATORS W is an abbreviation for Week
 		weekText: t('calendar', 'W'),
 		allDayText: t('calendar', 'All day'),

--- a/src/utils/moment.js
+++ b/src/utils/moment.js
@@ -53,6 +53,10 @@ export default async function loadMomentLocalization() {
 			LL: moment.localeData(realLocale).longDateFormat('LL'),
 			LLL: moment.localeData(realLocale).longDateFormat('LLL'),
 			LLLL: moment.localeData(realLocale).longDateFormat('LLLL'),
+			l: moment.localeData(realLocale).longDateFormat('l'),
+			ll: moment.localeData(realLocale).longDateFormat('ll'),
+			lll: moment.localeData(realLocale).longDateFormat('lll'),
+			llll: moment.localeData(realLocale).longDateFormat('llll'),
 		},
 		week: {
 			dow: moment.localeData(realLocale).firstDayOfWeek(),
@@ -70,19 +74,31 @@ export default async function loadMomentLocalization() {
  * @return {Promise<string>}
  */
 async function getLocaleFor(locale) {
+	// IMPORTANT: Keep each '/moment/local/...' string as is. Otherwise, webpack might not bundle
+	//            locale data because the contentRegExp fails to detect any files.
 	try {
-		// default load e.g. fr-fr
-		await import('moment/locale/' + locale)
+		// default load e.g. en-de
+		await import(`moment/locale/${locale}.js`)
 		return locale
 	} catch (error) {
+		const splitLocale = locale.split('-')
 		try {
-			// failure: fallback to fr
-			locale = locale.split('-')[0]
-			await import('moment/locale/' + locale)
+			// failure: fallback to de
+			locale = splitLocale[1]
+			await import(`moment/locale/${locale}.js`)
 			return locale
 		} catch (e) {
-			// failure, fallback to english
-			console.debug('Fallback to locale', 'en')
+			try {
+				// failure: fallback to en
+				locale = splitLocale[0]
+				await import(`moment/locale/${locale}.js`)
+				return locale
+			} catch (e) {
+				// failure, fallback to english
+				console.debug('Fallback to locale', 'en')
+				// English is the default locale and doesn't need to imported.
+				// It is already included in moment.js.
+			}
 		}
 	}
 
@@ -92,19 +108,8 @@ async function getLocaleFor(locale) {
 /**
  * Get's the first day of a week based on a moment locale
  *
- * @param {string} momentLocale Id of moment locale
  * @return {number}
  */
-export function getFirstDayOfWeekFromMomentLocale(momentLocale) {
-	return moment.localeData(momentLocale).firstDayOfWeek()
-}
-
-/**
- * Get's the first day of a year based on a moment locale
- *
- * @param {string} momentLocale Id of moment locale
- * @return {number}
- */
-export function getFirstDayOfYearFromMomentLocale(momentLocale) {
-	return moment.localeData(momentLocale).firstDayOfYear()
+export function getFirstDayOfWeekFromMomentLocale() {
+	return moment.localeData().firstDayOfWeek()
 }


### PR DESCRIPTION
Fixes #2663

This is my first commit, so please bear with me if I have made some mistakes 😄 .

Before: locale was not respected, fullCalendar displayed dates and time according to language
Now: Dates and times are now rendered by the two new functions in the options object.

# The new situation on the en_DE locale:
![image](https://user-images.githubusercontent.com/20358521/221360455-256548ee-836a-441e-bb02-68a6bf89841b.png)
![image](https://user-images.githubusercontent.com/20358521/221360502-b3eaf2b1-10fc-40dc-9def-0338ac53e65e.png)


I might have missed some things and this pull request does not currently have tests, as I do not know what is normally tested and how it is tested.