### PR TITLE
chore(vue3): migrate deprecated slot syntax

### DIFF
--- a/src/components/AppNavigation/AppointmentConfigList/AppointmentConfigListItem.vue
+++ b/src/components/AppNavigation/AppointmentConfigList/AppointmentConfigListItem.vue
@@ -30,23 +30,31 @@
 			<template #actions>
 				<ActionLink :href="config.bookingUrl"
 					target="_blank">
-					<OpenInNewIcon slot="icon" :size="20" decorative />
+					<template #icon>
+						<OpenInNewIcon :size="20" />
+					</template>
 					{{ t('calendar', 'Preview') }}
 				</ActionLink>
 				<ActionButton v-if="hasClipboard"
 					:close-after-click="true"
 					@click="copyLink">
-					<LinkVariantIcon slot="icon" :size="20" decorative />
+					<template #icon>
+						<LinkVariantIcon :size="20" />
+					</template>
 					{{ t('calendar', 'Copy link') }}
 				</ActionButton>
 				<ActionButton :close-after-click="true"
 					@click="showModal = true">
-					<PencilIcon slot="icon" :size="20" decorative />
+					<template #icon>
+						<PencilIcon :size="20" />
+					</template>
 					{{ t('calendar', 'Edit') }}
 				</ActionButton>
 				<ActionButton :close-after-click="true"
 					@click="$emit('delete', $event)">
-					<DeleteIcon slot="icon" :size="20" decorative />
+					<template #icon>
+						<DeleteIcon :size="20" />
+					</template>
 					{{ t('calendar', 'Delete') }}
 				</ActionButton>
 			</template>

--- a/src/components/AppNavigation/CalendarList/PublicCalendarListItem.vue
+++ b/src/components/AppNavigation/CalendarList/PublicCalendarListItem.vue
@@ -24,19 +24,20 @@
 		:title="calendar.displayName || $t('calendar', 'Untitled calendar')"
 		:menu-open.sync="menuOpen"
 		@click.prevent.stop="toggleEnabled">
-		<AppNavigationIconBullet v-if="calendar.enabled"
-			slot="icon"
-			:color="calendar.color"
-			@click.prevent.stop="toggleEnabled" />
+		<template #icon>
+			<AppNavigationIconBullet v-if="calendar.enabled"
+				:color="calendar.color"
+				@click.prevent.stop="toggleEnabled" />
+		</template>
 
-		<template slot="counter">
+		<template #counter>
 			<Avatar :user="owner"
 				:is-guest="true"
 				:disable-tooltip="true"
 				:disable-menu="true" />
 		</template>
 
-		<template slot="actions">
+		<template #actions>
 			<ActionButton v-if="showCopySubscriptionLinkLabel"
 				@click.prevent.stop="copySubscriptionLink">
 				<template #icon>

--- a/src/components/AppNavigation/EditCalendarModal/SharingSearch.vue
+++ b/src/components/AppNavigation/EditCalendarModal/SharingSearch.vue
@@ -39,7 +39,9 @@
 			label="displayName"
 			@search="findSharee"
 			@option:selected="shareCalendar">
-			<span slot="no-options">{{ $t('calendar', 'No users or groups') }}</span>
+			<template #no-options>
+				<span>{{ $t('calendar', 'No users or groups') }}</span>
+			</template>
 		</NcSelect>
 	</div>
 </template>

--- a/src/components/AppointmentConfigModal/NoEmailAddressWarning.vue
+++ b/src/components/AppointmentConfigModal/NoEmailAddressWarning.vue
@@ -23,7 +23,9 @@
 <template>
 	<AppNavigationItem :title="title"
 		@click="openUserSettings">
-		<AlertCircleIcon slot="icon" :size="20" decorative />
+		<template #icon>
+			<AlertCircleIcon :size="20" />
+		</template>
 	</AppNavigationItem>
 </template>
 


### PR DESCRIPTION
Fix https://github.com/nextcloud/calendar/issues/5694

I tested all migrated components locally for visual regressions.