### PR TITLE
[WIP] Edit email on a per-calendar basis

### DIFF
--- a/src/appointments/main-booking.js
+++ b/src/appointments/main-booking.js
@@ -44,6 +44,7 @@ Vue.prototype.$n = translatePlural
 
 const config = loadState('calendar', 'config')
 const userInfo = loadState('calendar', 'userInfo')
+const calendarEmail = loadState('calendar', 'calendarEmail')
 const visitorInfo = loadState('calendar', 'visitorInfo', {
 	displayName: '',
 	email: '',
@@ -55,6 +56,7 @@ export default new Vue({
 		props: {
 			config,
 			userInfo,
+			calendarEmail,
 			visitorInfo,
 		},
 	}),

--- a/src/components/AppNavigation/EditCalendarModal.vue
+++ b/src/components/AppNavigation/EditCalendarModal.vue
@@ -26,21 +26,27 @@
 		<div class="edit-calendar-modal">
 			<h2>{{ $t('calendar', 'Edit calendar') }}</h2>
 
-			<div class="edit-calendar-modal__name-and-color">
-				<div class="edit-calendar-modal__name-and-color__color">
+			<div class="edit-calendar-modal__name-email-and-color">
+				<div class="edit-calendar-modal__name-email-and-color__color">
 					<NcColorPicker v-model="calendarColor"
 						:advanced-fields="true"
 						@update:value="calendarColorChanged = true">
-						<div class="edit-calendar-modal__name-and-color__color__dot"
+						<div class="edit-calendar-modal__name-email-and-color__color__dot"
 							:style="{'background-color': calendarColor}" />
 					</NcColorPicker>
 				</div>
 
 				<input v-model="calendarName"
-					class="edit-calendar-modal__name-and-color__name"
+					class="edit-calendar-modal__name-email-and-color__name"
 					type="text"
 					:placeholder="$t('calendar', 'Calendar name …')"
 					@input="calendarNameChanged = true">
+
+				<input v-model="calendarEmail"
+					class="edit-calendar-modal__name-email-and-color__name"
+					type="text"
+					:placeholder="$t('calendar', 'Calendar email …')"
+					@input="calendarEmailChanged = true">
 			</div>
 
 			<template v-if="canBeShared">
@@ -123,6 +129,8 @@ export default {
 			calendarColorChanged: false,
 			calendarName: undefined,
 			calendarNameChanged: false,
+			calendarEmail: undefined,
+			calendarEmailChanged: false,
 		}
 	},
 	computed: {
@@ -176,8 +184,10 @@ export default {
 			}
 
 			this.calendarName = this.calendar.displayName
+			this.calendarEmail = this.calendar.email
 			this.calendarColor = this.calendar.color
 			this.calendarNameChanged = false
+			this.calendarEmailChanged = false
 			this.calendarColorChanged = false
 		},
 	},
@@ -226,6 +236,24 @@ export default {
 		},
 
 		/**
+		 * Save the calendar email.
+		 */
+		async saveEmail() {
+			try {
+				await this.$store.dispatch('changeCalendarEmail', {
+					calendar: this.calendar,
+					newEmail: this.calendarEmail,
+				})
+			} catch (error) {
+				logger.error('Failed to save calendar email', {
+					calendar: this.calendar,
+					newEmail: this.calendarEmail,
+				})
+				throw error
+			}
+		},
+
+		/**
 		 * Save unsaved changes and close the modal.
 		 *
 		 * @return {Promise<void>}
@@ -238,8 +266,11 @@ export default {
 				if (this.calendarNameChanged) {
 					await this.saveName()
 				}
+				if (this.calendarEmailChanged) {
+					await this.saveEmail()
+				}
 			} catch (error) {
-				showError(this.$t('calendar', 'Failed to save calendar name and color'))
+				showError(this.$t('calendar', 'Failed to save calendar name, email, and color'))
 			}
 
 			this.closeModal()

--- a/src/models/calendar.js
+++ b/src/models/calendar.js
@@ -33,6 +33,8 @@ const getDefaultCalendarObject = (props = {}) => Object.assign({}, {
 	id: '',
 	// Visible display name
 	displayName: '',
+	// Email of the calendar
+	email: '',
 	// Color of the calendar
 	color: uidToHexColor(''),
 	// Whether or not the calendar is visible in the grid
@@ -83,6 +85,8 @@ const getDefaultCalendarObject = (props = {}) => Object.assign({}, {
 const mapDavCollectionToCalendar = (calendar, currentUserPrincipal) => {
 	const id = btoa(calendar.url)
 	const displayName = calendar.displayname || getCalendarUriFromUrl(calendar.url)
+
+	const email = calendar.email
 
 	// calendar.color can be set to anything on the server,
 	// so make sure it's something that remotely looks like a color
@@ -142,6 +146,7 @@ const mapDavCollectionToCalendar = (calendar, currentUserPrincipal) => {
 	return getDefaultCalendarObject({
 		id,
 		displayName,
+		email,
 		color,
 		order,
 		url,

--- a/src/store/calendars.js
+++ b/src/store/calendars.js
@@ -938,6 +938,22 @@ const actions = {
 	},
 
 	/**
+	 * Change a calendar's email
+	 *
+	 * @param {object} context the store mutations Current context
+	 * @param {object} data destructuring object
+	 * @param {object} data.calendar the calendar to modify
+	 * @param {string} data.newEmail the new email of the calendar
+	 * @return {Promise}
+	 */
+	async changeCalendarEmail(context, { calendar, newEmail }) {
+		calendar.dav.email = newEmail
+
+		await calendar.dav.update()
+		context.commit('changeCalendarEmail', { calendar, newEmail })
+	},
+
+	/**
 	 * Share calendar with User or Group
 	 *
 	 * @param {object} context the store mutations Current context


### PR DESCRIPTION
This intends to partially address #2617.

The overall idea is that the `calendarEmail` string attribute will be added to each calendar, which will be modifiable, just like the calendar name currently is. When an invitation is prepared, this attribute will be checked. If it isn't empty, the set value will be used, otherwise the organizer's email will be used as the organizer name in the invitation.

I would also like to add the ability to disable sending invitations from Nextcloud and let my calendar client (e.g., Thunderbird) take care of it, using the invitation with the user-selected email as described above. I have not yet implemented this part at all.

Is this a valuable feature? Does this approach make sense? If so, could you please point me to the code that prepares the invitation? I guess it interacts with `dav`, but it's unclear to me how.

Thanks in advance for giving me the pointers I need to contribute!