### PR TITLE
fix: error handling for exceptions for recurrence next

### DIFF
--- a/src/mixins/EditorMixin.js
+++ b/src/mixins/EditorMixin.js
@@ -714,10 +714,19 @@ export default {
 					const closeToDate = dateFactory()
 					// TODO: can we replace this by simply returning the new route since we are inside next()
 					// Probably not though, because it's async
-					await vm.loadingCalendars()
-					const recurrenceId = await vm.$store.dispatch('resolveClosestRecurrenceIdForCalendarObject', { objectId, closeToDate })
-					const params = Object.assign({}, vm.$route.params, { recurrenceId })
-					vm.$router.replace({ name: vm.$route.name, params })
+					try {
+						await vm.loadingCalendars()
+						const recurrenceId = await vm.$store.dispatch('resolveClosestRecurrenceIdForCalendarObject', { objectId, closeToDate })
+						const params = Object.assign({}, vm.$route.params, { recurrenceId })
+						vm.$router.replace({ name: vm.$route.name, params })
+					} catch (error) {
+						console.debug(error)
+						vm.isError = true
+						vm.error = t('calendar', 'It might have been deleted, or there was a typo in a link')
+						return // if we cannot resolve next to an actual recurrenceId, return here to avoid further processing.
+					} finally {
+						vm.isLoading = false
+					}
 				}
 
 				try {


### PR DESCRIPTION
Companion for https://github.com/nextcloud/server/pull/40301

Handle exceptions that may happen when resolving recurrence next to an actual recurrence id.

| Before | After |
|--------|--------|
| ![image](https://github.com/nextcloud/calendar/assets/3902676/55805b21-d51b-48d5-b7a4-6cc3f579f999) | ![image](https://github.com/nextcloud/calendar/assets/3902676/579c04f1-238b-4c5c-8558-37dcde5908bc) |

**How to test**

- You need an invalid object id and recurrence next to trigger the state.
- Have the activity app
- Create an event
- Patch apps/dav/lib/CalDAV/Activity/Provider/Event.php with the patch below
- Open activity
- Click on calendar event
- Without the patch: Endless loading animation





**Patch**

```
Index: apps/dav/lib/CalDAV/Activity/Provider/Event.php
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/apps/dav/lib/CalDAV/Activity/Provider/Event.php b/apps/dav/lib/CalDAV/Activity/Provider/Event.php
--- a/apps/dav/lib/CalDAV/Activity/Provider/Event.php	(revision 2bd0f07e5a1bb1a83ec3b1c86c1a1271dcdad9e3)
+++ b/apps/dav/lib/CalDAV/Activity/Provider/Event.php	(date 1695136734933)
@@ -97,7 +97,7 @@
 				// The calendar app needs to be manually loaded for the routes to be loaded
 				OC_App::loadApp('calendar');
 				$linkData = $eventData['link'];
-				$objectId = base64_encode($this->url->getWebroot() . '/remote.php/dav/calendars/' . $linkData['owner'] . '/' . $linkData['calendar_uri'] . '/' . $linkData['object_uri']);
+				$objectId = base64_encode('blub' . '/remote.php/dav/calendars/' . $linkData['owner'] . '/' . $linkData['calendar_uri'] . '/' . $linkData['object_uri']);
 				$link = [
 					'view' => 'dayGridMonth',
 					'timeRange' => 'now',

```