### PR TITLE
fix: added translated label to new calendar availibility prop

### DIFF
--- a/src/components/AppointmentConfigModal.vue
+++ b/src/components/AppointmentConfigModal.vue
@@ -89,6 +89,7 @@
 								:l10n-delete-slot="t('calendar', 'Delete slot')"
 								:l10n-empty-day="t('calendar', 'No times set')"
 								:l10n-add-slot="t('calendar', 'Add')"
+								:l10n-week-day-list-label="$t('dav', 'Weekdays')"
 								:l10n-monday="t('calendar', 'Monday')"
 								:l10n-tuesday="t('calendar', 'Tuesday')"
 								:l10n-wednesday="t('calendar', 'Wednesday')"


### PR DESCRIPTION
☑️** See nextcloud/server#43656**
**REQUIRED CALENDAR-VUE LIBRARY TO BE UPDATED**
- [ ] is the calendar-vue library updated to the latest version?


**Summary**
This PR does not change anything visually, but to keep things consistent across our maintained applications, I added the correct translated ARIA label. Important to get added.