### PR TITLE
fix: missing public calendar initial state

### DIFF
--- a/src/views/Calendar.vue
+++ b/src/views/Calendar.vue
@@ -225,7 +225,7 @@ export default {
 			canSubscribeLink: loadState('calendar', 'can_subscribe_link', false),
 			attachmentsFolder: loadState('calendar', 'attachments_folder', false),
 			showResources: loadState('calendar', 'show_resources', true),
-			publicCalendars: loadState('calendar', 'publicCalendars'),
+			publicCalendars: loadState('calendar', 'publicCalendars', []),
 		})
 		this.$store.dispatch('initializeCalendarJsConfig')
 


### PR DESCRIPTION
The public view of calendars is currently broken. It loads indefinitely because some initial state is missing and breaking the main Calendar view.

Only main seems to be affected.