### PR TITLE
feat: add a setting for the default calendar url

### DIFF
--- a/css/app-settings.scss
+++ b/css/app-settings.scss
@@ -73,8 +73,9 @@
 				display: block;
 			}
 		}
-		
-		&--timezone {
+
+		&--timezone,
+		&--default-calendar {
 			width: 100%;
 		
 			.multiselect {

--- a/src/components/Shared/CalendarPicker.vue
+++ b/src/components/Shared/CalendarPicker.vue
@@ -1,6 +1,6 @@
 <template>
 	<NcSelect label="id"
-		input-id="url"
+		:input-id="inputId"
 		:disabled="isDisabled"
 		:options="options"
 		:value="valueIds"
@@ -25,6 +25,7 @@
 <script>
 import { NcSelect } from '@nextcloud/vue'
 import CalendarPickerOption from './CalendarPickerOption.vue'
+import { randomId } from '../../utils/randomId.js'
 
 export default {
 	name: 'CalendarPicker',
@@ -49,12 +50,20 @@ export default {
 			type: Boolean,
 			default: false,
 		},
+		disabled: {
+			type: Boolean,
+			default: false,
+		},
+		inputId: {
+			type: String,
+			default: () => randomId(),
+		},
 	},
 	computed: {
 		isDisabled() {
 			// for pickers where multiple can be selected (zero or more) we don't want to disable the picker
 			// for calendars where only one calendar can be selected, disable if there are < 2
-			return this.multiple ? this.calendars.length < 1 : this.calendars.length < 2
+			return this.disabled || (this.multiple ? this.calendars.length < 1 : this.calendars.length < 2)
 		},
 		valueIds() {
 			if (Array.isArray(this.value)) {

--- a/src/models/principal.js
+++ b/src/models/principal.js
@@ -65,6 +65,8 @@ const getDefaultPrincipalObject = (props) => Object.assign({}, {
 	isCalendarRoom: false,
 	// The id of the principal without prefix. e.g. userId / groupId / etc.
 	principalId: null,
+	// The url of the default calendar for invitations
+	scheduleDefaultCalendarUrl: null,
 }, props)
 
 /**
@@ -80,6 +82,7 @@ const mapDavToPrincipal = (dav) => {
 	const emailAddress = dav.email
 
 	const displayname = dav.displayname
+	const scheduleDefaultCalendarUrl = dav.scheduleDefaultCalendarUrl
 
 	const isUser = dav.principalScheme.startsWith(PRINCIPAL_PREFIX_USER)
 	const isGroup = dav.principalScheme.startsWith(PRINCIPAL_PREFIX_GROUP)
@@ -118,6 +121,7 @@ const mapDavToPrincipal = (dav) => {
 		isCalendarRoom,
 		principalId,
 		userId,
+		scheduleDefaultCalendarUrl,
 	})
 }
 

--- a/src/store/calendarObjects.js
+++ b/src/store/calendarObjects.js
@@ -352,8 +352,13 @@ const actions = {
 			vObject.undirtify()
 		}
 
-		const firstCalendar = context.getters.sortedCalendars[0].id
-		return Promise.resolve(mapCalendarJsToCalendarObject(calendar, firstCalendar))
+		const defaultCalendarUrl = context.getters.getCurrentUserPrincipal.scheduleDefaultCalendarUrl
+		const defaultCalendar = context.getters.getCalendarByUrl(defaultCalendarUrl)
+
+		return Promise.resolve(mapCalendarJsToCalendarObject(
+			calendar,
+			defaultCalendar?.id ?? context.getters.sortedCalendars[0].id,
+		))
 	},
 
 	/**

--- a/src/store/calendars.js
+++ b/src/store/calendars.js
@@ -523,6 +523,14 @@ const getters = {
 	getCalendarById: (state) => (calendarId) => state.calendarsById[calendarId],
 
 	/**
+	 * Gets a calendar by its url
+	 *
+	 * @param {object} state the store data
+	 * @return {function({String}): {Object}}
+	 */
+	getCalendarByUrl: (state) => (url) => state.calendars.find((calendar) => calendar.url === url),
+
+	/**
 	 * Gets the contact's birthday calendar or null
 	 *
 	 * @param {object} state the store data

--- a/src/store/principals.js
+++ b/src/store/principals.js
@@ -66,6 +66,22 @@ const mutations = {
 	setCurrentUserPrincipal(state, { principalId }) {
 		state.currentUserPrincipal = principalId
 	},
+
+	/**
+	 * Changes the schedule-default-calendar-URL of a principal
+	 *
+	 * @param {object} state The vuex state
+	 * @param {object} data The destructuring object
+	 * @param {object} data.principal The principal to modify
+	 * @param {string} data.scheduleDefaultCalendarUrl The new schedule-default-calendar-URL
+	 */
+	changePrincipalScheduleDefaultCalendarUrl(state, { principal, scheduleDefaultCalendarUrl }) {
+		Vue.set(
+			state.principalsById[principal.id],
+			'scheduleDefaultCalendarUrl',
+			scheduleDefaultCalendarUrl,
+		)
+	},
 }
 
 const getters = {
@@ -146,6 +162,25 @@ const actions = {
 		context.commit('addPrincipal', { principal })
 		context.commit('setCurrentUserPrincipal', { principalId: principal.id })
 		logger.debug(`Current user principal is ${principal.url}`)
+	},
+
+	/**
+	 * Change a principal's schedule-default-calendar-URL
+	 *
+	 * @param {object} context The vuex context
+	 * @param {object} data The destructuring object
+	 * @param {object} data.principal The principal to modify
+	 * @param {string} data.scheduleDefaultCalendarUrl The new schedule-default-calendar-URL
+	 * @return {Promise<void>}
+	 */
+	async changePrincipalScheduleDefaultCalendarUrl(context, { principal, scheduleDefaultCalendarUrl }) {
+		principal.dav.scheduleDefaultCalendarUrl = scheduleDefaultCalendarUrl
+
+		await principal.dav.update()
+		context.commit('changePrincipalScheduleDefaultCalendarUrl', {
+			principal,
+			scheduleDefaultCalendarUrl,
+		})
 	},
 }
 

--- a/tests/javascript/unit/models/principal.test.js
+++ b/tests/javascript/unit/models/principal.test.js
@@ -40,6 +40,7 @@ describe('Test suite: Principal model (models/principal.js)', () => {
 			isCalendarResource: false,
 			isCalendarRoom: false,
 			principalId: null,
+			scheduleDefaultCalendarUrl: null,
 		})
 	})
 
@@ -63,6 +64,7 @@ describe('Test suite: Principal model (models/principal.js)', () => {
 			isCalendarRoom: false,
 			principalId: 'bar',
 			otherProp: 'foo',
+			scheduleDefaultCalendarUrl: null,
 		})
 	})
 


### PR DESCRIPTION
Resolves https://github.com/nextcloud/calendar/issues/1835

Based on https://github.com/nextcloud/calendar/pull/2331 and https://github.com/nextcloud/calendar/pull/4310

Closes https://github.com/nextcloud/calendar/pull/2331
Closes https://github.com/nextcloud/calendar/pull/4310

Requires:
- https://github.com/nextcloud/cdav-library/pull/871
- https://github.com/nextcloud/server/pull/43745

![grafik](https://github.com/nextcloud/calendar/assets/1479486/efd83b0f-85ab-432c-9c6f-8f04709426b9)

## TODO

- [x] Use the default calendar when creating new events
- [x] Fix tests