### PR TITLE
don't filter results while sharing

### DIFF
--- a/src/components/AppNavigation/EditCalendarModal/SharingSearch.vue
+++ b/src/components/AppNavigation/EditCalendarModal/SharingSearch.vue
@@ -33,6 +33,7 @@
 			class="sharing-search__select"
 			:class="{ 'showContent': inputGiven, 'icon-loading': isLoading }"
 			:user-select="true"
+			:filter-by="filterResults"
 			open-direction="above"
 			track-by="user"
 			label="displayName"
@@ -90,7 +91,16 @@ export default {
 				isCircle,
 			})
 		},
-
+		/**
+		 * Function to filter results in NcSelect
+		 *
+		 * @param {object} option
+		 * @param {string} label
+		 * @param {string} search
+		 */
+		filterResults(option, label, search) {
+			return true
+		},
 		/**
 		 * Use the cdav client call to find matches to the query from the existing Users & Groups
 		 *


### PR DESCRIPTION
- Share only works by display name right now
- Search by email to share calendar is broken completely as there is a `filterBy` option in [vue-select](https://vue-select.org/api/props.html#filterby) whose return value defaults to `return (label || '').toLocaleLowerCase().indexOf(search.toLocaleLowerCase()) > -1`
  - `label` in  our code is set to `displayName` so only search by `displayName` works

- Since we already get our results by searching(DAV & OCS), I don't see why we need the `filterBy` option in the first place
  - So I just make the return value `true`
  - In case we do need the option, we should make it check for both `displayName` and `email` attributes 