### PR TITLE
fix(editor): add and remove categories from events

### DIFF
--- a/src/components/Editor/Properties/PropertySelectMultiple.vue
+++ b/src/components/Editor/Properties/PropertySelectMultiple.vue
@@ -185,7 +185,7 @@ export default {
 			}
 
 			this.selectionData.push(value)
-			this.$emit('add-single-value', value)
+			this.$emit('add-single-value', value.value)
 		},
 	},
 }


### PR DESCRIPTION
Fix #5785 

An artifact of the nextcloud-vue migration.

The component is not used anywhere else besides the category select so this is a safe change.