### PR TITLE
feat: Ability to invite circles

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -5,9 +5,12 @@ declare(strict_types=1);
  * Calendar App
  *
  * @author Georg Ehrke
- * @copyright 2018 Georg Ehrke <oc.list@georgehrke.com>
  * @author Thomas Müller
+ * @author Jonas Heinrich
+ *
+ * @copyright 2018 Georg Ehrke <oc.list@georgehrke.com>
  * @copyright 2016 Thomas Müller <thomas.mueller@tmit.eu>
+ * @copyright 2023 Jonas Heinrich <heinrich@synyx.net>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU AFFERO GENERAL PUBLIC LICENSE
@@ -54,6 +57,8 @@ return [
 		['name' => 'contact#searchAttendee', 'url' => '/v1/autocompletion/attendee', 'verb' => 'POST'],
 		['name' => 'contact#searchLocation', 'url' => '/v1/autocompletion/location', 'verb' => 'POST'],
 		['name' => 'contact#searchPhoto', 'url' => '/v1/autocompletion/photo', 'verb' => 'POST'],
+		// Circles
+		['name' => 'contact#getCircleMembers', 'url' => '/v1/circles/getmembers', 'verb' => 'GET'],
 		// Settings
 		['name' => 'settings#setConfig', 'url' => '/v1/config/{key}', 'verb' => 'POST'],
 		// Tools

--- a/lib/Service/ServiceException.php
+++ b/lib/Service/ServiceException.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace OCA\Calendar\Service;
+
+use Exception;
+
+class ServiceException extends Exception {
+}

--- a/psalm.xml
+++ b/psalm.xml
@@ -27,6 +27,10 @@
 				<referencedClass name="Doctrine\DBAL\Types\Type" />
 				<referencedClass name="Doctrine\DBAL\Types\Types" />
 				<referencedClass name="OC\Security\CSP\ContentSecurityPolicyNonceManager" />
+				<referencedClass name="OC\App\CompareVersion" />
+				<referencedClass name="OCA\Circles\Api\v1\Circles" />
+				<referencedClass name="OCA\Circles\Exceptions\CircleNotFoundException" />
+				<referencedClass name="OCA\Calendar\Controller\Exception" />
 				<referencedClass name="Psr\Http\Client\ClientExceptionInterface" />
 				<referencedClass name="Sabre\VObject\Component\VCalendar" />
 				<referencedClass name="Sabre\VObject\Component\VTimezone" />
@@ -48,6 +52,9 @@
 				<referencedClass name="Doctrine\DBAL\Schema\Table" />
 				<referencedClass name="OC\Security\CSP\ContentSecurityPolicyNonceManager" />
 				<referencedClass name="Sabre\VObject\Component\VTimezone" />
+				<referencedClass name="OC\App\CompareVersion" />
+				<referencedClass name="OCA\Calendar\Controller\Exception" />
+				<referencedClass name="OCA\Circles\Api\v1\Circles" />
 				<referencedClass name="Symfony\Component\Console\Output\OutputInterface" />
 			</errorLevel>
 		</UndefinedDocblockClass>

--- a/src/services/circleService.js
+++ b/src/services/circleService.js
@@ -1,0 +1,100 @@
+/**
+ * @copyright Copyright (c) 2023 Jonas Heinrich
+ *
+ * @author Jonas Heinrich <heinrich@synyx.net>
+ *
+ * @license AGPL-3.0-or-later
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+import HttpClient from '@nextcloud/axios'
+import {
+	generateOcsUrl,
+	linkTo,
+} from '@nextcloud/router'
+
+/**
+ * Finds circles by displayname
+ *
+ * @param {string} query The search-term
+ * @return {Promise<void>}
+ */
+const circleSearchByName = async (query) => {
+	let results
+	try {
+		results = await HttpClient.get(generateOcsUrl('apps/files_sharing/api/v1/') + 'sharees', {
+			params: {
+				format: 'json',
+				search: query,
+				perPage: 200,
+				itemType: 'pringroucipals',
+			},
+		})
+	} catch (error) {
+		return []
+	}
+
+	if (results.data.ocs.meta.status === 'failure') {
+		return []
+	}
+
+	let circles = []
+	if (Array.isArray(results.data.ocs.data.circles)) {
+		circles = circles.concat(results.data.ocs.data.circles)
+	}
+	if (Array.isArray(results.data.ocs.data.exact.circles)) {
+		circles = circles.concat(results.data.ocs.data.exact.circles)
+	}
+
+	if (circles.length === 0) {
+		return []
+	}
+
+	return circles.filter((circle) => {
+		return true
+	}).map(circle => ({
+		displayname: circle.label,
+		population: circle.value.circle.population,
+		id: circle.value.circle.id,
+		instance: circle.value.circle.owner.instance,
+	}))
+}
+
+/**
+ * Get members of circle by id
+ *
+ * @param {string} circleId The circle id to query
+ * @return {Promise<void>}
+ */
+const circleGetMembers = async (circleId) => {
+	let results
+	try {
+		results = await HttpClient.get(linkTo('calendar', 'index.php') + '/v1/circles/getmembers', {
+			params: {
+				format: 'json',
+				circleId,
+			},
+		})
+	} catch (error) {
+		console.debug(error)
+		return []
+	}
+	return results
+}
+
+export {
+	circleSearchByName,
+	circleGetMembers,
+}

--- a/src/services/isCirclesEnabled.js
+++ b/src/services/isCirclesEnabled.js
@@ -1,0 +1,28 @@
+/**
+ * @copyright Copyright (c) 2021 John Molakvoæ <skjnldsv@protonmail.com>
+ * @copyright Copyright (c) 2023 Jonas Heinrich <heinrich@synyx.net>
+ *
+ * @author John Molakvoæ <skjnldsv@protonmail.com>
+ * @author Jonas Heinrich <heinrich@synyx.net>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+import { loadState } from '@nextcloud/initial-state'
+
+const isCirclesEnabled = loadState('calendar', 'isCirclesEnabled', false)
+export default isCirclesEnabled

--- a/src/store/calendarObjectInstance.js
+++ b/src/store/calendarObjectInstance.js
@@ -431,7 +431,7 @@ const mutations = {
 	 * @param {string=} data.timezoneId Preferred timezone of the attendee
 	 * @param {object=} data.organizer Principal of the organizer to be set if not present
 	 */
-	addAttendee(state, { calendarObjectInstance, commonName, uri, calendarUserType = null, participationStatus = null, role = null, rsvp = null, language = null, timezoneId = null, organizer = null }) {
+	addAttendee(state, { calendarObjectInstance, commonName, uri, calendarUserType = null, participationStatus = null, role = null, rsvp = null, language = null, timezoneId = null, organizer = null, member = null }) {
 		const attendee = AttendeeProperty.fromNameAndEMail(commonName, uri)
 
 		if (calendarUserType !== null) {
@@ -451,6 +451,9 @@ const mutations = {
 		}
 		if (timezoneId !== null) {
 			attendee.updateParameterIfExist('TZID', timezoneId)
+		}
+		if (member !== null) {
+			attendee.updateParameterIfExist('MEMBER', member)
 		}
 
 		// TODO - use real addAttendeeFrom method

--- a/tests/php/unit/Controller/ContactControllerTest.php
+++ b/tests/php/unit/Controller/ContactControllerTest.php
@@ -24,9 +24,11 @@ declare(strict_types=1);
 namespace OCA\Calendar\Controller;
 
 use ChristophWurst\Nextcloud\Testing\TestCase;
+use OCP\App\IAppManager;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\Contacts\IManager;
 use OCP\IRequest;
+use OCP\IUserManager;
 use PHPUnit\Framework\MockObject\MockObject;
 
 class ContactControllerTest extends TestCase {
@@ -39,6 +41,12 @@ class ContactControllerTest extends TestCase {
 	/** @var IManager|MockObject */
 	protected $manager;
 
+	/** @var IAppManager|MockObject */
+	private $appManager;
+
+	/** @var IUserManager|MockObject */
+	private $userManager;
+
 	/** @var ContactController */
 	protected $controller;
 
@@ -48,8 +56,10 @@ class ContactControllerTest extends TestCase {
 		$this->appName = 'calendar';
 		$this->request = $this->createMock(IRequest::class);
 		$this->manager = $this->createMock(IManager::class);
+		$this->appManager = $this->createMock(IAppManager::class);
+		$this->userManager = $this->createMock(IUserManager::class);
 		$this->controller = new ContactController($this->appName,
-			$this->request, $this->manager);
+			$this->request, $this->manager, $this->appManager, $this->userManager);
 	}
 
 	public function testSearchLocationDisabled():void {

--- a/tests/php/unit/Controller/ViewControllerTest.php
+++ b/tests/php/unit/Controller/ViewControllerTest.php
@@ -27,6 +27,7 @@ declare(strict_types=1);
 namespace OCA\Calendar\Controller;
 
 use ChristophWurst\Nextcloud\Testing\TestCase;
+use OC\App\CompareVersion;
 use OCA\Calendar\Db\AppointmentConfig;
 use OCA\Calendar\Service\Appointments\AppointmentConfigService;
 use OCP\App\IAppManager;
@@ -65,6 +66,9 @@ class ViewControllerTest extends TestCase {
 	/** @var IAppData|MockObject */
 	private $appData;
 
+	/** @var CompareVersion|MockObject*/
+	private $compareVersion;
+
 	protected function setUp(): void {
 		$this->appName = 'calendar';
 		$this->request = $this->createMock(IRequest::class);
@@ -72,6 +76,7 @@ class ViewControllerTest extends TestCase {
 		$this->config = $this->createMock(IConfig::class);
 		$this->appointmentContfigService = $this->createMock(AppointmentConfigService::class);
 		$this->initialStateService = $this->createMock(IInitialState::class);
+		$this->compareVersion = $this->createMock(CompareVersion::class);
 		$this->userId = 'user123';
 		$this->appData = $this->createMock(IAppData::class);
 
@@ -82,6 +87,7 @@ class ViewControllerTest extends TestCase {
 			$this->appointmentContfigService,
 			$this->initialStateService,
 			$this->appManager,
+			$this->compareVersion,
 			$this->userId,
 			$this->appData,
 		);
@@ -122,22 +128,24 @@ class ViewControllerTest extends TestCase {
 				['user123', 'calendar', 'defaultReminder', 'defaultDefaultReminder', '00:10:00'],
 				['user123', 'calendar', 'showTasks', 'defaultShowTasks', '00:15:00'],
 			]);
-		$this->appManager->expects(self::exactly(2))
+		$this->appManager->expects(self::exactly(3))
 			->method('isEnabledForUser')
 			->willReturnMap([
 				['spreed', null, true],
-				['tasks', null, true]
+				['tasks', null, true],
+				['circles', null, false],
 			]);
-		$this->appManager->expects(self::once())
+		$this->appManager->expects(self::exactly(2))
 			->method('getAppVersion')
 			->willReturnMap([
 				['spreed', true, '12.0.0'],
+				['circles', true, '22.0.0'],
 			]);
 		$this->appointmentContfigService->expects(self::once())
 			->method('getAllAppointmentConfigurations')
 			->with($this->userId)
 			->willReturn([new AppointmentConfig()]);
-		$this->initialStateService->expects(self::exactly(21))
+		$this->initialStateService->expects(self::exactly(22))
 			->method('provideInitialState')
 			->withConsecutive(
 				['app_version', '1.0.0'],
@@ -161,6 +169,7 @@ class ViewControllerTest extends TestCase {
 				['disable_appointments', false],
 				['can_subscribe_link', false],
 				['show_resources', true],
+				['isCirclesEnabled', false],
 			);
 
 		$response = $this->controller->index();
@@ -212,22 +221,24 @@ class ViewControllerTest extends TestCase {
 				['user123', 'calendar', 'defaultReminder', 'defaultDefaultReminder', '00:10:00'],
 				['user123', 'calendar', 'showTasks', 'defaultShowTasks', '00:15:00'],
 			]);
-		$this->appManager->expects(self::exactly(2))
+		$this->appManager->expects(self::exactly(3))
 			->method('isEnabledForUser')
 			->willReturnMap([
 				['spreed', null, false],
-				['tasks', null, false]
+				['tasks', null, false],
+				['circles', null, false],
 			]);
-		$this->appManager->expects(self::once())
+		$this->appManager->expects(self::exactly(2))
 			->method('getAppVersion')
 			->willReturnMap([
 				['spreed', true, '11.3.0'],
+				['circles', true, '22.0.0'],
 			]);
 		$this->appointmentContfigService->expects(self::once())
 			->method('getAllAppointmentConfigurations')
 			->with($this->userId)
 			->willReturn([new AppointmentConfig()]);
-		$this->initialStateService->expects(self::exactly(21))
+		$this->initialStateService->expects(self::exactly(22))
 			->method('provideInitialState')
 			->withConsecutive(
 				['app_version', '1.0.0'],
@@ -251,6 +262,7 @@ class ViewControllerTest extends TestCase {
 				['disable_appointments', false],
 				['can_subscribe_link', false],
 				['show_resources', true],
+				['isCirclesEnabled', false],
 			);
 
 		$response = $this->controller->index();


### PR DESCRIPTION
```
This commit adds support for adding circles as attendees to a calendar event.
The relationship between the imported group and members will be compliant with
the iCal specification.

A circle with the title "testcircle" will be added as an attendee with iCal
attributes "CUTYPE=GROUP` and uri "mailto:circle+CIRCLEID@CIRCLE_INSTANCE".

Members of the circle will be imported as standard attendees. Each member gets
assigned to the circle group entry by assigning them to the group uri using the
iCal member property: "MEMBER='mailto:circle+CIRCLEID@CIRCLE_INSTANCE'".

Searching for circles is only enabled if the circles app is activated.

Circles added to the list of attendees get imported only once and are not
synced yet. While adding a circle, a notice about this is shown to the user.
Only members of local circles which are local users get imported.

Rendering groups in the frontend is done in a separate PR
https://github.com/nextcloud/calendar/pull/5396
```

![image](https://github.com/nextcloud/calendar/assets/757752/36b8b55f-4334-4c0e-831a-cadf06fddc19)

Closes https://github.com/nextcloud/calendar/issues/2954

Work inspired by @tcitworld PR https://github.com/nextcloud/calendar/pull/4742