### PR TITLE
fix(duplicateEvent): Open duplicate in sidebar not original

### DIFF
--- a/src/views/EditSimple.vue
+++ b/src/views/EditSimple.vue
@@ -270,7 +270,7 @@ export default {
 			this.requiresActionOnRouteLeave = false
 
 			const params = Object.assign({}, this.$route.params)
-			if (this.$route.name === 'NewPopoverView') {
+			if (this.isNew) {
 				this.$router.push({ name: 'NewSidebarView', params })
 			} else {
 				this.$router.push({


### PR DESCRIPTION
Fix: #4598

#### How to test:
1. Create an event
2. Open the event again in simplified editor
3. Duplicate event
4. Click "More" to show sidebar editor
5. Change something
6. Save Event

On main this leads to updating the original event.
In this PR a new event is created (with the copied and edited data)