### PR TITLE
Allow to define and subscribe to custom public calendars

### DIFF
--- a/lib/Controller/ViewController.php
+++ b/lib/Controller/ViewController.php
@@ -120,6 +120,7 @@ class ViewController extends Controller {
 		}
 		$canSubscribeLink = $this->config->getAppValue('dav', 'allow_calendar_link_subscriptions', 'yes') === 'yes';
 		$showResources = $this->config->getAppValue($this->appName, 'showResources', 'yes') === 'yes';
+		$publicCalendars = $this->config->getAppValue($this->appName, 'publicCalendars', '');
 
 		$talkEnabled = $this->appManager->isEnabledForUser('spreed');
 		$talkApiVersion = version_compare($this->appManager->getAppVersion('spreed'), '12.0.0', '>=') ? 'v4' : 'v1';
@@ -152,6 +153,7 @@ class ViewController extends Controller {
 		$this->initialStateService->provideInitialState('can_subscribe_link', $canSubscribeLink);
 		$this->initialStateService->provideInitialState('show_resources', $showResources);
 		$this->initialStateService->provideInitialState('isCirclesEnabled', $isCirclesEnabled && $isCircleVersionCompatible);
+		$this->initialStateService->provideInitialState('publicCalendars', $publicCalendars);
 
 		return new TemplateResponse($this->appName, 'main');
 	}

--- a/src/components/AppNavigation/CalendarList/CalendarListNew.vue
+++ b/src/components/AppNavigation/CalendarList/CalendarListNew.vue
@@ -98,9 +98,19 @@
 					<Web :size="20" decorative />
 				</template>
 			</ActionButton>
+			<ActionButton v-if="hasPublicCalendars" @click="showPublicCalendarSubscriptionPicker = true">
+				{{ t('calendar', 'Add custom public calendar') }}
+				<template #icon>
+					<Web :size="20" decorative />
+				</template>
+			</ActionButton>
 		</template>
 		<template #extra>
-			<HolidaySubscriptionPicker v-if="showHolidaySubscriptionPicker" @close="showHolidaySubscriptionPicker = false" />
+			<PublicCalendarSubscriptionPicker v-if="showHolidaySubscriptionPicker"
+				:show-holidays="true"
+				@close="showHolidaySubscriptionPicker = false" />
+			<PublicCalendarSubscriptionPicker v-if="showPublicCalendarSubscriptionPicker"
+				@close="showPublicCalendarSubscriptionPicker = false" />
 		</template>
 	</AppNavigationItem>
 </template>
@@ -136,7 +146,7 @@ export default {
 		AppNavigationItem,
 		CalendarBlank,
 		CalendarCheck,
-		HolidaySubscriptionPicker: () => import(/* webpackChunkName: "holiday-subscription-picker" */ '../../Subscription/HolidaySubscriptionPicker.vue'),
+		PublicCalendarSubscriptionPicker: () => import(/* webpackChunkName: "public-calendar-subscription-picker" */ '../../Subscription/PublicCalendarSubscriptionPicker.vue'),
 		LinkVariant,
 		Plus,
 		Web,
@@ -158,11 +168,13 @@ export default {
 			showCreateSubscriptionInput: false,
 			showCreateSubscriptionSaving: false,
 			showHolidaySubscriptionPicker: false,
+			showPublicCalendarSubscriptionPicker: false,
 		}
 	},
 	computed: {
 		...mapState({
 			canSubscribeLink: state => state.settings.canSubscribeLink,
+			hasPublicCalendars: state => Boolean(state.settings.publicCalendars),
 		}),
 	},
 	watch: {

--- a/src/components/Subscription/PublicCalendarSubscriptionPicker.vue
+++ b/src/components/Subscription/PublicCalendarSubscriptionPicker.vue
@@ -28,7 +28,14 @@
 			<h2 v-else>
 				{{ t('calendar', 'Public calendars') }}
 			</h2>
-			<p v-if="showHolidays" class="holiday-subscription-picker__attribution">
+			<NcEmptyContent v-if="!calendars.length"
+				:title="$t('calendar', 'No valid public calendars configured')"
+				:description="$t('calendar', 'Speak to the server administrator to resolve this issue.' )">
+				<template #icon>
+					<CalendarBlank :size="20" decorative />
+				</template>
+			</NcEmptyContent>
+			<p v-else-if="showHolidays" class="holiday-subscription-picker__attribution">
 				{{ t('calendar',
 					'Public holiday calendars are provided by Thunderbird. Calendar data will be downloaded from {website}',
 					{ website: 'thunderbird.net' }) }}
@@ -58,9 +65,10 @@
 </template>
 
 <script>
-import { NcButton, NcModal } from '@nextcloud/vue'
+import { NcButton, NcEmptyContent, NcModal } from '@nextcloud/vue'
 import { showError } from '@nextcloud/dialogs'
 import { mapGetters } from 'vuex'
+import CalendarBlank from 'vue-material-design-icons/CalendarBlank.vue'
 
 import { findAllSubscriptions } from '../../services/caldavService.js'
 import holidayCalendars from '../../resources/holiday_calendars.json'
@@ -81,7 +89,9 @@ const isValidURL = str => {
 export default {
 	name: 'PublicCalendarSubscriptionPicker',
 	components: {
+		CalendarBlank,
 		NcButton,
+		NcEmptyContent,
 		NcModal,
 	},
 	props: {

--- a/src/store/settings.js
+++ b/src/store/settings.js
@@ -34,6 +34,7 @@ const state = {
 	firstRun: null,
 	talkEnabled: false,
 	disableAppointments: false,
+	publicCalendars: null,
 	// user-defined calendar settings
 	eventLimit: null,
 	showTasks: null,
@@ -167,8 +168,9 @@ const mutations = {
 	 * @param {boolean} data.canSubscribeLink
 	 * @param {string} data.attachmentsFolder Default user's attachments folder
 	 * @param {boolean} data.showResources Show or hide the resources tab
+	 * @param {string} data.publicCalendars
 	 */
-	loadSettingsFromServer(state, { appVersion, eventLimit, firstRun, showWeekNumbers, showTasks, showWeekends, skipPopover, slotDuration, defaultReminder, talkEnabled, tasksEnabled, timezone, hideEventExport, forceEventAlarmType, disableAppointments, canSubscribeLink, attachmentsFolder, showResources }) {
+	loadSettingsFromServer(state, { appVersion, eventLimit, firstRun, showWeekNumbers, showTasks, showWeekends, skipPopover, slotDuration, defaultReminder, talkEnabled, tasksEnabled, timezone, hideEventExport, forceEventAlarmType, disableAppointments, canSubscribeLink, attachmentsFolder, showResources, publicCalendars }) {
 		logInfo(`
 Initial settings:
 	- AppVersion: ${appVersion}
@@ -189,6 +191,7 @@ Initial settings:
 	- CanSubscribeLink: ${canSubscribeLink}
 	- attachmentsFolder: ${attachmentsFolder}
 	- ShowResources: ${showResources}
+	- PublicCalendars: ${publicCalendars}
 `)
 
 		state.appVersion = appVersion
@@ -209,6 +212,7 @@ Initial settings:
 		state.canSubscribeLink = canSubscribeLink
 		state.attachmentsFolder = attachmentsFolder
 		state.showResources = showResources
+		state.publicCalendars = publicCalendars
 	},
 
 	/**

--- a/src/views/Calendar.vue
+++ b/src/views/Calendar.vue
@@ -225,6 +225,7 @@ export default {
 			canSubscribeLink: loadState('calendar', 'can_subscribe_link', false),
 			attachmentsFolder: loadState('calendar', 'attachments_folder', false),
 			showResources: loadState('calendar', 'show_resources', true),
+			publicCalendars: loadState('calendar', 'publicCalendars'),
 		})
 		this.$store.dispatch('initializeCalendarJsConfig')
 

--- a/tests/javascript/unit/store/settings.test.js
+++ b/tests/javascript/unit/store/settings.test.js
@@ -67,6 +67,7 @@ describe('store/settings test suite', () => {
 			canSubscribeLink: true,
 			attachmentsFolder: '/Calendar',
 			showResources: true,
+			publicCalendars: null,
 		})
 	})
 
@@ -179,6 +180,7 @@ describe('store/settings test suite', () => {
 			canSubscribeLink: true,
 			attachmentsFolder: '/Calendar',
 			showResources: true,
+			publicCalendars: null,
 		}
 
 		const settings = {
@@ -201,6 +203,7 @@ describe('store/settings test suite', () => {
 			canSubscribeLink: true,
 			attachmentsFolder: '/Attachments',
 			showResources: true,
+			publicCalendars: null,
 		}
 
 		settingsStore.mutations.loadSettingsFromServer(state, settings)
@@ -226,6 +229,7 @@ Initial settings:
 	- CanSubscribeLink: true
 	- attachmentsFolder: /Attachments
 	- ShowResources: true
+	- PublicCalendars: null
 `)
 		expect(state).toEqual({
 			appVersion: '2.1.0',
@@ -248,6 +252,7 @@ Initial settings:
 			canSubscribeLink: true,
 			attachmentsFolder: '/Attachments',
 			showResources: true,
+			publicCalendars: null,
 		})
 	})
 

--- a/tests/php/unit/Controller/ViewControllerTest.php
+++ b/tests/php/unit/Controller/ViewControllerTest.php
@@ -94,7 +94,7 @@ class ViewControllerTest extends TestCase {
 	}
 
 	public function testIndex(): void {
-		$this->config->expects(self::exactly(15))
+		$this->config->expects(self::exactly(16))
 			->method('getAppValue')
 			->willReturnMap([
 				['calendar', 'eventLimit', 'yes', 'defaultEventLimit'],
@@ -112,6 +112,7 @@ class ViewControllerTest extends TestCase {
 				['calendar', 'forceEventAlarmType', '', 'forceEventAlarmType'],
 				['dav', 'allow_calendar_link_subscriptions', 'yes', 'no'],
 				['calendar', 'showResources', 'yes', 'yes'],
+				['calendar', 'publicCalendars', ''],
 			]);
 		$this->config->expects(self::exactly(11))
 			->method('getUserValue')
@@ -145,7 +146,7 @@ class ViewControllerTest extends TestCase {
 			->method('getAllAppointmentConfigurations')
 			->with($this->userId)
 			->willReturn([new AppointmentConfig()]);
-		$this->initialStateService->expects(self::exactly(22))
+		$this->initialStateService->expects(self::exactly(23))
 			->method('provideInitialState')
 			->withConsecutive(
 				['app_version', '1.0.0'],
@@ -170,6 +171,7 @@ class ViewControllerTest extends TestCase {
 				['can_subscribe_link', false],
 				['show_resources', true],
 				['isCirclesEnabled', false],
+				['publicCalendars', null],
 			);
 
 		$response = $this->controller->index();
@@ -187,7 +189,7 @@ class ViewControllerTest extends TestCase {
 	 * @param string $expectedView
 	 */
 	public function testIndexViewFix(string $savedView, string $expectedView): void {
-		$this->config->expects(self::exactly(15))
+		$this->config->expects(self::exactly(16))
 			->method('getAppValue')
 			->willReturnMap([
 				['calendar', 'eventLimit', 'yes', 'defaultEventLimit'],
@@ -205,6 +207,7 @@ class ViewControllerTest extends TestCase {
 				['calendar', 'forceEventAlarmType', '', 'forceEventAlarmType'],
 				['dav', 'allow_calendar_link_subscriptions', 'yes', 'no'],
 				['calendar', 'showResources', 'yes', 'yes'],
+				['calendar', 'publicCalendars', ''],
 			]);
 		$this->config->expects(self::exactly(11))
 			->method('getUserValue')
@@ -238,7 +241,7 @@ class ViewControllerTest extends TestCase {
 			->method('getAllAppointmentConfigurations')
 			->with($this->userId)
 			->willReturn([new AppointmentConfig()]);
-		$this->initialStateService->expects(self::exactly(22))
+		$this->initialStateService->expects(self::exactly(23))
 			->method('provideInitialState')
 			->withConsecutive(
 				['app_version', '1.0.0'],
@@ -263,6 +266,7 @@ class ViewControllerTest extends TestCase {
 				['can_subscribe_link', false],
 				['show_resources', true],
 				['isCirclesEnabled', false],
+				['publicCalendars', null],
 			);
 
 		$response = $this->controller->index();


### PR DESCRIPTION
This PR enables the admin to define custom public calendars to be subscribed.
![image](https://github.com/nextcloud/calendar/assets/428567/b7d0c076-bff5-458e-ac9f-1cdc360bec53)
![image](https://github.com/nextcloud/calendar/assets/428567/7dedb8be-1db8-4439-bf7d-bcfaa85e67cc)

linked to #962, #5167