### PR TITLE
feat(appointments): Disable the booking button while loading

### DIFF
--- a/src/components/Appointments/AppointmentDetails.vue
+++ b/src/components/Appointments/AppointmentDetails.vue
@@ -28,7 +28,8 @@
 					v-model="displayName"
 					type="text"
 					class="no-close"
-					required>
+					required
+					:disabled="isLoading">
 				<div>
 					{{ $t('calendar', 'Your email address') }}
 				</div>
@@ -38,6 +39,7 @@
 					autocapitalize="none"
 					autocomplete="on"
 					autocorrect="off"
+					:disabled="isLoading"
 					required>
 				<div class="meeting-info">
 					{{ $t('calendar', 'Please share anything that will help prepare for our meeting') }}
@@ -47,7 +49,8 @@
 							v-autosize="true"
 							rows="8"
 							autocapitalize="none"
-							autocomplete="off" />
+							autocomplete="off"
+							:disabled="isLoading" />
 					</div>
 				</div>
 				<div v-if="showError"

--- a/src/components/Appointments/AppointmentDetails.vue
+++ b/src/components/Appointments/AppointmentDetails.vue
@@ -55,7 +55,7 @@
 					{{ $t('calendar', 'Could not book the appointment. Please try again later or contact the organizer.') }}
 				</div>
 				<div class="buttons">
-					<NcButton type="primary" @click="save">
+					<NcButton type="primary" @click="save" :disabled="isLoading">
 						{{ $t('calendar', 'Book the appointment') }}
 					</NcButton>
 				</div>
@@ -113,6 +113,7 @@ export default {
 			email: this.visitorInfo.email,
 			displayName: this.visitorInfo.displayName,
 			timeZone: this.timeZoneId,
+			isLoading: false,
 		}
 	},
 	computed: {
@@ -125,12 +126,15 @@ export default {
 	},
 	methods: {
 		save() {
+			this.isLoading = true
 			this.$emit('save', {
 				slot: this.timeSlot,
 				description: this.description,
 				email: this.email,
 				displayName: this.displayName,
 				timeZone: this.timeZone,
+			}).then(() => {
+				this.isLoading = false
 			})
 		},
 	},

--- a/src/components/Appointments/AppointmentDetails.vue
+++ b/src/components/Appointments/AppointmentDetails.vue
@@ -129,6 +129,7 @@ export default {
 	},
 	methods: {
 		async save() {
+			this.canClose = false
 			this.isLoading = true
 			await this.$emit('save', {
 				slot: this.timeSlot,
@@ -137,6 +138,7 @@ export default {
 				displayName: this.displayName,
 				timeZone: this.timeZone,
 			})
+			this.canClose = true
 			this.isLoading = false
 		},
 	},

--- a/src/components/Appointments/AppointmentDetails.vue
+++ b/src/components/Appointments/AppointmentDetails.vue
@@ -58,6 +58,7 @@
 					{{ $t('calendar', 'Could not book the appointment. Please try again later or contact the organizer.') }}
 				</div>
 				<div class="buttons">
+					<NcLoadingIcon v-if="isLoading" :size="32" class="loading-icon" />
 					<NcButton type="primary" @click="save" :disabled="isLoading">
 						{{ $t('calendar', 'Book the appointment') }}
 					</NcButton>
@@ -69,6 +70,7 @@
 <script>
 import Avatar from '@nextcloud/vue/dist/Components/NcAvatar.js'
 import NcButton from '@nextcloud/vue/dist/Components/NcButton.js'
+import NcLoadingIcon from '@nextcloud/vue/dist/Components/NcLoadingIcon.js'
 import Modal from '@nextcloud/vue/dist/Components/NcModal.js'
 import autosize from '../../directives/autosize.js'
 
@@ -79,6 +81,7 @@ export default {
 	components: {
 		Avatar,
 		NcButton,
+		NcLoadingIcon,
 		Modal,
 	},
 	directives: {
@@ -176,6 +179,10 @@ export default {
 	input {
 		width: 100%;
 	}
+}
+
+.buttons .loading-icon {
+	margin-right:5px
 }
 
 .booking-error {

--- a/src/components/Appointments/AppointmentDetails.vue
+++ b/src/components/Appointments/AppointmentDetails.vue
@@ -134,15 +134,18 @@ export default {
 		async save() {
 			this.canClose = false
 			this.isLoading = true
-			await this.$emit('save', {
-				slot: this.timeSlot,
-				description: this.description,
-				email: this.email,
-				displayName: this.displayName,
-				timeZone: this.timeZone,
-			})
-			this.canClose = true
-			this.isLoading = false
+			try {
+				await this.$emit('save', {
+					slot: this.timeSlot,
+					description: this.description,
+					email: this.email,
+					displayName: this.displayName,
+					timeZone: this.timeZone,
+				})
+			} finally {
+				this.canClose = true
+				this.isLoading = false
+			}
 		},
 	},
 }

--- a/src/components/Appointments/AppointmentDetails.vue
+++ b/src/components/Appointments/AppointmentDetails.vue
@@ -125,17 +125,16 @@ export default {
 		},
 	},
 	methods: {
-		save() {
+		async save() {
 			this.isLoading = true
-			this.$emit('save', {
+			await this.$emit('save', {
 				slot: this.timeSlot,
 				description: this.description,
 				email: this.email,
 				displayName: this.displayName,
 				timeZone: this.timeZone,
-			}).then(() => {
-				this.isLoading = false
 			})
+			this.isLoading = false
 		},
 	},
 }


### PR DESCRIPTION
The server can take a bit of time to response after clicking the 'Book the appointment button' (see below video - might be my server/email server is slow, hence why it taskes 8+ seconds!). To improve UX and to avoid the user clicking the button multiple times, we should disable the button while loading and/or add a loading icon.


https://github.com/nextcloud/calendar/assets/150431/ceacf31a-7ed6-47d9-8288-435a86d8f53c


Ideally, the code would also either replace the 'Book the appointment' text with a loading spinner, or grey out the entire popup window and add a loading icon, but that's beyond my ability 😿