### PR TITLE
fix: sidebar editor subtitle not respecting event's timezone

### DIFF
--- a/src/views/EditSidebar.vue
+++ b/src/views/EditSidebar.vue
@@ -320,7 +320,8 @@ import InformationOutline from 'vue-material-design-icons/InformationOutline.vue
 import MapMarker from 'vue-material-design-icons/MapMarker.vue'
 
 import { shareFile } from '../services/attachmentService.js'
-import { Parameter } from '@nextcloud/calendar-js'
+import { DateTimeValue, Parameter } from '@nextcloud/calendar-js'
+import getTimezoneManager from '../services/timezoneDataProviderService.js'
 
 export default {
 	name: 'EditSidebar',
@@ -393,7 +394,14 @@ export default {
 				return ''
 			}
 
-			return moment(this.calendarObjectInstance.startDate).locale(this.locale).fromNow()
+			const timezone = getTimezoneManager()
+				.getTimezoneForId(this.calendarObjectInstance.startTimezoneId)
+			const startDateInTz = DateTimeValue
+				.fromJSDate(this.calendarObjectInstance.startDate)
+				.getInTimezone(timezone)
+				.jsDate
+
+			return moment(startDateInTz).locale(this.locale).fromNow()
 		},
 		attachments() {
 			return this.calendarObjectInstance?.attachments || null


### PR DESCRIPTION
Fix https://github.com/nextcloud/calendar/issues/3421

The start date has to be converted to the correct timezone before formatting it.

| Before | After
| --- | --- |
| ![before](https://user-images.githubusercontent.com/14975046/129847065-8ce772e4-585c-4947-82ac-09f67d1c4f04.png) | ![grafik](https://user-images.githubusercontent.com/1479486/228017093-3fb9fb47-4ce3-43a6-abf6-e1e611325427.png) |
