### PR TITLE
Fix: Hide widget header for non-existent calendars

### DIFF
--- a/src/views/Calendar.vue
+++ b/src/views/Calendar.vue
@@ -22,7 +22,7 @@
 
 <template>
 	<div v-if="isWidget" class="calendar-Widget">
-		<EmbedTopNavigation :is-widget="true" />
+		<EmbedTopNavigation v-if="!showEmptyCalendarScreen" :is-widget="true" />
 
 		<CalendarGrid v-if="!showEmptyCalendarScreen"
 			ref="calendarGridWidget"


### PR DESCRIPTION
Fix #5878

| b | a |
|--------|--------|
| ![image](https://github.com/nextcloud/calendar/assets/40746210/304501f1-cb90-48ac-aacc-7224c30a5776) | <img width="870" alt="image" src="https://github.com/nextcloud/calendar/assets/40746210/459e79e7-cea6-499b-9222-761997f74aae"> | 