### PR TITLE
fix: calendar color picker

### DIFF
--- a/src/components/AppNavigation/EditCalendarModal.vue
+++ b/src/components/AppNavigation/EditCalendarModal.vue
@@ -161,9 +161,6 @@ export default {
 		},
 	},
 	watch: {
-		async calendarColor() {
-			await this.saveColorDebounced()
-		},
 		async calendarName() {
 			await this.saveNameDebounced()
 		},
@@ -178,7 +175,6 @@ export default {
 	},
 	created() {
 		// debounce.flush() only works if the functions are added here (or in data())
-		this.saveColorDebounced = debounce(() => this.saveColor(), 1000)
 		this.saveNameDebounced = debounce(() => this.saveName(), 1000)
 	},
 	methods: {
@@ -237,7 +233,7 @@ export default {
 		 * @return {Promise<void>}
 		 */
 		async saveAndClose() {
-			await this.saveColorDebounced.flush()
+			await this.saveColor()
 			await this.saveNameDebounced.flush()
 			this.closeModal()
 		},


### PR DESCRIPTION
This pull request fixes issue #4864. By removing the use of debounce, the user can preview different colors for the calendar through the color picker, closing it when ready to save the edits.

Possible regression of https://github.com/nextcloud/calendar/pull/4515