### PR TITLE
fix: don't apply default calendar on Nextcloud < 29

### DIFF
--- a/src/store/calendarObjects.js
+++ b/src/store/calendarObjects.js
@@ -352,8 +352,15 @@ const actions = {
 			vObject.undirtify()
 		}
 
-		const defaultCalendarUrl = context.getters.getCurrentUserPrincipal.scheduleDefaultCalendarUrl
-		const defaultCalendar = context.getters.getCalendarByUrl(defaultCalendarUrl)
+		// TODO: remove version check once Nextcloud 28 is not supported anymore
+		let defaultCalendar
+		const nextcloudVersion = parseInt(OC.config.version.split('.')[0])
+		if (nextcloudVersion >= 29) {
+			// Don't select the default calendar by default on Nextcloud < 29 as it can't be
+			// configured by the user and might lead to confusion
+			const defaultCalendarUrl = context.getters.getCurrentUserPrincipal.scheduleDefaultCalendarUrl
+			defaultCalendar = context.getters.getCalendarByUrl(defaultCalendarUrl)
+		}
 
 		return Promise.resolve(mapCalendarJsToCalendarObject(
 			calendar,


### PR DESCRIPTION
Fix https://github.com/nextcloud/calendar/issues/5942

The feature to set the default calendar is only available in Nextcloud >= 29 so users might be confused by the default calendar choice which they can't influence.

Simply use the old logic (first sorted calendar) on older instances.