### PR TITLE
Change toggle RSVP menu label from "Send email" to "Request reply" (R…

### DIFF
--- a/src/components/Editor/Invitees/InviteesListItem.vue
+++ b/src/components/Editor/Invitees/InviteesListItem.vue
@@ -57,7 +57,7 @@
 			<Actions v-if="isViewedByOrganizer">
 				<ActionCheckbox :checked="attendee.rsvp"
 					@change="toggleRSVP">
-					{{ $t('calendar', 'Send email') }}
+					{{ $t('calendar', 'Request reply') }}
 				</ActionCheckbox>
 
 				<ActionRadio :name="radioName"


### PR DESCRIPTION
…épondez, s’il vous plaît!)

This sort of fixes #4372 by changing the menu label to indicate how the underlying code reacts to changes. Of course, it does not resolve that issue by changing the underlying code to react in the way the original label promises.

A detailed explanation can be found in my comment https://github.com/nextcloud/calendar/issues/4372#issuecomment-1487668314