### PR TITLE
fix(appointments): slot generation deviation for increments that don't fit modulo

### DIFF
--- a/lib/Service/Appointments/AvailabilityGenerator.php
+++ b/lib/Service/Appointments/AvailabilityGenerator.php
@@ -70,8 +70,8 @@ class AvailabilityGenerator {
 		//      when the user opens the page at 10:17.
 		// But only do this when the time isn't already a "pretty" time
 		if ($earliestStart % $config->getIncrement() !== 0) {
-			$roundTo = (int)round(($config->getIncrement()) / 300) * 300;
-			$earliestStart = (int)ceil($earliestStart / $roundTo) * $roundTo;
+			$roundTo = (int)(round(($config->getIncrement()) / 300) * 300);
+			$earliestStart = (int)(ceil($earliestStart / $roundTo) * $roundTo);
 		}
 
 		$latestEnd = min(


### PR DESCRIPTION
Thanks @nickvergessen who figured out that the `ciel()` function wasn't working properly because `(int)` is stronger than `x*y`, so the results were [not correct](https://www.youtube.com/watch?v=Jk6jVl1fAn0)