### PR TITLE
fix(editor): don't respect default calendar in the calendar picker

### DIFF
--- a/src/components/AppNavigation/Settings.vue
+++ b/src/components/AppNavigation/Settings.vue
@@ -76,7 +76,7 @@
 			<li v-if="currentUserPrincipal && defaultCalendarOptions.length > 1 && nextcloudVersion >= 29"
 				class="settings-fieldset-interior-item settings-fieldset-interior-item--default-calendar">
 				<label :for="defaultCalendarPickerId">
-					{{ $t('calendar', 'Default calendar for invitations and new events') }}
+					{{ $t('calendar', 'Default calendar for incoming invitations') }}
 				</label>
 				<CalendarPicker :value="defaultCalendar"
 					:calendars="defaultCalendarOptions"
@@ -300,7 +300,7 @@ export default {
 				.filter(calendar => !calendar.readOnly && !calendar.isSharedWithMe)
 		},
 		/**
-		 * The default calendar for new events and inivitations
+		 * The default calendar for incoming inivitations
 		 *
 		 * @return {object|undefined} The default calendar or undefined if none is available
 		 */
@@ -443,7 +443,7 @@ export default {
 			}
 		},
 		/**
-		 * Changes the default calendar for new events
+		 * Changes the default calendar for incoming invitations
 		 *
 		 * @param {object} selectedCalendar The new selected default calendar
 		 */

--- a/src/store/calendarObjects.js
+++ b/src/store/calendarObjects.js
@@ -352,20 +352,8 @@ const actions = {
 			vObject.undirtify()
 		}
 
-		// TODO: remove version check once Nextcloud 28 is not supported anymore
-		let defaultCalendar
-		const nextcloudVersion = parseInt(OC.config.version.split('.')[0])
-		if (nextcloudVersion >= 29) {
-			// Don't select the default calendar by default on Nextcloud < 29 as it can't be
-			// configured by the user and might lead to confusion
-			const defaultCalendarUrl = context.getters.getCurrentUserPrincipal.scheduleDefaultCalendarUrl
-			defaultCalendar = context.getters.getCalendarByUrl(defaultCalendarUrl)
-		}
-
-		return Promise.resolve(mapCalendarJsToCalendarObject(
-			calendar,
-			defaultCalendar?.id ?? context.getters.sortedCalendars[0].id,
-		))
+		const firstCalendar = context.getters.sortedCalendars[0].id
+		return Promise.resolve(mapCalendarJsToCalendarObject(calendar, firstCalendar))
 	},
 
 	/**


### PR DESCRIPTION
Ref https://github.com/nextcloud/calendar/issues/5942
Partially reverts https://github.com/nextcloud/calendar/pull/5790

The default calendar URL from the backend is more restrictive as it is primarily meant for incoming invitations. This commit effectively reverts the editor's calendar picker default choice to how it behaved before v4.7.0.

As discussed in a meeting with Christoph.