### PR TITLE
fix(categories): fall back to empty array

### DIFF
--- a/src/mixins/EditorMixin.js
+++ b/src/mixins/EditorMixin.js
@@ -317,7 +317,7 @@ export default {
 		},
 		categoryOptions() {
 			const categories = { ...this.rfcProps.categories }
-			categories.options = loadState('calendar', 'categories')
+			categories.options = loadState('calendar', 'categories', [])
 			return categories
 		},
 		/**


### PR DESCRIPTION
Followup to #5161

The categories are not injected on some views, e.g. the public view.

## Repro

1. Create a calendar and share it publicly via a link.
2. Open the calendar in a private/anonymous tab.
3. Observe how shit breaks because the initial state for categories is missing and no fallback is specified.