### PR TITLE
chore: remove obsolete server version check

### DIFF
--- a/src/components/AppNavigation/Settings.vue
+++ b/src/components/AppNavigation/Settings.vue
@@ -266,8 +266,7 @@ export default {
 			return this.defaultReminderOptions.find(o => o.value === this.defaultReminder)
 		},
 		availabilitySettingsUrl() {
-			// TODO: remove specific logic when NC 25 is not supported anymore
-			return this.nextcloudVersion >= 26 ? generateUrl('/settings/user/availability') : generateUrl('/settings/user/groupware')
+			return generateUrl('/settings/user/availability')
 		},
 		nextcloudVersion() {
 			return parseInt(OC.config.version.split('.')[0])


### PR DESCRIPTION
:broom: 

```
$ grep 'nextcloud min-version' appinfo/info.xml
                <nextcloud min-version="26" max-version="29" />

```