### PR TITLE
fix(appointments): calendar booking notifications

### DIFF
--- a/lib/Notification/Notifier.php
+++ b/lib/Notification/Notifier.php
@@ -75,12 +75,6 @@ class Notifier implements INotifier {
 						'link' => $this->url->linkToRouteAbsolute('calendar.view.index')
 					]
 				]);
-				$placeholders = $replacements = [];
-				foreach ($notification->getRichSubjectParameters() as $placeholder => $parameter) {
-					$placeholders[] = '{' . $placeholder . '}';
-					$replacements[] = $parameter[$placeholder];
-				}
-				$notification->setParsedSubject(str_replace($placeholders, $replacements, $notification->getRichSubject()));
 
 				$messageParameters = $notification->getMessageParameters();
 				$notification->setRichMessage($l->t('{display_name} ({email}) booked the appointment "{config_display_name}" on {date_time}.'), [
@@ -105,16 +99,10 @@ class Notifier implements INotifier {
 						'name' => $messageParameters['config_display_name'],
 					]
 				]);
-				foreach ($notification->getRichMessageParameters() as $placeholder => $parameter) {
-					$placeholders[] = '{' . $placeholder . '}';
-					$replacements[] = $parameter[$placeholder];
-				}
-				$notification->setParsedMessage(str_replace($placeholders, $replacements, $notification->getRichMessage()));
 				break;
 			default:
 				throw  new \InvalidArgumentException();
 		}
-
 
 		return $notification;
 	}

--- a/tests/php/unit/Notification/NotifierTest.php
+++ b/tests/php/unit/Notification/NotifierTest.php
@@ -179,20 +179,12 @@ class NotifierTest extends \PHPUnit\Framework\TestCase {
 		$notification->expects($this->once())
 			->method('setRichSubject')
 			->with('New booking {booking}', $booking);
-		$notification->expects($this->once())
-			->method('getRichSubjectParameters');
-		$notification->expects(self::once())
-			->method('setParsedSubject');
 		$notification->expects(self::once())
 			->method('getMessageParameters')
 			->willReturn($messageParameters);
 		$notification->expects($this->once())
 			->method('setRichMessage')
 			->with('{display_name} ({email}) booked the appointment "{config_display_name}" on {date_time}.', $messageRichData);
-		$notification->expects($this->once())
-			->method('getRichMessageParameters');
-		$notification->expects(self::once())
-			->method('setParsedMessage');
 
 		$return = $this->notifier->prepare($notification, 'de');
 		$this->assertEquals($notification, $return);


### PR DESCRIPTION
Notifications on appointment bookings weren't dispatched because of undefined array key errors in the removed code.

Problematic line:
`$replacements[] = $parameter[$placeholder];`

All rich parameters are automatically replaced by the INotification class. I guess the removed statements were debugging leftovers.

## How to reproduce:
1. Create some appointment config.
2. Book and confirm an appointment.
3. **Here:** Observe that a (browser/client) notification is shown.
4. **Main:** No notification will be shown because undefined array key errors. 

This works best if the account owning the appointment config is setup in a desktop client. Browser notifications tend to be a bit delayed sometimes.
