### PR TITLE
fix(scheduling): Find attendee via email

### DIFF
--- a/src/components/Editor/Invitees/InviteesListSearch.vue
+++ b/src/components/Editor/Invitees/InviteesListSearch.vue
@@ -51,13 +51,13 @@
 				<Avatar v-if="!option.isUser && option.type !== 'circle'"
 					:key="option.uid"
 					:url="option.avatar"
-					:display-name="option.dropdownName" />
+					:display-name="option.commonName" />
 
 				<div class="invitees-search-list-item__label">
 					<div>
-						{{ option.dropdownName }}
+						{{ option.commonName }}
 					</div>
-					<div v-if="option.email !== option.dropdownName && option.type !== 'circle'">
+					<div v-if="option.email !== option.commonName && option.type !== 'circle'">
 						{{ option.email }}
 					</div>
 					<div v-if="option.type === 'circle'">
@@ -282,9 +282,9 @@ export default {
 					email: principal.email,
 					language: principal.language,
 					isUser: principal.calendarUserType === 'INDIVIDUAL',
-					avatar: principal.userId,
+					avatar: decodeURIComponent(principal.userId),
 					hasMultipleEMails: false,
-					dropdownName: principal.displayname || principal.email,
+					dropdownName: principal.displayname ? [principal.displayname, principal.email].join(' ') : principal.email,
 				}
 			})
 		},


### PR DESCRIPTION
Fixes https://github.com/nextcloud/calendar/issues/5872

NcSelect only shows options that **match the current search input**. If you search for user *Alice* with an email of *accounting@acme.com* you will not see her in the suggestions. If her email is *alice@acme.com* you will.

This change adds the email to the property used for searching so NcSelect shows it again.