### PR TITLE
Fix navigation toggle overlap

### DIFF
--- a/css/app-navigation.scss
+++ b/css/app-navigation.scss
@@ -108,6 +108,11 @@
 	}
 }
 
+// Add background to navigation toggle to fix overlap with calendar elements
+.app-navigation-toggle {
+	background-color: var(--color-main-background) !important;
+}
+
 .app-navigation {
 	button.icon-share {
 		opacity: 0.3 !important;

--- a/css/fullcalendar.scss
+++ b/css/fullcalendar.scss
@@ -116,6 +116,16 @@
 	word-break: break-word;
 }
 
+// Prevent events overlapping over day header
+.fc .fc-list-sticky .fc-list-day > * {
+	z-index: 1;
+}
+
+// Padding to account for left navigation toggle
+.fc-list-table .fc-list-day-cushion {
+	padding-left: calc(var(--default-clickable-area) + var(--default-grid-baseline) * 2);
+}
+
 // highlight current day (exclude day view)
 .fc-timeGridWeek-view,
 .fc-dayGridMonth-view {


### PR DESCRIPTION
This fixes the leftovers of https://github.com/nextcloud/groupware/issues/2
The only part where this is still a problem is in month view in mobile mode, but all the rest is significantly better so I would consider it done for now.


https://github.com/nextcloud/calendar/assets/925062/a04a018a-f41d-4b8e-9540-c1a3af597f43

https://github.com/nextcloud/calendar/assets/925062/1a7ceb80-8fd4-4c3b-a967-40561fc8a26b