### PR TITLE
fix Circular structure in calendar object

### DIFF
--- a/src/components/Shared/CalendarPicker.vue
+++ b/src/components/Shared/CalendarPicker.vue
@@ -2,11 +2,11 @@
 	<Select label="displayName"
 		input-id="url"
 		:disabled="isDisabled"
-		:options="calendars"
-		:value="value"
+		:options="options"
+		:value="removeCircularStructure(value)"
 		:multiple="multiple"
 		@input="change"
-		@remove="remove">
+		@option:deselected="remove">
 		<template #option="option">
 			<CalendarPickerOption :color="option.color"
 				:display-name="option.displayName"
@@ -55,6 +55,9 @@ export default {
 			// for calendars where only one calendar can be selected, disable if there are < 2
 			return this.multiple ? this.calendars.length < 1 : this.calendars.length < 2
 		},
+		options() {
+			return this.calendars.map(this.removeCircularStructure)
+		}
 	},
 	methods: {
 		/**
@@ -79,6 +82,10 @@ export default {
 			if (this.multiple) {
 				this.$emit('remove-calendar', calendar)
 			}
+		},
+		removeCircularStructure(calendar) {
+			const { dav, ...rest } = calendar
+			return rest
 		},
 	},
 }


### PR DESCRIPTION
Dav Object contains circular reference which breaks NcSelect  
<img width="861" alt="image" src="https://github.com/nextcloud/calendar/assets/40746210/03c81eb9-9ba8-436f-820e-9292d2e0fe56">
part of #5648
