### PR TITLE
fix: Allow dynamic autoloading for classes added during upgrade

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,6 @@
         },
         "sort-packages": true,
         "optimize-autoloader": true,
-        "classmap-authoritative": true,
         "autoloader-suffix": "Calendar",
         "allow-plugins": {
             "bamarni/composer-bin-plugin": true

--- a/tests/php/integration/Composer/AutoloaderTest.php
+++ b/tests/php/integration/Composer/AutoloaderTest.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * @copyright 2023 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @author 2023 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace OCA\Calendar\Tests\Integration\Composer;
+
+use ChristophWurst\Nextcloud\Testing\TestCase;
+use OCP\Security\ISecureRandom;
+use OCP\Server;
+use function class_exists;
+use function file_exists;
+use function file_put_contents;
+use function ucfirst;
+use function unlink;
+
+class AutoloaderTest extends TestCase {
+
+	/** @var null|string */
+	private $testClass = null;
+
+	private static function getClassPath(string $class): string {
+		return __DIR__ . '/../../../../lib/' . $class . '.php';
+	}
+
+	protected function tearDown(): void {
+		parent::tearDown();
+
+		if ($this->testClass !== null && file_exists(self::getClassPath($this->testClass))) {
+			unlink(self::getClassPath($this->testClass));
+		}
+	}
+
+	public function testLoadDynamicClass(): void {
+		$rand = Server::get(ISecureRandom::class);
+		$className = ucfirst($rand->generate(10, ISecureRandom::CHAR_LOWER));
+		$namespace = "OCA\\Calendar";
+
+		file_put_contents(self::getClassPath($className), <<<FILE
+<?php
+
+namespace $namespace;
+
+class $className {}
+FILE);
+		$this->testClass = $className;
+
+		self::assertTrue(class_exists($namespace . '\\' . $className));
+	}
+
+}


### PR DESCRIPTION
Fixes https://github.com/nextcloud/calendar/issues/5191

https://github.com/nextcloud/server/pull/6853 + authoritative class loaders for apps distributed via the app store is problematic.

What I have tested

* `composer/autoload.php` + authoritative class loader optimization: :boom: (main)
* `composer/autoload.php` + apcu class loader optimization: :sunglasses: 
* `composer/autoload.php` + basic class map optimization: :sunglasses: (here)
* no `composer/autoload.php`: :sunglasses: 

To do

- [x] Test that fails to load dynamically created classes
- [x] Fix the autoloader config

## How to test

1) Run ``composer i``
2) ``composer run test tests/php/integration/Composer``