### PR TITLE
[stable5.4] chore(deps): bump @nextcloud/calendar-availability-vue to 1.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "@fullcalendar/vue": "6.1.8",
         "@nextcloud/auth": "^2.1.0",
         "@nextcloud/axios": "^2.4.0",
-        "@nextcloud/calendar-availability-vue": "^1.0.0",
+        "@nextcloud/calendar-availability-vue": "^1.0.1",
         "@nextcloud/calendar-js": "^6.0.1",
         "@nextcloud/cdav-library": "^1.1.0",
         "@nextcloud/dialogs": "^4.2.0-beta.4",
@@ -2987,9 +2987,9 @@
       }
     },
     "node_modules/@nextcloud/calendar-availability-vue": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@nextcloud/calendar-availability-vue/-/calendar-availability-vue-1.0.0.tgz",
-      "integrity": "sha512-vB1mJC/mGSo+a/7K2zw4xwR9R/GPM4qlfkGVSl1nEQtPP7Mk3el5T+3DYKWr1843JW6c/6ujTXqVLu2SIMbW5w==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@nextcloud/calendar-availability-vue/-/calendar-availability-vue-1.0.1.tgz",
+      "integrity": "sha512-fBKXvq+UFYHNxBe/UKPD3gp4ueZFj12VuLL7/F/dsz4PGLMUd7aeyyWe9qNnujiwKWZhmAKlXqOx+iOVLe8Scg==",
       "dependencies": {
         "@nextcloud/logger": "^2.4.0",
         "ical.js": "^1.4.0",
@@ -19994,9 +19994,9 @@
       "dev": true
     },
     "@nextcloud/calendar-availability-vue": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@nextcloud/calendar-availability-vue/-/calendar-availability-vue-1.0.0.tgz",
-      "integrity": "sha512-vB1mJC/mGSo+a/7K2zw4xwR9R/GPM4qlfkGVSl1nEQtPP7Mk3el5T+3DYKWr1843JW6c/6ujTXqVLu2SIMbW5w==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@nextcloud/calendar-availability-vue/-/calendar-availability-vue-1.0.1.tgz",
+      "integrity": "sha512-fBKXvq+UFYHNxBe/UKPD3gp4ueZFj12VuLL7/F/dsz4PGLMUd7aeyyWe9qNnujiwKWZhmAKlXqOx+iOVLe8Scg==",
       "requires": {
         "@nextcloud/logger": "^2.4.0",
         "ical.js": "^1.4.0",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "@fullcalendar/vue": "6.1.8",
     "@nextcloud/auth": "^2.1.0",
     "@nextcloud/axios": "^2.4.0",
-    "@nextcloud/calendar-availability-vue": "^1.0.0",
+    "@nextcloud/calendar-availability-vue": "^1.0.1",
     "@nextcloud/calendar-js": "^6.0.1",
     "@nextcloud/cdav-library": "^1.1.0",
     "@nextcloud/dialogs": "^4.2.0-beta.4",


### PR DESCRIPTION
Ref https://github.com/nextcloud/calendar-availability-vue/pull/165

| Before | After |
| --- | --- |
| ![before](https://user-images.githubusercontent.com/6078378/270280979-1698704b-6277-4b78-95c3-483c702229f5.png) | ![grafik](https://github.com/nextcloud/calendar-availability-vue/assets/1479486/af3a7e2f-c436-47a9-b38b-29d0a01a94c5)  |