### PR TITLE
feat: Add link to the Thunderbird holiday calendar page

### DIFF
--- a/src/components/AppNavigation/CalendarList/CalendarListNew.vue
+++ b/src/components/AppNavigation/CalendarList/CalendarListNew.vue
@@ -72,6 +72,7 @@
 				{{ $t('calendar', 'Creating calendar …') }}
 			</ActionText>
 
+			<ActionSeparator v-if="canSubscribeLink" />
 			<ActionButton v-if="showCreateSubscriptionLabel && canSubscribeLink"
 				@click.prevent.stop="openCreateSubscriptionInput">
 				<template #icon>
@@ -91,6 +92,15 @@
 				<!-- eslint-disable-next-line no-irregular-whitespace -->
 				{{ $t('calendar', 'Creating subscription …') }}
 			</ActionText>
+			<ActionLink v-if="canSubscribeLink"
+				href="https://www.thunderbird.net/calendar/holidays/"
+				target="_blank"
+				rel="noopener noreferrer">
+				{{ t('calendar', 'Browse holiday subscriptions. Find and copy the .ics link for your region and add it as new subscription above.') }}
+				<template #icon>
+					<Web :size="20" decorative />
+				</template>
+			</ActionLink>
 		</template>
 	</AppNavigationItem>
 </template>
@@ -98,6 +108,8 @@
 <script>
 import ActionButton from '@nextcloud/vue/dist/Components/NcActionButton.js'
 import ActionInput from '@nextcloud/vue/dist/Components/NcActionInput.js'
+import ActionLink from '@nextcloud/vue/dist/Components/NcActionLink.js'
+import ActionSeparator from '@nextcloud/vue/dist/Components/NcActionSeparator.js'
 import ActionText from '@nextcloud/vue/dist/Components/NcActionText.js'
 import AppNavigationItem from '@nextcloud/vue/dist/Components/NcAppNavigationItem.js'
 import {
@@ -110,6 +122,7 @@ import CalendarBlank from 'vue-material-design-icons/CalendarBlank.vue'
 import CalendarCheck from 'vue-material-design-icons/CalendarCheck.vue'
 import LinkVariant from 'vue-material-design-icons/LinkVariant.vue'
 import Plus from 'vue-material-design-icons/Plus.vue'
+import Web from 'vue-material-design-icons/Web.vue'
 import { mapState } from 'vuex'
 
 export default {
@@ -117,12 +130,15 @@ export default {
 	components: {
 		ActionButton,
 		ActionInput,
+		ActionLink,
+		ActionSeparator,
 		ActionText,
 		AppNavigationItem,
 		CalendarBlank,
 		CalendarCheck,
 		LinkVariant,
 		Plus,
+		Web,
 	},
 	data() {
 		return {


### PR DESCRIPTION
This is the MVP version of https://github.com/nextcloud/calendar/issues/962. We plan to add an advanced modal to our app later so users don't have to leave the page.

| Before | After |
|--------|--------|
| ![Bildschirmfoto vom 2023-04-27 09-24-53](https://user-images.githubusercontent.com/1374172/234790509-daa0ed4d-28b6-4866-a03a-1d4009bb4a0d.png) | ![Bildschirmfoto vom 2023-04-27 09-24-06](https://user-images.githubusercontent.com/1374172/234790448-7f4ff7cb-5ff9-4385-9f75-8b58eddfcff1.png) |
