### PR TITLE
test: replace \Safe\DateTimeImmutable with \DateTimeImmutable

### DIFF
--- a/tests/php/unit/Controller/BookingControllerTest.php
+++ b/tests/php/unit/Controller/BookingControllerTest.php
@@ -25,6 +25,7 @@ declare(strict_types=1);
 namespace OCA\Calendar\Controller;
 
 use ChristophWurst\Nextcloud\Testing\TestCase;
+use DateTimeImmutable;
 use DateTimeZone;
 use Exception;
 use InvalidArgumentException;
@@ -46,7 +47,6 @@ use OCP\IUser;
 use OCP\Mail\IMailer;
 use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Log\LoggerInterface;
-use Safe\DateTimeImmutable;
 
 class BookingControllerTest extends TestCase {
 	/** @var string */

--- a/tests/php/unit/Dashbaord/CalendarWidgetTest.php
+++ b/tests/php/unit/Dashbaord/CalendarWidgetTest.php
@@ -23,6 +23,7 @@ declare(strict_types=1);
  */
 namespace OCA\Calendar\Dashboard;
 
+use DateTimeImmutable;
 use OCA\Calendar\Service\JSDataService;
 use OCA\DAV\CalDAV\CalendarImpl;
 use OCP\AppFramework\Services\IInitialState;
@@ -34,7 +35,6 @@ use OCP\IDateTimeFormatter;
 use OCP\IL10N;
 use OCP\IURLGenerator;
 use PHPUnit\Framework\MockObject\MockObject;
-use Safe\DateTimeImmutable;
 use Test\TestCase;
 
 class CalendarWidgetTest extends TestCase {

--- a/tests/php/unit/Service/Appointments/BookingServiceTest.php
+++ b/tests/php/unit/Service/Appointments/BookingServiceTest.php
@@ -27,6 +27,7 @@ declare(strict_types=1);
 namespace OCA\Calendar\Tests\Unit\Service\Appointments;
 
 use ChristophWurst\Nextcloud\Testing\TestCase;
+use DateTimeImmutable;
 use Exception;
 use OCA\Calendar\Db\AppointmentConfig;
 use OCA\Calendar\Db\Booking;
@@ -47,7 +48,6 @@ use OCP\IUser;
 use OCP\Security\ISecureRandom;
 use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Log\LoggerInterface;
-use Safe\DateTimeImmutable;
 
 class BookingServiceTest extends TestCase {
 	/** @var AvailabilityGenerator|MockObject */


### PR DESCRIPTION
I don't get why this fails now and worked in the past.