### PR TITLE
Fix : Calendar invitees buttons (width and space between)

### DIFF
--- a/css/app-sidebar.scss
+++ b/css/app-sidebar.scss
@@ -851,3 +851,9 @@
 	align-items: center;
 	margin-top: 20px;
 }
+
+.invitees-list-button-group {
+	> button.button-vue {  
+		width: calc(50% - 5px);
+	}
+}


### PR DESCRIPTION
Signed-off-by: Jérôme Herbinet <33763786+Jerome-Herbinet@users.noreply.github.com>

50% width for each and 2x5px = 10px space between

### BEFORE
![2023-04-26_12-10](https://user-images.githubusercontent.com/33763786/234559514-0ce760e3-7913-423b-b12d-66359f785eec.png)

### AFTER
![2023-04-26_13-13](https://user-images.githubusercontent.com/33763786/234559432-3fa3d192-f61c-4642-8d35-01b878e12d8b.png)
