### PR TITLE
feat(simple-editor): show additional actions inline

### DIFF
--- a/src/views/EditSimple.vue
+++ b/src/views/EditSimple.vue
@@ -55,7 +55,7 @@
 
 			<template v-else>
 				<div class="event-popover__top-right-actions">
-					<Actions v-if="!isLoading && !isError && !isNew" :force-menu="true">
+					<Actions v-if="!isLoading && !isError && !isNew" :inline="5">
 						<ActionLink v-if="!hideEventExport && hasDownloadURL"
 							:href="downloadURL">
 							<template #icon>


### PR DESCRIPTION
| Before | After |
|---|---|
| ![image](https://github.com/nextcloud/calendar/assets/42591237/6533a9c9-5ffd-48f2-868d-07b3ef4c3b9f) | ![image](https://github.com/nextcloud/calendar/assets/42591237/7ced2fcd-2086-455a-97d6-d0bcc8f01d9f) |