### PR TITLE
fix: userAsAttendee failing in case of public links

### DIFF
--- a/src/mixins/EditorMixin.js
+++ b/src/mixins/EditorMixin.js
@@ -227,7 +227,7 @@ export default {
 		 * @return {?object}
 		 */
 		userAsAttendee() {
-			if (!this.calendarObjectInstance.organizer) {
+			if (this.isReadOnly || !this.$store.getters.getCurrentUserPrincipalEmail || !this.calendarObjectInstance.organizer) {
 				return null
 			}
 

--- a/src/store/principals.js
+++ b/src/store/principals.js
@@ -98,9 +98,9 @@ const getters = {
 	 * Gets the email-address of the current-user-principal
 	 *
 	 * @param {object} state the store data
-	 * @return {string}
+	 * @return {string|undefined}
 	 */
-	getCurrentUserPrincipalEmail: (state) => state.principalsById[state.currentUserPrincipal].emailAddress,
+	getCurrentUserPrincipalEmail: (state) => state.principalsById[state.currentUserPrincipal]?.emailAddress,
 }
 
 const actions = {

--- a/src/views/EditSidebar.vue
+++ b/src/views/EditSidebar.vue
@@ -107,7 +107,7 @@
 				@update-end-timezone="updateEndTimezone"
 				@toggle-all-day="toggleAllDay" />
 
-			<InvitationResponseButtons v-if="isViewedByAttendee && userAsAttendee && !isReadOnly"
+			<InvitationResponseButtons v-if="isViewedByAttendee"
 				:attendee="userAsAttendee"
 				:calendar-id="calendarId"
 				:narrow="true"

--- a/src/views/EditSimple.vue
+++ b/src/views/EditSimple.vue
@@ -142,7 +142,7 @@
 					:value="description"
 					@update:value="updateDescription" />
 
-				<InvitationResponseButtons v-if="isViewedByAttendee && userAsAttendee && !isReadOnly"
+				<InvitationResponseButtons v-if="isViewedByAttendee"
 					:attendee="userAsAttendee"
 					:calendar-id="calendarId"
 					@close="closeEditorAndSkipAction" />


### PR DESCRIPTION
Check if the calendar is read-only first to avoid error due to non-existent currentUserPrincipal which causes endless loading on events with atendees in publicly shared calendars.
This should resolve issues #4011 and #4706

Closes #4011
Closes #4706
Closes #4169