### PR TITLE
fix(appointments): Write Talk link to event

### DIFF
--- a/lib/Service/Appointments/BookingCalendarWriter.php
+++ b/lib/Service/Appointments/BookingCalendarWriter.php
@@ -180,8 +180,8 @@ class BookingCalendarWriter {
 			$vcalendar->VEVENT->add($alarm);
 		}
 
-		if ($config->getLocation() !== null) {
-			$vcalendar->VEVENT->add('LOCATION', $config->getLocation());
+		if ($location !== null) {
+			$vcalendar->VEVENT->add('LOCATION', $location);
 		}
 
 		$vcalendar->VEVENT->add('X-NC-APPOINTMENT', $config->getToken());


### PR DESCRIPTION
## How to test

0) Have Talk set up
1) Create an appointment config, enable the Talk link integration
2) Open the booking page
3) Book
4) Confirm
4) Open the event as organizer

main: Event has no location set
here: Event has location set to the Talk URL