### PR TITLE
Fix 'after event' slot not being displayed on modal

### DIFF
--- a/lib/Db/AppointmentConfig.php
+++ b/lib/Db/AppointmentConfig.php
@@ -207,7 +207,7 @@ class AppointmentConfig extends Entity implements JsonSerializable {
 			'length' => $this->getLength(),
 			'increment' => $this->getIncrement(),
 			'preparationDuration' => $this->getPreparationDuration(),
-			'followUpDuration' => $this->getFollowupDuration(),
+			'followupDuration' => $this->getFollowupDuration(),
 			'totalLength' => $this->getTotalLength(),
 			'timeBeforeNextSlot' => $this->getTimeBeforeNextSlot(),
 			'dailyMax' => $this->getDailyMax(),


### PR DESCRIPTION
If the code is identical to another method that works, then its a typo :) it took me 20 min.

fixes #4743