### PR TITLE
Creating attachments folder when uploading attachments

### DIFF
--- a/src/components/Editor/Attachments/AttachmentsList.vue
+++ b/src/components/Editor/Attachments/AttachmentsList.vue
@@ -80,6 +80,7 @@ import { getFilePickerBuilder, showError } from '@nextcloud/dialogs'
 import {
 	uploadLocalAttachment,
 	getFileInfo,
+	createFolder,
 } from '../../../services/attachmentService.js'
 import { parseXML } from 'webdav/dist/node/tools/dav.js'
 
@@ -108,6 +109,7 @@ export default {
 	data() {
 		return {
 			uploading: false,
+			folderCreated: false,
 		}
 	},
 	computed: {
@@ -166,6 +168,10 @@ export default {
 			this.$refs.localAttachments.click()
 		},
 		async onLocalAttachmentSelected(e) {
+			if (!this.folderCreated) {
+				await createFolder(this.attachmentsFolder, this.currentUser.userId)
+				this.folderCreated = true
+			}
 			const attachments = await uploadLocalAttachment(this.attachmentsFolder, e, this.currentUser.dav, this.attachments)
 			// TODO do not share file, move to PHP
 			attachments.map(async attachment => {

--- a/src/views/Calendar.vue
+++ b/src/views/Calendar.vue
@@ -104,8 +104,6 @@ import '@nextcloud/dialogs/dist/index.css'
 import Trashbin from '../components/AppNavigation/CalendarList/Trashbin.vue'
 import AppointmentConfigList from '../components/AppNavigation/AppointmentConfigList.vue'
 
-import { createFolder } from '../services/attachmentService.js'
-
 export default {
 	name: 'Calendar',
 	components: {
@@ -191,7 +189,6 @@ export default {
 	watch: {
 		currentUserPrincipal() {
 			if (this.currentUserPrincipal !== undefined && this.loadingUser) {
-				createFolder(this.attachmentsFolder, this.currentUserPrincipal.userId)
 				this.loadingUser = false
 			}
 		},


### PR DESCRIPTION
Hello! Fixes this - https://github.com/nextcloud/calendar/issues/5073

So far, I can't test it definitively, as there is a little problem with nextcloud-vue, which is solved here: https://github.com/nextcloud/nextcloud-vue/pull/3907 

However, I've moved the creation of the folder when the attachment is loaded, and also added an option to check the status of the folder's creation to reduce the number of requests when loading attachments before reloading the page.
