### PR TITLE
fix(editor): grow save buttons and change their order

### DIFF
--- a/src/components/Editor/SaveButtons.vue
+++ b/src/components/Editor/SaveButtons.vue
@@ -47,17 +47,17 @@
 			</template>
 			{{ $t('calendar', 'Update') }}
 		</NcButton>
-		<NcButton v-if="showUpdateOnlyThisButton"
-			type="primary"
-			:disabled="disabled"
-			@click="saveThisOnly">
-			{{ $t('calendar', 'Update this occurrence') }}
-		</NcButton>
 		<NcButton v-if="showUpdateThisAndFutureButton"
 			:type="forceThisAndAllFuture ? 'primary' : 'secondary'"
 			:disabled="disabled"
 			@click="saveThisAndAllFuture">
 			{{ $t('calendar', 'Update this and all future') }}
+		</NcButton>
+		<NcButton v-if="showUpdateOnlyThisButton"
+			type="primary"
+			:disabled="disabled"
+			@click="saveThisOnly">
+			{{ $t('calendar', 'Update this occurrence') }}
 		</NcButton>
 
 		<!-- Allow additional buttons -->

--- a/src/views/EditSimple.vue
+++ b/src/views/EditSimple.vue
@@ -155,7 +155,7 @@
 					:force-this-and-all-future="forceThisAndAllFuture"
 					:show-more-button="true"
 					:more-button-type="isViewing ? 'tertiary' : undefined"
-					:grow-horizontally="false"
+					:grow-horizontally="!isViewing && canCreateRecurrenceException"
 					:disabled="isSaving"
 					@save-this-only="saveAndView(false)"
 					@save-this-and-all-future="saveAndView(true)"


### PR DESCRIPTION
## Fixes
- Move the primary button to the last position
- Grow buttons on the simple editor to prevent their text from being cut off

## After

| Simple | Sidebar |
| --- | --- |
| ![Screenshot_20240306_153130](https://github.com/nextcloud/calendar/assets/1479486/5f3427fd-149d-4940-94d0-786711a1960a) | ![Screenshot_20240306_153154](https://github.com/nextcloud/calendar/assets/1479486/abe7bc05-3087-4e60-9522-7631c37e11b7) |