### PR TITLE
Fix creating empty events

### DIFF
--- a/src/mixins/EditorMixin.js
+++ b/src/mixins/EditorMixin.js
@@ -811,7 +811,10 @@ export default {
 		}
 
 		try {
-			await this.save()
+			if ((from.name !== 'NewPopoverView' || to.name !== 'EditPopoverView')
+			&& (from.name !== 'NewPopoverView' || to.name !== 'EditSideBarView')) {
+				await this.save()
+			}
 			next()
 		} catch (error) {
 			console.debug(error)

--- a/tests/javascript/unit/fullcalendar/interaction/eventClick.test.js
+++ b/tests/javascript/unit/fullcalendar/interaction/eventClick.test.js
@@ -20,6 +20,7 @@
  *
  */
 import eventClick from "../../../../../src/fullcalendar/interaction/eventClick.js";
+import EditorMixin from "../../../../../src/mixins/EditorMixin.js";
 import {
 	getPrefixedRoute,
 	isPublicOrEmbeddedRoute,
@@ -412,4 +413,164 @@ describe('fullcalendar/eventClick test suite', () => {
 		expect(window.location).toEqual(oldLocation)
 	})
 
+	it('should do nothing when there is no require action on route leave', () => {
+		const fromRoute = {
+			name: 'Test1',
+			params: {
+				object: 'object123',
+				otherParam: '456',
+				recurrenceId: 'recurrence456',
+			}
+		}
+		const toRoute = {
+			name: 'Test2',
+			params: {
+				object: 'object123',
+				otherParam: '456',
+				recurrenceId: 'recurrence456',
+			}
+		}
+
+		const next = jest.fn()
+		EditorMixin.requiresActionOnRouteLeave = false
+		EditorMixin.beforeRouteLeave(toRoute, fromRoute, next)
+	})
+
+	it('should not save the event when new side bar view is open and then clicked in a saved event', () => {
+		const fromRoute = {
+			name: 'NewSideBarView',
+			params: {
+				object: 'object123',
+				otherParam: '456',
+				recurrenceId: 'recurrence456',
+			}
+		}
+		const toRoute = {
+			name: 'EditSideBarView',
+			params: {
+				object: 'object123',
+				otherParam: '456',
+				recurrenceId: 'recurrence456',
+			}
+		}
+
+		const next = jest.fn()
+		EditorMixin.requiresActionOnRouteLeave = true
+		EditorMixin.beforeRouteLeave(toRoute, fromRoute, next)
+	})
+
+	it('should not save the event when new popover view is open and then clicked in a saved event in popover view', () => {
+		const fromRoute = {
+			name: 'NewPopoverView',
+			params: {
+				object: 'object123',
+				otherParam: '456',
+				recurrenceId: 'recurrence456',
+			}
+		}
+		const toRoute = {
+			name: 'EditPopoverView',
+			params: {
+				object: 'object123',
+				otherParam: '456',
+				recurrenceId: 'recurrence456',
+			}
+		}
+
+		const next = jest.fn()
+		EditorMixin.requiresActionOnRouteLeave = true
+		EditorMixin.beforeRouteLeave(toRoute, fromRoute, next)
+	})
+
+	it('should not save the event when new popover view is open and then clicked in a saved event in sidebar view', () => {
+		const fromRoute = {
+			name: 'NewPopoverView',
+			params: {
+				object: 'object123',
+				otherParam: '456',
+				recurrenceId: 'recurrence456',
+			}
+		}
+		const toRoute = {
+			name: 'EditSideBarView',
+			params: {
+				object: 'object123',
+				otherParam: '456',
+				recurrenceId: 'recurrence456',
+			}
+		}
+
+		const next = jest.fn()
+		EditorMixin.requiresActionOnRouteLeave = true
+		EditorMixin.beforeRouteLeave(toRoute, fromRoute, next)
+	})
+
+	it('show save event', () => {
+		const fromRoute = {
+			name: 'EditPopoverView',
+			params: {
+				object: 'object123',
+				otherParam: '456',
+				recurrenceId: 'recurrence456',
+			}
+		}
+		const toRoute = {
+			name: 'NewPopoverView',
+			params: {
+				object: 'object123',
+				otherParam: '456',
+				recurrenceId: 'recurrence456',
+			}
+		}
+
+		const next = jest.fn()
+		EditorMixin.requiresActionOnRouteLeave = true
+		EditorMixin.beforeRouteLeave(toRoute, fromRoute, next)
+	})
+
+	it('show save event', () => {
+		const fromRoute = {
+			name: 'EditSideBarView',
+			params: {
+				object: 'object123',
+				otherParam: '456',
+				recurrenceId: 'recurrence456',
+			}
+		}
+		const toRoute = {
+			name: 'NewSideBarView',
+			params: {
+				object: 'object123',
+				otherParam: '456',
+				recurrenceId: 'recurrence456',
+			}
+		}
+
+		const next = jest.fn()
+		EditorMixin.requiresActionOnRouteLeave = true
+		EditorMixin.beforeRouteLeave(toRoute, fromRoute, next)
+	})
+
+	it('should not save event with invalid to and from routes on beforeRouteLeave', () => {
+		const fromRoute = {
+			name: 'Test1',
+			params: {
+				object: 'object123',
+				otherParam: '456',
+				recurrenceId: 'recurrence456',
+			}
+		}
+		const toRoute = {
+			name: 'Test2',
+			params: {
+				object: 'object123',
+				otherParam: '456',
+				recurrenceId: 'recurrence456',
+			}
+		}
+
+		const next = jest.fn()
+		EditorMixin.requiresActionOnRouteLeave = true
+		EditorMixin.beforeRouteLeave(toRoute, fromRoute, next)
+	})
 })


### PR DESCRIPTION
The problem was in the "beforeRouteLeave" because it didn't contemplated the case when the from route was the Popover to create the event and the to route was the popover to edit an existing event. 

Fixes https://github.com/nextcloud/calendar/issues/3820