### PR TITLE
Fix issue with Attendee not being string crashing tooltip

### DIFF
--- a/src/utils/attendee.js
+++ b/src/utils/attendee.js
@@ -27,6 +27,8 @@
  * @return {string} URI without a mailto prefix
  */
 export function removeMailtoPrefix(uri) {
+	if (typeof uri !== 'string') return ''
+
 	if (uri.startsWith('mailto:')) {
 		return uri.slice(7)
 	}
@@ -41,6 +43,8 @@ export function removeMailtoPrefix(uri) {
  * @return {string} URI with a mailto prefix
  */
 export function addMailtoPrefix(uri) {
+	if (typeof uri !== 'string') return 'mailto:'
+
 	if (uri.startsWith('mailto:')) {
 		return uri
 	}

--- a/src/utils/attendee.js
+++ b/src/utils/attendee.js
@@ -45,7 +45,9 @@ export function removeMailtoPrefix(uri) {
  * @return {string} URI with a mailto prefix
  */
 export function addMailtoPrefix(uri) {
-	if (typeof uri !== 'string') return 'mailto:'
+	if (typeof uri !== 'string') {
+		return 'mailto:'
+	}
 
 	if (uri.startsWith('mailto:')) {
 		return uri

--- a/src/utils/attendee.js
+++ b/src/utils/attendee.js
@@ -27,7 +27,9 @@
  * @return {string} URI without a mailto prefix
  */
 export function removeMailtoPrefix(uri) {
-	if (typeof uri !== 'string') return ''
+	if (typeof uri !== 'string') {
+		return ''
+	}
 
 	if (uri.startsWith('mailto:')) {
 		return uri.slice(7)

--- a/tests/javascript/unit/utils/attendee.test.js
+++ b/tests/javascript/unit/utils/attendee.test.js
@@ -33,11 +33,21 @@ describe('utils/attendee test suite', () => {
 		expect(removeMailtoPrefix(`mailto:${uri}`)).toEqual(uri)
 	})
 
+	it('should return blank strings when uris are not of type string', () => {
+		expect(removeMailtoPrefix(null)).toEqual('')
+		expect(removeMailtoPrefix(undefined)).toEqual('')
+	})
+
 	it('should add mailto prefixes to uris', () => {
 		const uri = 'principal@test.com'
 		const uriWithPrefix = `mailto:${uri}`
 		expect(addMailtoPrefix(uri)).toEqual(uriWithPrefix)
 		expect(addMailtoPrefix(uriWithPrefix)).toEqual(uriWithPrefix)
+	})
+	
+	it('should add mailto prefixes to uris when they are not of type string', () => {
+		expect(addMailtoPrefix(null)).toEqual("mailto:")
+		expect(addMailtoPrefix(undefined)).toEqual("mailto:")
 	})
 
 	it('should extract a display name of an organizer', () => {


### PR DESCRIPTION
There is an issue when you upload a new ics file to nextcloud calendar that does not contain attendees.

Since there is an assumption that the attendee is going to be a string (and not undefined), the tooltip crashes when you try to edit an event.

```
TypeError: Cannot read properties of undefined (reading 'startsWith')
    at b9 (attendee.js:30:10)
    at o.userAsAttendee (EditorMixin.js:234:22)
    at e.get (vue.runtime.esm.js:3446:33)
    at e.evaluate (vue.runtime.esm.js:3547:27)
    at o.userAsAttendee (vue.runtime.esm.js:5537:25)
    at o.isViewedByAttendee (EditorMixin.js:222:16)
    at e.get (vue.runtime.esm.js:3446:33)
    at e.evaluate (vue.runtime.esm.js:3547:27)
    at o.isViewedByAttendee (vue.runtime.esm.js:5537:25)
    at o.<anonymous> (EditSimple.vue:1:4915)
```

This PR should fix this by coercing non strings to become strings.