### PR TITLE
Include name of booking creator in event name in calendar

### DIFF
--- a/lib/Service/Appointments/BookingCalendarWriter.php
+++ b/lib/Service/Appointments/BookingCalendarWriter.php
@@ -113,7 +113,8 @@ class BookingCalendarWriter {
 			'CALSCALE' => 'GREGORIAN',
 			'VERSION' => '2.0',
 			'VEVENT' => [
-				'SUMMARY' => $config->getName(),
+				// TRANSLATORS Title for event appoinment, first the attendee name, then the appointment name
+				'SUMMARY' => $this->l10n->t('%1$s - %2$s', [$displayName, $config->getName()]),
 				'STATUS' => 'CONFIRMED',
 				'DTSTART' => $start,
 				'DTEND' => $start->setTimestamp($start->getTimestamp() + ($config->getLength()))


### PR DESCRIPTION
This is a really simple fix for #4263 -  I won't argue that this is the best or most 'complete' fix, but it's already a big improvement on having *all* appointments use the same name.

The format is now: `[DisplayName] - [AppointmentName]`

Throwing this out there in the hopes it can get merged quickly. If people still think having a field to enter 'topic' or 'meeting title' is worthwhile, then #4263 can be kept open for that. :)