### PR TITLE
fix: move global sidebar style overrides to sfc

### DIFF
--- a/css/app-sidebar.scss
+++ b/css/app-sidebar.scss
@@ -23,37 +23,6 @@
 
 .app-sidebar,
 .event-popover .event-popover__inner {
-	.app-sidebar-header__figure {
-		height: unset !important;
-	}
-
-	.app-sidebar-header__action {
-		margin-top: 0 !important;
-		max-height: none !important;
-		flex-wrap: wrap;
-
-		div {
-			flex-shrink: 0;
-		}
-	}
-
-	.app-sidebar-header__desc {
-		// We use our custom header layout for the sidebar editor
-		height: 0 !important;
-		padding: 0 !important;
-		margin: 0 !important;
-
-		// But keep the three-dot menu in the front
-		.app-sidebar-header__menu {
-			z-index: 1;
-		}
-	}
-
-	.app-sidebar-header__description {
-		// Close button should be aligned with calendar picker (header)
-		padding-top: 5px;
-	}
-
 	.editor-invitee-list-empty-message,
 	.editor-reminders-list-empty-message,
 	.editor-invitee-list-no-email-configured-message {

--- a/src/views/EditSidebar.vue
+++ b/src/views/EditSidebar.vue
@@ -683,13 +683,41 @@ export default {
 	height: auto;
 	border-radius: var(--border-radius);
 }
-:deep(.app-sidebar-header__description) {
-	flex-direction: column;
-}
 .property-location {
 	margin-top: 10px;
 }
 .property-description {
 	margin-bottom: 10px;
+}
+
+:deep {
+	.app-sidebar-header__action {
+		margin-top: 0 !important;
+		max-height: none !important;
+		flex-wrap: wrap;
+
+		div {
+			flex-shrink: 0;
+		}
+	}
+
+	.app-sidebar-header__desc {
+		// We use our custom header layout for the sidebar editor
+		height: 0 !important;
+		padding: 0 !important;
+		margin: 0 !important;
+
+		// But keep the three-dot menu in the front
+		.app-sidebar-header__menu {
+			z-index: 1;
+		}
+	}
+
+	.app-sidebar-header__description {
+		flex-direction: column;
+
+		// Close button should be aligned with calendar picker (header)
+		padding-top: 5px;
+	}
 }
 </style>


### PR DESCRIPTION
Regression was introduced by de1cf849af30518efd22d32e8f88af93bef00cb1 in combination with the new reference widget. The global stylesheet is imported by the reference entry point and thus overrides some styles in other apps.

## How to reproduce?

1. Install talk.
2. Open a conversation.
3. Look at the sidebar.

![grafik](https://github.com/nextcloud/calendar/assets/1479486/fb68680b-af33-4f70-b9cf-986a553e98a3)
