### PR TITLE
fix(dashboard): properly handle recurring events

### DIFF
--- a/lib/Dashboard/CalendarWidgetV2.php
+++ b/lib/Dashboard/CalendarWidgetV2.php
@@ -43,10 +43,8 @@ class CalendarWidgetV2 extends CalendarWidget implements IAPIWidgetV2 {
 		$halfEmptyContentMessage = '';
 		if (!empty($widgetItems)) {
 			$startOfTomorrow = $this->timeFactory->getDateTime('tomorrow')->getTimestamp();
-			foreach ($widgetItems as $item) {
-				if ((int)$item->getSinceId() >= $startOfTomorrow) {
-					$halfEmptyContentMessage = $this->l10n->t('No more events today');
-				}
+			if ($widgetItems[0]->getSinceId() >= $startOfTomorrow) {
+				$halfEmptyContentMessage = $this->l10n->t('No more events today');
 			}
 		}
 


### PR DESCRIPTION
- [x] Requires https://github.com/nextcloud/server/pull/40541

The dashboard will now correctly show and sort recurring events.

This also works without the server patch and will just hide outdated recurrences in this case. I think we should merge this asap to have proper event ordering.