### PR TITLE
chore: fix npm build warning about moment locales

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -45,10 +45,6 @@ webpackRules.RULE_SCSS.use = [
 ]
 
 webpackConfig.plugins.push(
-	new webpack.IgnorePlugin({
-		resourceRegExp: /^\.\/locale$/,
-		contextRegExp: /moment$/,
-	}),
 	new webpack.ProvidePlugin({
 		// Shim ICAL to prevent using the global object (window.ICAL).
 		// The library ical.js heavily depends on instanceof checks which will


### PR DESCRIPTION
Due to #5699 

Backports are not necessary.

```
WARNING in ./node_modules/moment/min/moment-with-locales.js 2159:16-50 Module not found: Error: Can't resolve './locale' in '/home/richard/src/nextcloud/master/dev_apps/calendar/node_modules/moment/min'
 @ ./node_modules/@nextcloud/moment/dist/index.mjs 1:0-50 2:0-65 6:0-8 9:58-72 9:73-81 15:0-17:2
```