### PR TITLE
fix(Public-Sharing): Show footer with server details and eventual ToS through PublicTemplateResponse

### DIFF
--- a/css/public.scss
+++ b/css/public.scss
@@ -60,12 +60,23 @@
 	}
 
 	.app-content {
-		margin-top: 44px
+		margin-top: 44px;
 		//position: absolute !important;
 		//top: 44px;
 		//left: 0;
 		//right: 0;
 		//bottom: 0;
 		//min-height: unset !important;
+	}
+}
+
+#body-public .app-calendar-public {
+	& + footer {
+		// Only show bottom rounded corners
+		border-radius: 0 0 var(--border-radius-large) var(--border-radius-large);
+	}
+
+	.app-content {
+		height: calc(100% - 65px) !important; // $footer-height is hardcoded to 65px in core/css/public.scss
 	}
 }

--- a/lib/Controller/PublicViewController.php
+++ b/lib/Controller/PublicViewController.php
@@ -28,7 +28,7 @@ use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http\ContentSecurityPolicy;
 use OCP\AppFramework\Http\RedirectResponse;
 use OCP\AppFramework\Http\Response;
-use OCP\AppFramework\Http\TemplateResponse;
+use OCP\AppFramework\Http\Template\PublicTemplateResponse;
 use OCP\IConfig;
 use OCP\IInitialStateService;
 use OCP\IRequest;
@@ -79,16 +79,13 @@ class PublicViewController extends Controller {
 	 *
 	 * @PublicPage
 	 * @NoCSRFRequired
-	 *
-	 * @param string $token
-	 * @return Response
 	 */
 	public function publicIndexWithBranding(string $token):Response {
 		$acceptHeader = $this->request->getHeader('Accept');
 		if (strpos($acceptHeader, 'text/calendar') !== false) {
 			return new RedirectResponse($this->urlGenerator->linkTo('', 'remote.php') . '/dav/public-calendars/' . $token . '/?export');
 		}
-		return $this->publicIndex($token, 'public');
+		return $this->publicIndex($token);
 	}
 
 	/**
@@ -97,12 +94,10 @@ class PublicViewController extends Controller {
 	 * @PublicPage
 	 * @NoCSRFRequired
 	 * @NoSameSiteCookieRequired
-	 *
-	 * @param string $token
-	 * @return TemplateResponse
 	 */
-	public function publicIndexForEmbedding(string $token):TemplateResponse {
-		$response = $this->publicIndex($token, 'base');
+	public function publicIndexForEmbedding(string $token):PublicTemplateResponse {
+		$response = $this->publicIndex($token);
+		$response->setFooterVisible(false);
 		$response->addHeader('X-Frame-Options', 'ALLOW');
 
 		$csp = new ContentSecurityPolicy();
@@ -112,13 +107,7 @@ class PublicViewController extends Controller {
 		return $response;
 	}
 
-	/**
-	 * @param string $token
-	 * @param string $renderAs
-	 * @return TemplateResponse
-	 */
-	private function publicIndex(string $token,
-		string $renderAs):TemplateResponse {
+	private function publicIndex(string $token):PublicTemplateResponse {
 		$defaultEventLimit = $this->config->getAppValue($this->appName, 'eventLimit', 'yes');
 		$defaultInitialView = $this->config->getAppValue($this->appName, 'currentView', 'dayGridMonth');
 		$defaultShowWeekends = $this->config->getAppValue($this->appName, 'showWeekends', 'yes');
@@ -149,16 +138,14 @@ class PublicViewController extends Controller {
 		$this->initialStateService->provideInitialState($this->appName, 'hide_event_export', false);
 		$this->initialStateService->provideInitialState($this->appName, 'can_subscribe_link', $defaultCanSubscribeLink);
 
-		return new TemplateResponse($this->appName, 'main', [
+		return new PublicTemplateResponse($this->appName, 'main', [
 			'share_url' => $this->getShareURL(),
 			'preview_image' => $this->getPreviewImage(),
-		], $renderAs);
+		]);
 	}
 
 	/**
 	 * Get the sharing Url
-	 *
-	 * @return string
 	 */
 	private function getShareURL():string {
 		$shareURL = $this->request->getServerProtocol() . '://';
@@ -170,8 +157,6 @@ class PublicViewController extends Controller {
 
 	/**
 	 * Get an image for preview when sharing in social media
-	 *
-	 * @return string
 	 */
 	private function getPreviewImage():string {
 		$relativeImagePath = $this->urlGenerator->imagePath('core', 'favicon-touch.png');

--- a/tests/php/unit/Controller/PublicViewControllerTest.php
+++ b/tests/php/unit/Controller/PublicViewControllerTest.php
@@ -26,7 +26,7 @@ namespace OCA\Calendar\Controller;
 
 use ChristophWurst\Nextcloud\Testing\TestCase;
 use OCP\AppFramework\Http\RedirectResponse;
-use OCP\AppFramework\Http\TemplateResponse;
+use OCP\AppFramework\Http\Template\PublicTemplateResponse;
 use OCP\IConfig;
 use OCP\IInitialStateService;
 use OCP\IRequest;
@@ -122,7 +122,7 @@ class PublicViewControllerTest extends TestCase {
 
 		$response = $this->controller->publicIndexWithBranding('');
 
-		$this->assertInstanceOf(TemplateResponse::class, $response);
+		$this->assertInstanceOf(PublicTemplateResponse::class, $response);
 		$this->assertEquals([
 			'share_url' => 'protocol://host123/456',
 			'preview_image' => 'absoluteImagePath456'
@@ -199,12 +199,12 @@ class PublicViewControllerTest extends TestCase {
 
 		$response = $this->controller->publicIndexForEmbedding('');
 
-		$this->assertInstanceOf(TemplateResponse::class, $response);
+		$this->assertInstanceOf(PublicTemplateResponse::class, $response);
 		$this->assertEquals([
 			'share_url' => 'protocol://host123/456',
 			'preview_image' => 'absoluteImagePath456'
 		], $response->getParams());
-		$this->assertEquals('base', $response->getRenderAs());
+		$this->assertEquals('public', $response->getRenderAs());
 		$this->assertEquals('main', $response->getTemplateName());
 	}
 }


### PR DESCRIPTION
The public calendar view used 'base' `Template` responses, preventing the footer that's being used on other public sharing pages from showing. This makes use of `PublicTemplateResponse` to show it automatically. It's however hidden (unchanged) on embed view.

Reference: https://help.nextcloud.com/t/feature-request-impressum-and-privacy-declaration-links/161162

![localhost_8080_index php_apps_calendar_p_z9gd4FP8sgB8k8Cs_dayGridMonth_now](https://user-images.githubusercontent.com/2197836/235614200-aabf631c-a463-4de2-a8bc-94e91cdf846b.png)
