### PR TITLE
fix(freebusy): free for all blocks

### DIFF
--- a/src/fullcalendar/eventSources/freeBusyBlockedForAllEventSource.js
+++ b/src/fullcalendar/eventSources/freeBusyBlockedForAllEventSource.js
@@ -66,7 +66,7 @@ export default function(organizer, attendees, resources) {
 			)
 
 			const slots = []
-			for (const [, freeBusyProperty] of freeBusyIterator) {
+			for await (const [, freeBusyProperty] of freeBusyIterator) {
 				slots.push({
 					start: freeBusyProperty.getFirstValue().start.getInTimezone(timezoneObject).jsDate,
 					end: freeBusyProperty.getFirstValue().end.getInTimezone(timezoneObject).jsDate,


### PR DESCRIPTION
Fix https://github.com/nextcloud/calendar/issues/5754

Ref (for the syntax) https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/AsyncGenerator#async_generator_iteration

## After

![grafik](https://github.com/nextcloud/calendar/assets/1479486/9f8778fe-f1c7-4763-83e4-f97ddd1c920b)
