### PR TITLE
fix(appointments): Ignore extraneous columns in AppointmentConfigMapper::findByToken

### DIFF
--- a/lib/Db/AppointmentConfigMapper.php
+++ b/lib/Db/AppointmentConfigMapper.php
@@ -77,7 +77,7 @@ class AppointmentConfigMapper extends QBMapper {
 	 */
 	public function findByToken(string $token) : AppointmentConfig {
 		$qb = $this->db->getQueryBuilder();
-		$qb->select('*')
+		$qb->select('id', 'token', 'name', 'description', 'location', 'visibility', 'user_id', 'target_calendar_uri', 'calendar_freebusy_uris', 'availability', 'start', 'end', 'length', 'increment', 'preparation_duration', 'followup_duration', 'time_before_next_slot', 'daily_max', 'future_limit')
 			->from($this->getTableName())
 			->where($qb->expr()->eq('token', $qb->createNamedParameter($token, IQueryBuilder::PARAM_STR), IQueryBuilder::PARAM_STR));
 		return $this->findEntity($qb);


### PR DESCRIPTION
Oversight of https://github.com/nextcloud/calendar/pull/5306 found in https://github.com/nextcloud/calendar/pull/5310

If someone ran the *Create Talk room for booked appointments* migration before there is a `create_talk_room` column. Let's ignore it until the feature returns. The app should work with and without the column.