### PR TITLE
fix(attachments): Convert FileList to array for FireFox

### DIFF
--- a/src/services/attachmentService.js
+++ b/src/services/attachmentService.js
@@ -97,8 +97,7 @@ const createFolder = async function(folderName, userId) {
 	})
 }
 
-const uploadLocalAttachment = async function(folder, event, dav, componentAttachments) {
-	const files = event.target.files
+const uploadLocalAttachment = async function(folder, files, dav, componentAttachments) {
 	const attachments = []
 	const promises = []
 


### PR DESCRIPTION
Firefox does not have FileList.forEach.

Fixes https://github.com/nextcloud/calendar/issues/5655

Additionally, I've added try-catch with an error toast for when upload still fails.

## How to test

1) Start Firefox
2) Create an event
3) Open the sidebar
4) Upload a local attachment

