### PR TITLE
v3.5.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
-
 # Changelog
+
+## 3.5.8 - 2023-01-10
+### Fixed
+- Rate limit appointment booking and config creation
+- Tooltip when importing ics with invalid attendees
+- "After the event" slot not being displayed on the appointment config modal
 
 ## 3.5.7 - 2023-04-06
 ### Fixed

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -15,7 +15,7 @@
 * ☑️ Tasks! See tasks with a due date directly in the calendar
 * 🙈 **We’re not reinventing the wheel!** Based on the great [c-dav library](https://github.com/nextcloud/cdav-library), [ical.js](https://github.com/mozilla-comm/ical.js) and [fullcalendar](https://github.com/fullcalendar/fullcalendar) libraries.
 	]]></description>
-	<version>3.5.7</version>
+	<version>3.5.8</version>
 	<licence>agpl</licence>
 	<author>Anna Larch</author>
 	<author homepage="https://github.com/nextcloud/groupware">Nextcloud Groupware Team</author>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "calendar",
-  "version": "3.5.7",
+  "version": "3.5.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "calendar",
-      "version": "3.5.7",
+      "version": "3.5.8",
       "license": "agpl",
       "dependencies": {
         "@fullcalendar/core": "5.11.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "calendar",
   "description": "A calendar app for Nextcloud. Easily sync events from various devices, share and edit them online.",
-  "version": "3.5.7",
+  "version": "3.5.8",
   "author": "Georg Ehrke <oc.list@georgehrke.com>",
   "contributors": [
     "Georg Ehrke <oc.list@georgehrke.com>",


### PR DESCRIPTION
# Changelog

## 3.5.8 - 2023-01-10
### Fixed
- Rate limit appointment booking and config creation
- Tooltip when importing ics with invalid attendees
- "After the event" slot not being displayed on the appointment config modal