### PR TITLE
"Event" instead of "New event" to fit new design (since Nextcloud 27)

### DIFF
--- a/src/components/AppNavigation/AppNavigationHeader/AppNavigationHeaderNewEvent.vue
+++ b/src/components/AppNavigation/AppNavigationHeader/AppNavigationHeaderNewEvent.vue
@@ -22,6 +22,7 @@
 
 <template>
 	<NcButton v-shortkey="['c']"
+		:aria-label="newEventButtonAriaLabel"
 		class="button new-event"
 		type="primary"
 		@click="newEvent"
@@ -29,7 +30,7 @@
 		<template #icon>
 			<Plus :size="20" />
 		</template>
-		{{ $t('calendar', 'New event') }}
+		{{ $t('calendar', 'Event') }}
 	</NcButton>
 </template>
 
@@ -42,6 +43,11 @@ export default {
 	components: {
 		Plus,
 		NcButton,
+	},
+	computed: {
+		newEventButtonAriaLabel() {
+			return this.$t('calendar', 'Create new event')
+		},
 	},
 	methods: {
 		/**


### PR DESCRIPTION
## Currently in French (longer words than in English) in Nextcloud 27 RC1 :
![2023-05-24_13-14](https://github.com/nextcloud/calendar/assets/33763786/d201659d-ff42-466e-bd29-1b71c0fbe951)
Note : It may not affect negatively previous major versions (just a shorter wording)

## After, in 3 languages : 
![2023-05-24_11-55-FR](https://github.com/nextcloud/calendar/assets/33763786/e2bfb977-429f-460f-a20c-c7e808d86931)
![2023-05-24_11-54-DE](https://github.com/nextcloud/calendar/assets/33763786/ba7b7f06-6b99-452d-8296-dccaffa30525)
![2023-05-24_11-55-EN](https://github.com/nextcloud/calendar/assets/33763786/cb1cb82c-924b-4dd2-b461-9456dd2b815a)

@nextcloud/designers 