### PR TITLE
Enh: free busy UI

### DIFF
--- a/css/freebusy.scss
+++ b/css/freebusy.scss
@@ -28,7 +28,7 @@
 	}
 
 	.blocking-event-free-busy {
-		border-color: red;
+		border-color: var(--color-primary-element);
 		border-style: solid;
 		border-left-width: 2px;
 		border-right-width: 2px;
@@ -38,10 +38,12 @@
 	}
 
 	.blocking-event-free-busy.blocking-event-free-busy--first-row {
+		border-radius: var(--border-radius) var(--border-radius) 0 0;
 		border-top-width: 2px;
 	}
 
 	.blocking-event-free-busy.blocking-event-free-busy--last-row {
+		border-radius: 0 0 var(--border-radius) var(--border-radius) ;
 		border-bottom-width: 2px;
 	}
 
@@ -66,7 +68,8 @@
 	&__colors {
 		width: 100%;
 		display:flex;
-		flex-wrap: wrap;
+		flex-direction: column;
+		padding: 5px;
 		.freebusy-caption-item {
 			display: flex;
 			align-items: center;

--- a/src/components/Appointments/AppointmentDetails.vue
+++ b/src/components/Appointments/AppointmentDetails.vue
@@ -15,7 +15,7 @@
 					{{ config.name }}
 				</h2>
 				<div class="booking__time">
-					{{date}} {{ startTime }} - {{ endTime }}
+					{{ date }} {{ startTime }} - {{ endTime }}
 				</div>
 				<!-- Description needs to stay inline due to its whitespace -->
 				<span class="booking__description">{{ config.description }}</span>
@@ -146,7 +146,7 @@ export default {
 		},
 		date() {
 			return timeStampToLocaleDate(this.timeSlot.start, this.timeZoneId)
-		}
+		},
 	},
 	methods: {
 		 save() {

--- a/src/components/Editor/Invitees/InviteesList.vue
+++ b/src/components/Editor/Invitees/InviteesList.vue
@@ -74,6 +74,11 @@
 				:organizer="calendarObjectInstance.organizer"
 				:start-date="calendarObjectInstance.startDate"
 				:end-date="calendarObjectInstance.endDate"
+				:event-title="calendarObjectInstance.title"
+				:already-invited-emails="alreadyInvitedEmails"
+				@remove-attendee="removeAttendee"
+				@add-attendee="addAttendee"
+				@update-dates="saveNewDate"
 				@close="closeFreeBusy" />
 		</div>
 	</div>
@@ -329,6 +334,10 @@ export default {
 			this.showFreeBusyModel = true
 		},
 		closeFreeBusy() {
+			this.showFreeBusyModel = false
+		},
+		saveNewDate(dates) {
+			this.$emit('update-dates', dates)
 			this.showFreeBusyModel = false
 		},
 		async createTalkRoom() {

--- a/src/store/calendarObjectInstance.js
+++ b/src/store/calendarObjectInstance.js
@@ -430,6 +430,7 @@ const mutations = {
 	 * @param {string=} data.language Preferred language of the attendee
 	 * @param {string=} data.timezoneId Preferred timezone of the attendee
 	 * @param {object=} data.organizer Principal of the organizer to be set if not present
+	 * @param data.member
 	 */
 	addAttendee(state, { calendarObjectInstance, commonName, uri, calendarUserType = null, participationStatus = null, role = null, rsvp = null, language = null, timezoneId = null, organizer = null, member = null }) {
 		const attendee = AttendeeProperty.fromNameAndEMail(commonName, uri)

--- a/src/utils/freebusy.js
+++ b/src/utils/freebusy.js
@@ -37,16 +37,16 @@ export function getColorForFBType(type = 'BUSY') {
 		return 'rgba(255,255,255,0)'
 
 	case 'BUSY-TENTATIVE':
-		return 'rgb(221,203,85)'
+		return 'rgba(184,129,0,0.3)'
 
 	case 'BUSY':
-		return 'rgb(201,136,121)'
+		return 'rgba(217,24,18,0.3)'
 
 	case 'BUSY-UNAVAILABLE':
-		return 'rgb(182,70,157)'
+		return 'rgba(219,219,219)'
 
 	default:
-		return 'rgb(0,130,201)'
+		return 'rgba(0,113,173,0.3)'
 	}
 }
 

--- a/src/views/EditSidebar.vue
+++ b/src/views/EditSidebar.vue
@@ -243,7 +243,8 @@
 				<InviteesList v-if="!isLoading"
 					:calendar-object-instance="calendarObjectInstance"
 					:is-read-only="isReadOnly"
-					:is-shared-with-me="isSharedWithMe" />
+					:is-shared-with-me="isSharedWithMe"
+					@update-dates="updateDates" />
 			</div>
 			<SaveButtons v-if="showSaveButtons"
 				class="app-sidebar-tab__buttons"
@@ -427,6 +428,15 @@ export default {
 		window.removeEventListener('keydown', this.keyboardDuplicateEvent)
 	},
 	methods: {
+		/**
+		 * Update the start and end date of this event
+		 *
+		 * @param {object} dates The new start and end date
+		 */
+		updateDates(dates) {
+			this.updateStartDate(dates.start)
+			this.updateEndDate(dates.end)
+		},
 		/**
 		 * Updates the access-class of this event
 		 *


### PR DESCRIPTION
Fixes #39
| Current state | Goal |
|--------|--------|
|https://github.com/nextcloud/calendar/assets/40746210/50a499d4-4c40-413e-b171-a8d76843c762|![image](https://github.com/nextcloud/calendar/assets/40746210/f9936455-d227-48b1-b529-d8d2b23b8ec0)| 




Todo list from design team: 
--***Nimisha***
Differences from current free/busy view:
- [x] Use components for all the elements (eg, date picker, today/previous day/next day buttons)
- [x] Add a heading "Find a time"
- [x] Add the time and time zone below the date in the top left corner
- [x] Nice-to-haves:
  - [x] The "guide" for the color (currently below the free/busy section) can be shifted into a small help section on the top right, which on hover opens a tooltip showing the guide 
  - [x] change the colors: 
    - [x] busy: `--color-error` in 0.3 opacity
    - [x] out of office/unavailable: `--color-background-darker`
    - [x] busy tentatively: `--color-warning` in 0.3 opacity
    - [x] unknown: `--color-info` in 0.3 opacity

New features:
- [x] Allow selecting different times in the modal itself: the selected time is indicated by the border (2px solid --color-primary-element with --border-radius)
- [x] Selected time is also reflected in the top left date and time
- [x] Show detailed attendees: Attendee names are shown as well as avatar and role, similar to how it's shown in the attendee list in the sidebar 
- [x] Add and remove attendees: Add attendees via a select component, similar to the attendee list in the sidebar, 
- [x] newly added attendees are shown at the bottom
- [x] Remove attendees using a close button
- [x] A done button to save changes 
-- ***Jan***
- [x] Scroll point: Currently when opening the free/busy modal, it always starts at midnight. Instead, it should scroll so the current time slot is in the middle. If it’s a full-day event, it could start at e.g. 8/9/10 AM, something of the sort. (If the person has out of office set, at their start of day for example)
- [ ] Color contrast: We need to make sure that the out of office, busy etc. blocks have proper contrast and/or are understandable without color. E.g. for out of office we could use grey with diagonal hatch pattern lines, and for busy we could use the red with diagonal criss-cross lines.
- [ ] Width: Since this element will most likely always scroll horizontally, it would be good to give it more space to the sides. Currently it is a box inside the modal, but it could also extend to the left and right edge (the text on the left should still be aligned with the other text of course). This is mostly a detail though, and least important of the points. :) 
