### PR TITLE
Reset attendees participation on eventDrop

### DIFF
--- a/src/fullcalendar/interaction/eventDrop.js
+++ b/src/fullcalendar/interaction/eventDrop.js
@@ -68,6 +68,19 @@ export default function(store, fcAPI) {
 			return
 		}
 
+		// Reset attendees participation state to NEEDS-ACTION, since eventDrop
+		// is always a signification change
+		// Partly a workaround for Sabre-DAV not respecting RFC 6638 3.2.8, see
+		// https://github.com/sabre-io/dav/issues/1282
+		if (eventComponent.organizer && eventComponent.hasProperty('ATTENDEE')) {
+			const organizer = eventComponent.getFirstProperty('ORGANIZER')
+			for (const attendee of eventComponent.getAttendeeIterator()) {
+				if (organizer.value !== attendee.value) {
+					attendee.participationStatus = 'NEEDS-ACTION'
+				}
+			}
+		}
+
 		try {
 			// shiftByDuration may throw exceptions in certain cases
 			eventComponent.shiftByDuration(deltaDuration, event.allDay, timezone, defaultAllDayDuration, defaultTimedDuration)


### PR DESCRIPTION
Following change resets participation state of all attendees (except organizer) on eventDrop to NEEDS-ACTION. Considering that eventDrop would be always a significant change. This will trigger resending of an invitation.

This is a workaround for sabre-dav doesn't respecting [RFC 6638 3.2.8](https://datatracker.ietf.org/doc/html/rfc6638#section-3.2.8): https://github.com/sabre-io/dav/issues/1282

Addresses: https://github.com/nextcloud/server/issues/13862

