### PR TITLE
fix(scheduling): Use attendee placeholder avatars

### DIFF
--- a/src/components/Editor/AvatarParticipationStatus.vue
+++ b/src/components/Editor/AvatarParticipationStatus.vue
@@ -23,8 +23,9 @@
 <template>
 	<div class="avatar-participation-status">
 		<Avatar :disable-tooltip="true"
-			:user="avatarLink"
-			:is-no-user="isResource" />
+			:user="commonName"
+			:display-name="commonName"
+			:is-no-user="true" />
 		<template v-if="participationStatus === 'ACCEPTED' && isViewedByOrganizer">
 			<IconCheck class="avatar-participation-status__indicator"
 				fill-color="#32CD32"


### PR DESCRIPTION
Instead of broken user avatars. This is not a comprehensive fix but a workaround for #3099, which is not trivial to fix.

| Before | After |
|--------|--------|
| ![Bildschirmfoto vom 2023-09-06 09-16-11](https://github.com/nextcloud/calendar/assets/1374172/7b9c1c9a-e780-4b5f-b9a8-6d23e22ba5b4) | ![Bildschirmfoto vom 2023-09-06 09-13-32](https://github.com/nextcloud/calendar/assets/1374172/c9b36e8d-5d27-4de7-9721-3cdee05dc238) |
