### PR TITLE
fix: restore original event ordering

### DIFF
--- a/src/components/CalendarGrid.vue
+++ b/src/components/CalendarGrid.vue
@@ -128,8 +128,7 @@ export default {
 				dayHeaderDidMount,
 				eventDidMount,
 				noEventsDidMount,
-				// FIXME: remove title if upstream is fixed (https://github.com/fullcalendar/fullcalendar/issues/6608#issuecomment-954241059)
-				eventOrder: (this.$route.params.view === 'timeGridWeek' ? ['title'] : []).concat(['start', '-duration', 'allDay', eventOrder]),
+				eventOrder: ['start', '-duration', 'allDay', eventOrder],
 				forceEventDuration: false,
 				headerToolbar: false,
 				height: '100%',

--- a/src/fullcalendar/rendering/eventOrder.js
+++ b/src/fullcalendar/rendering/eventOrder.js
@@ -41,11 +41,9 @@ export default function(firstEvent, secondEvent) {
 		return (firstEvent.extendedProps.calendarId < secondEvent.extendedProps.calendarId) ? -1 : 1
 	}
 
-	/* FIXME: uncomment this if upstream is fixed (https://github.com/fullcalendar/fullcalendar/issues/6608#issuecomment-954241059)
 	if (firstEvent.title !== secondEvent.title) {
 		return (firstEvent.title < secondEvent.title) ? -1 : 1
 	}
-	 */
 
 	return 0
 }

--- a/tests/javascript/unit/fullcalendar/rendering/eventOrder.test.js
+++ b/tests/javascript/unit/fullcalendar/rendering/eventOrder.test.js
@@ -107,10 +107,8 @@ describe('fullcalendar/eventOrder test suite', () => {
 			title: 'Title 456',
 		}
 
-		/* FIXME: uncomment if upstream is fixed (https://github.com/fullcalendar/fullcalendar/issues/6608#issuecomment-954241059)
 		expect(eventOrder(firstEvent, secondEvent)).toEqual(-1)
 		expect(eventOrder(secondEvent, firstEvent)).toEqual(1)
-		 */
 	})
 
 	it('should return zero if all properties are equal', () => {


### PR DESCRIPTION
The underlying issue has been fixed upstream.

This reverts:
- c5b5f162e0ec5adae9bb57dcf75dfbbaba00afc0 (#4431)
- 5334250382703499a1c832f23a50cd321d712d8a (#4646)

Have a look at the screenshots below. Note that 
1. All events are shown in both before and after screenshots -> no regressions introduced
2. The events are ordered by name again -> old/original sort order restored

## Expanded

### Before
![before](https://github.com/nextcloud/calendar/assets/1479486/974d4ba8-be86-4ff0-9ec4-8d3fb8a5b221)

### After
![after](https://github.com/nextcloud/calendar/assets/1479486/b48e1c16-31fc-49ab-b952-c2a15ba2a508)

## Limited

### Before
![before-limited](https://github.com/nextcloud/calendar/assets/1479486/8b00248d-e84a-4d37-af02-7f4bf08fc15e)

### After
![after-limited](https://github.com/nextcloud/calendar/assets/1479486/d75ed8d2-dba0-4836-9fc9-fa120da2f1ac)