### PR TITLE
fix(accessibility): replace recurrence multiselect with ncselect

### DIFF
--- a/src/components/Editor/Repeat/RepeatFreqSelect.vue
+++ b/src/components/Editor/Repeat/RepeatFreqSelect.vue
@@ -21,22 +21,19 @@
   -->
 
 <template>
-	<Multiselect :allow-empty="false"
-		:options="options"
+	<NcSelect :options="options"
 		:value="selected"
-		open-direction="bottom"
-		track-by="freq"
 		label="label"
-		@select="select" />
+		@input="select" />
 </template>
 
 <script>
-import Multiselect from '@nextcloud/vue/dist/Components/NcMultiselect.js'
+import { NcSelect } from '@nextcloud/vue'
 
 export default {
 	name: 'RepeatFreqSelect',
 	components: {
-		Multiselect,
+		NcSelect,
 	},
 	props: {
 		freq: {
@@ -74,6 +71,7 @@ export default {
 	methods: {
 		select(value) {
 			if (!value) {
+				this.$emit('change', 'NONE')
 				return
 			}
 


### PR DESCRIPTION
Fix: #4618 

I only replaced the deprecated NcMultiselect by NcSelect. Now the Select takes more space but when you select week for example, the left part is squeezed.

![image](https://github.com/nextcloud/calendar/assets/74607597/afd8ad83-1e6b-4063-aed9-910e0d57a189)
