### PR TITLE
fix(editor): convert start date to user's tz for the sub line

### DIFF
--- a/src/views/EditSidebar.vue
+++ b/src/views/EditSidebar.vue
@@ -324,8 +324,9 @@ import InformationOutline from 'vue-material-design-icons/InformationOutline.vue
 import MapMarker from 'vue-material-design-icons/MapMarker.vue'
 
 import { shareFile } from '../services/attachmentService.js'
-import { DateTimeValue, Parameter } from '@nextcloud/calendar-js'
+import { Parameter } from '@nextcloud/calendar-js'
 import getTimezoneManager from '../services/timezoneDataProviderService.js'
+import logger from '../utils/logger.js'
 
 export default {
 	name: 'EditSidebar',
@@ -399,14 +400,16 @@ export default {
 				return ''
 			}
 
-			const timezone = getTimezoneManager()
-				.getTimezoneForId(this.calendarObjectInstance.startTimezoneId)
-			const startDateInTz = DateTimeValue
-				.fromJSDate(this.calendarObjectInstance.startDate)
-				.getInTimezone(timezone)
-				.jsDate
+			const userTimezone = getTimezoneManager().getTimezoneForId(this.currentUserTimezone)
+			if (!userTimezone) {
+				logger.warn(`User timezone not found: ${this.currentUserTimezone}`)
+				return ''
+			}
 
-			return moment(startDateInTz).locale(this.locale).fromNow()
+			const startDateInUserTz = this.calendarObjectInstance.eventComponent.startDate
+				.getInTimezone(userTimezone)
+				.jsDate
+			return moment(startDateInUserTz).locale(this.locale).fromNow()
 		},
 		attachments() {
 			return this.calendarObjectInstance?.attachments || null


### PR DESCRIPTION
Just use the user's time zone to display the sub line. This fixes displaying events with custom time zones that might not be known by our global time zone manager, e.g. when they are defined in the event itself.

## Proof of no regressions

| Before | After |
| --- | --- |
| ![grafik](https://github.com/nextcloud/calendar/assets/1479486/05219c2e-17c2-4374-a9f3-3b606d4e0eec) | ![grafik](https://github.com/nextcloud/calendar/assets/1479486/fc6b89f1-6975-424a-a6a2-87c9d7efe7de) |

The event is in `America/New_York`.
`19:20 Tuesday in New York City` is `01:20 Wednesday in Germany`
Now is 17:20 so the event starts in 8 hours for me in Germany.

Subline: `in 8 hours`