### PR TITLE
fix: disable resharing of incoming shared calendars

### DIFF
--- a/src/components/AppNavigation/CalendarList/CalendarListItem.vue
+++ b/src/components/AppNavigation/CalendarList/CalendarListItem.vue
@@ -139,6 +139,12 @@ export default {
 		 * @return {boolean}
 		 */
 		canBeShared() {
+			// The backend falsely reports incoming editable shares as being shareable
+			// Ref https://github.com/nextcloud/calendar/issues/5755
+			if (this.calendar.isSharedWithMe) {
+				return false
+			}
+
 			return this.calendar.canBeShared || this.calendar.canBePublished
 		},
 		/**

--- a/src/components/AppNavigation/EditCalendarModal.vue
+++ b/src/components/AppNavigation/EditCalendarModal.vue
@@ -151,6 +151,12 @@ export default {
 		 * @return {boolean}
 		 */
 		canBeShared() {
+			// The backend falsely reports incoming editable shares as being shareable
+			// Ref https://github.com/nextcloud/calendar/issues/5755
+			if (this.calendar.isSharedWithMe) {
+				return false
+			}
+
 			return this.calendar.canBeShared || this.calendar.canBePublished
 		},
 


### PR DESCRIPTION
Fix https://github.com/nextcloud/calendar/issues/5755

| Before | After |
| --- | --- |
| ![grafik](https://github.com/nextcloud/calendar/assets/1479486/86b10868-ad33-4f2c-b156-6a50754e8e61) ![grafik](https://github.com/nextcloud/calendar/assets/1479486/a69fc352-d156-4e9c-8475-598cbd087b98) | ![grafik](https://github.com/nextcloud/calendar/assets/1479486/da15c442-fa3f-4d2f-9216-c9b4152ed364) ![grafik](https://github.com/nextcloud/calendar/assets/1479486/4bf37de0-b01d-4c0f-ae0b-bb3faca1f066) |