### PR TITLE
Updated public.scss

### DIFF
--- a/css/public.scss
+++ b/css/public.scss
@@ -38,7 +38,7 @@
 		overflow: visible;
 		z-index: 2000;
 		display: flex;
-		justify-content: space-between;
+		justify-content: flex-start;  //field updated to adjust the content towards left.
 
 		.embed-header__date-section,
 		.embed-header__share-section {


### PR DESCRIPTION
Fixes https://github.com/nextcloud/calendar/issues/4891https://github.com/nextcloud/calendar/issues/4891

I have modified the header property to move the day toward the left and should appear along with the date.