### PR TITLE
chore(deps): bump @nextcloud/cdav-library to ^1.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "@nextcloud/axios": "^2.4.0",
         "@nextcloud/calendar-availability-vue": "^2.2.0",
         "@nextcloud/calendar-js": "^6.1.0",
-        "@nextcloud/cdav-library": "^1.1.0",
+        "@nextcloud/cdav-library": "^1.3.0",
         "@nextcloud/dialogs": "^4.2.6",
         "@nextcloud/event-bus": "^3.1.0",
         "@nextcloud/initial-state": "^2.1.0",
@@ -3129,16 +3129,22 @@
       }
     },
     "node_modules/@nextcloud/cdav-library": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@nextcloud/cdav-library/-/cdav-library-1.1.0.tgz",
-      "integrity": "sha512-hmJgR9Cp11y3ch4dS0NufsPgofe4+iwhUkusYKmDTl0PFsJrBUNy1zawLdfDrpEjK1zXrU3tOpyF3pIqyGMYBg==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@nextcloud/cdav-library/-/cdav-library-1.3.0.tgz",
+      "integrity": "sha512-fyp9D81JYLpM877bgG8e9sFDkw7I4p7WXRNxbwRZsSRtSKgIA5fCh8lyg2kpzhPxEOGILcvzZ4UrKhTusicSyQ==",
       "dependencies": {
         "core-js": "^3.19.3",
-        "regenerator-runtime": "^0.13.9"
+        "regenerator-runtime": "^0.14.0"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": "^20.0.0",
+        "npm": "^10.0.0"
       }
+    },
+    "node_modules/@nextcloud/cdav-library/node_modules/regenerator-runtime": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
+      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw=="
     },
     "node_modules/@nextcloud/dialogs": {
       "version": "4.2.6",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "@nextcloud/axios": "^2.4.0",
     "@nextcloud/calendar-availability-vue": "^2.2.0",
     "@nextcloud/calendar-js": "^6.1.0",
-    "@nextcloud/cdav-library": "^1.1.0",
+    "@nextcloud/cdav-library": "^1.3.0",
     "@nextcloud/dialogs": "^4.2.6",
     "@nextcloud/event-bus": "^3.1.0",
     "@nextcloud/initial-state": "^2.1.0",


### PR DESCRIPTION
Required for #1835 