### PR TITLE
fix: improve grammar

### DIFF
--- a/src/components/AppNavigation/EditCalendarModal/ShareItem.vue
+++ b/src/components/AppNavigation/EditCalendarModal/ShareItem.vue
@@ -110,7 +110,7 @@ export default {
 				this.updatingSharee = false
 			} catch (error) {
 				console.error(error)
-				showInfo(this.$t('calendar', 'An error occurred, unable to change the unshare the calendar.'))
+				showInfo(this.$t('calendar', 'An error occurred while unsharing the calendar.'))
 
 				this.updatingSharee = false
 			}


### PR DESCRIPTION
Fixes: #4713

Change 
`An error occurred, unable to change the unshare the calendar.` 
to 
`An error occurred while unsharing the calendar.`