### PR TITLE
Fix navigation button positioning

### DIFF
--- a/css/app-navigation.scss
+++ b/css/app-navigation.scss
@@ -35,7 +35,7 @@
 		// for the rounded corner buttons on the sides, see further below
 		border-radius: 0;
 		font-weight: normal;
-		margin: 3px -1px 3px 0;
+		margin: 0 0 var(--default-grid-baseline) 0;
 		flex-grow: 1;
 	}
 
@@ -94,6 +94,11 @@
 
 .new-event-today-view-section {
 	display: flex;
+
+	// Fix margins from core
+	.button {
+		margin: 0 var(--default-grid-baseline) 0 0;
+	}
 
 	.new-event {
 		flex-grow: 5;


### PR DESCRIPTION
To illustrate the issues, the view switcher on the right is in hovered state:
- More whitespace to the top of the navigation than to the left
- Using hardcoded values instead of variables
- "Event" and "Today" vertically not aligned with view switcher

Before | After
-|-
![image](https://github.com/nextcloud/calendar/assets/925062/0cf1dba9-3855-4f59-9a51-10b3bc8c230d)|![image](https://github.com/nextcloud/calendar/assets/925062/365cce02-df82-4bb4-b333-e36b367b3434)
