### PR TITLE
Fix 2 import buttons alignment in calendar import modal

### DIFF
--- a/css/import.scss
+++ b/css/import.scss
@@ -32,9 +32,8 @@
 		}
 
 		.import-modal__actions {
-			> button {
-				display: inline-block !important;
-			}
+			display: flex;
+			gap: 5px;
 		}
 
 		.import-modal-file-item {

--- a/css/import.scss
+++ b/css/import.scss
@@ -31,6 +31,12 @@
 			text-align: center;
 		}
 
+		.import-modal__actions {
+			> button {
+				display: inline-block !important;
+			}
+		}
+
 		.import-modal-file-item {
 			display: flex;
 			padding-top: 10px;


### PR DESCRIPTION
Signed-off-by: Jérôme Herbinet <33763786+Jerome-Herbinet@users.noreply.github.com>

**Before :** 
![2023-04-05_09-36](https://user-images.githubusercontent.com/33763786/230013304-b871077c-44e7-4fb3-8203-64c336c326d5.png)

**After :** 
![2023-04-05_09-35](https://user-images.githubusercontent.com/33763786/230013314-40c62e2d-d3b1-4acd-a97f-1b689eaa6e93.png)

Note : I notice that the file is a .css and that it's content is written in SCSS. Should I run a "npm run sass" ?