### PR TITLE
Release v4.6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 
 # Changelog
 
+## 4.6.2 - 2024-01-03
+### Fixed
+- Uploading attachments in Firefox
+
 ## 4.6.1 - 2023-12-21
 ### Fixed
 - Localisation for month view

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -15,7 +15,7 @@
 * ☑️ Tasks! See tasks with a due date directly in the calendar
 * 🙈 **We’re not reinventing the wheel!** Based on the great [c-dav library](https://github.com/nextcloud/cdav-library), [ical.js](https://github.com/mozilla-comm/ical.js) and [fullcalendar](https://github.com/fullcalendar/fullcalendar) libraries.
 	]]></description>
-	<version>4.6.1</version>
+	<version>4.6.2</version>
 	<licence>agpl</licence>
 	<author>Anna Larch</author>
 	<author homepage="https://github.com/nextcloud/groupware">Nextcloud Groupware Team</author>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "calendar",
-  "version": "4.6.1",
+  "version": "4.6.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "calendar",
-      "version": "4.6.1",
+      "version": "4.6.2",
       "license": "agpl",
       "dependencies": {
         "@fullcalendar/core": "6.1.9",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "calendar",
   "description": "A calendar app for Nextcloud. Easily sync events from various devices, share and edit them online.",
-  "version": "4.6.1",
+  "version": "4.6.2",
   "author": "Georg Ehrke <oc.list@georgehrke.com>",
   "contributors": [
     "Georg Ehrke <oc.list@georgehrke.com>",


### PR DESCRIPTION
# Changelog

## 4.6.2 - 2024-01-03
### Fixed
- Uploading attachments in Firefox