### PR TITLE
feat: Write Talk URL into location, not description

### DIFF
--- a/src/services/talkService.js
+++ b/src/services/talkService.js
@@ -122,20 +122,20 @@ export async function updateTalkParticipants(eventComponent) {
 }
 
 /**
- * Checks whether the description already contains a talk link
+ * Checks whether the value contains a talk link
  *
- * @param {?string} description Description of event
+ * @param {?string} text Haystack
  * @return {boolean}
  */
-export function doesDescriptionContainTalkLink(description) {
-	if (!description) {
+export function doesContainTalkLink(text) {
+	if (!text) {
 		return false
 	}
 
 	// TODO: there is most definitely a more reliable way,
 	// but this works for now
 	const fakeUrl = generateURLForToken()
-	return description.includes(fakeUrl)
+	return text.includes(fakeUrl)
 }
 
 /**


### PR DESCRIPTION
Fall back to description if location is filled, e.g. for a hybrid event.

This contributes part 2 of https://github.com/nextcloud/calendar/issues/5389.

## How to test

1. Set up Calendar and Talk
2. Create an event
3. Click the *Create Talk room* button

On `main` there will be an URL inserted into the description.
On this branch the URL will be written to the location if it's empty or not set. If it is, the URL is appended to the description.