### PR TITLE
Fix PublicCalendarSubscriptionPicker import

### DIFF
--- a/src/components/AppNavigation/CalendarList/CalendarListNew.vue
+++ b/src/components/AppNavigation/CalendarList/CalendarListNew.vue
@@ -128,7 +128,6 @@ import {
 } from '@nextcloud/dialogs'
 
 import { uidToHexColor } from '../../../utils/color.js'
-import PublicCalendarSubscriptionPicker from '../../Subscription/PublicCalendarSubscriptionPicker.vue'
 
 import CalendarBlank from 'vue-material-design-icons/CalendarBlank.vue'
 import CalendarCheck from 'vue-material-design-icons/CalendarCheck.vue'
@@ -147,7 +146,7 @@ export default {
 		AppNavigationItem,
 		CalendarBlank,
 		CalendarCheck,
-		PublicCalendarSubscriptionPicker,
+		PublicCalendarSubscriptionPicker: () => import(/* webpackChunkName: "public-calendar-subscription-picker" */ '../../Subscription/PublicCalendarSubscriptionPicker.vue'),
 		LinkVariant,
 		Plus,
 		Web,

--- a/src/components/AppNavigation/CalendarList/CalendarListNew.vue
+++ b/src/components/AppNavigation/CalendarList/CalendarListNew.vue
@@ -128,6 +128,7 @@ import {
 } from '@nextcloud/dialogs'
 
 import { uidToHexColor } from '../../../utils/color.js'
+import PublicCalendarSubscriptionPicker from '../../Subscription/PublicCalendarSubscriptionPicker.vue'
 
 import CalendarBlank from 'vue-material-design-icons/CalendarBlank.vue'
 import CalendarCheck from 'vue-material-design-icons/CalendarCheck.vue'
@@ -146,7 +147,7 @@ export default {
 		AppNavigationItem,
 		CalendarBlank,
 		CalendarCheck,
-		PublicCalendarSubscriptionPicker: () => import(/* webpackChunkName: "public-calendar-subscription-picker" */ '../../Subscription/PublicCalendarSubscriptionPicker.vue'),
+		PublicCalendarSubscriptionPicker,
 		LinkVariant,
 		Plus,
 		Web,

--- a/src/components/AppNavigation/CalendarList/CalendarListNew.vue
+++ b/src/components/AppNavigation/CalendarList/CalendarListNew.vue
@@ -146,7 +146,7 @@ export default {
 		AppNavigationItem,
 		CalendarBlank,
 		CalendarCheck,
-		PublicCalendarSubscriptionPicker: () => import(/* webpackChunkName: "public-calendar-subscription-picker" */ '../../Subscription/PublicCalendarSubscriptionPicker.vue'),
+		PublicCalendarSubscriptionPicker: () => import(/* webpackChunkName: "public-calendar-subscription-picker" */ '../../Subscription/PublicCalendarSubscriptionPicker'),
 		LinkVariant,
 		Plus,
 		Web,


### PR DESCRIPTION
Fix https://github.com/nextcloud/calendar/issues/5788

I'm honestly not sure why it was previously imported in such a weird way:
`PublicCalendarSubscriptionPicker: () => import(/* webpackChunkName: "public-calendar-subscription-picker" */ '../../Subscription/PublicCalendarSubscriptionPicker.vue'),`

But importing it normally seems to work without any issues, so I guess it can go