### PR TITLE
Make it clearer that confirmation is needed for appointments

### DIFF
--- a/lib/Service/Appointments/MailService.php
+++ b/lib/Service/Appointments/MailService.php
@@ -118,7 +118,10 @@ class MailService {
 		// Heading
 		$summary = $this->l10n->t("Dear %s, please confirm your booking", [$booking->getDisplayName()]);
 		$template->addHeading($summary);
-
+		
+		$bookingUrl = $this->urlGenerator->linkToRouteAbsolute('calendar.booking.confirmBooking', ['token' => $booking->getToken()]);
+		$template->addBodyButton($this->l10n->t('Confirm'), $bookingUrl);
+		
 		$template->addBodyListItem($user->getDisplayName(), 'Appointment with:');
 		if (!empty($config->getDescription())) {
 			$template->addBodyListItem($config->getDescription(), 'Description:');
@@ -126,9 +129,6 @@ class MailService {
 
 		// Create Booking overview
 		$this->addBulletList($template, $this->l10n, $booking, $config);
-
-		$bookingUrl = $this->urlGenerator->linkToRouteAbsolute('calendar.booking.confirmBooking', ['token' => $booking->getToken()]);
-		$template->addBodyButton($this->l10n->t('Confirm'), $bookingUrl);
 
 		$bodyText = $this->l10n->t('This confirmation link expires in %s hours.', [(BookingService::EXPIRY / 3600)]);
 		$template->addBodyText($bodyText);

--- a/src/components/Appointments/AppointmentBookingConfirmation.vue
+++ b/src/components/Appointments/AppointmentBookingConfirmation.vue
@@ -24,7 +24,7 @@
 	<div class="appointment-booking-confirmation">
 		<EmptyContent :title="$t('calendar', 'Please confirm your reservation')" :description="$t('calendar', 'We sent you an email with details. Please confirm your appointment using the link in the email. You can close this page now.')">
 			<template #icon>
-				<CheckIcon decorative />
+				<EmailIcon decorative />
 			</template>
 		</EmptyContent>
 	</div>
@@ -32,13 +32,13 @@
 
 <script>
 import EmptyContent from '@nextcloud/vue/dist/Components/NcEmptyContent.js'
-import CheckIcon from 'vue-material-design-icons/Check.vue'
+import EmailIcon from 'vue-material-design-icons/Email.vue'
 
 export default {
 	name: 'AppointmentBookingConfirmation',
 	components: {
 		EmptyContent,
-		CheckIcon,
+		EmailIcon,
 	},
 }
 </script>


### PR DESCRIPTION
Does two things to fix #5189

1. Uses an 'email' icon instead of a 'check' icon on the page after submitting an appointment request. The checkmark is confusing and implies that the booking has been confirmed.

Before:
<img width="755" alt="Screen Region 2023-05-15 at 20 49 25" src="https://github.com/nextcloud/calendar/assets/150431/c87954ec-7a9b-4f67-bb68-4d6d9cb89ff4">

After:
<img width="590" alt="Screen Region 2023-05-15 at 20 51 49" src="https://github.com/nextcloud/calendar/assets/150431/b8467f62-f0be-446d-ae87-e95b876dbd3a">


2. Moved the 'confirm' button further up in the confirmation email, so people can see it more clearly that they have to click it
Problem:
<img width="733" alt="Screen Region 2023-05-15 at 20 21 12" src="https://github.com/nextcloud/calendar/assets/150431/70f03cdc-d5f4-4969-b9b9-2639196e5383">




I would also say the wording on the page on no.1 should also be improved, but I'm not sure how that works with translations so I've left it for now.