### PR TITLE
fix: Do not disable multiple calendar picker with one option

### DIFF
--- a/src/components/Shared/CalendarPicker.vue
+++ b/src/components/Shared/CalendarPicker.vue
@@ -50,7 +50,9 @@ export default {
 	},
 	computed: {
 		isDisabled() {
-			return this.calendars.length < 2
+			// for pickers where multiple can be selected (zero or more) we don't want to disable the picker
+			// for calendars where only one calendar can be selected, disable if there are < 2
+			return this.multiple ? this.calendars.length < 1 : this.calendars.length < 2
 		},
 	},
 	methods: {


### PR DESCRIPTION
Fixes #5223 and #4697

See discussion on #5223

Basically, 'multiple' calendar pickers should not be disabled when the number of calendars is 2 or fewer. Because 'multiple' select calendars can have 0, 1, 2... calendars selected. So they should only be disabled if calendars < 1