### PR TITLE
fix(appointments): switch to/from order for the booking information email (to the organizer)

### DIFF
--- a/lib/Service/Appointments/MailService.php
+++ b/lib/Service/Appointments/MailService.php
@@ -284,12 +284,12 @@ class MailService {
 		if ($toEmail === null) {
 			throw new ServiceException('Organizer has no email set');
 		}
-		$fromName = $user->getDisplayName();
+		$toName = $user->getDisplayName();
 
 		$sys = $this->getSysEmail();
 		$message = $this->mailer->createMessage()
-			->setFrom([$sys => $fromName])
-			->setTo([$toEmail => $booking->getDisplayName()]);
+			->setFrom([$sys => $booking->getDisplayName()])
+			->setTo([$toEmail => $toName]);
 
 
 		$template = $this->mailer->createEMailTemplate('calendar.confirmOrganizer');


### PR DESCRIPTION
I noticed that the confirmation email I receive when somebody else books an appointment has the from/to names mixed up.

Right now it looks like this:

<img width="476" alt="Screen Region 2023-11-22 at 17 34 44" src="https://github.com/nextcloud/calendar/assets/150431/cc47e2a8-a4a1-4592-be0c-fbd43db4af2e">

To clarify, it's set as:

```
From: MY NAME <no-reply@nextcloud.address>
To: PERSON WHO BOOKED <my-email@domain.com>
```

but it should be:
```
From: PERSON WHO BOOKED <no-reply@nextcloud.address>
To: MY NAME <my-email@domain.com>
```

This is really confusing, the names are mixed so it looks like the email has been send *from* me but *to* the person who booked. That's the case for all the other emails (to the person who booked) but this one should be the other way around :)