### PR TITLE
fix: navigation when clicking on the grid on a custom week/month

### DIFF
--- a/src/components/CalendarGrid.vue
+++ b/src/components/CalendarGrid.vue
@@ -22,10 +22,10 @@
   -->
 
 <template>
-	<FullCalendar v-if="calendarOptions"
+	<FullCalendar v-if="options"
 		ref="fullCalendar"
 		:class="isWidget? 'fullcalendar-widget': ''"
-		:options="calendarOptions" />
+		:options="options" />
 </template>
 
 <script>
@@ -94,7 +94,6 @@ export default {
 		return {
 			updateTodayJob: null,
 			updateTodayJobPreviousDate: null,
-			calendarOptions: null,
 			fullCalendarReady: false,
 		}
 	},
@@ -208,28 +207,12 @@ export default {
 			const calendarApi = this.$refs.fullCalendar.getApi()
 			calendarApi.gotoDate(getYYYYMMDDFromFirstdayParam(newDate))
 		},
-		eventSources(sources, oldSources) {
-			const newSources = sources.filter(source => !oldSources.map(oldSource => oldSource.id).includes(source.id))
-			const removedSources = oldSources.filter(oldSource => !sources.map(source => source.id).includes(oldSource.id))
-
-			// Hackity hack! Unfortunately, calendarOptions.eventSources is not reactive ...
-			// Ref https://fullcalendar.io/docs/Calendar-addEventSource
-			// TODO: Find a better/safer way to prevent duplicated event sources
-			const calendarApi = this.$refs.fullCalendar.getApi()
-			for (const source of newSources) {
-				calendarApi.addEventSource(source)
-			}
-			const eventSources = calendarApi.getEventSources()
-			for (const source of removedSources) {
-				eventSources.find(x => x.id === source.id)?.remove()
-			}
-		},
 		modificationCount: debounce(function() {
 			const calendarApi = this.$refs.fullCalendar.getApi()
 			calendarApi.refetchEvents()
 		}, 50),
-		async calendarOptions(newOptions, oldOptions) {
-			if (!this.fullCalendarReady && newOptions && !oldOptions) {
+		async options(newOptions) {
+			if (!this.fullCalendarReady && newOptions) {
 				this.fullCalendarReady = true
 				// Wait until the component is mounted and the ref is available
 				await this.$nextTick()
@@ -238,8 +221,6 @@ export default {
 		},
 	},
 	async created() {
-		this.calendarOptions = await this.options
-
 		this.updateTodayJob = setInterval(() => {
 			const newDate = getYYYYMMDDFromFirstdayParam('now')
 

--- a/src/components/CalendarGrid.vue
+++ b/src/components/CalendarGrid.vue
@@ -22,8 +22,7 @@
   -->
 
 <template>
-	<FullCalendar v-if="options"
-		ref="fullCalendar"
+	<FullCalendar ref="fullCalendar"
 		:class="isWidget? 'fullcalendar-widget': ''"
 		:options="options" />
 </template>
@@ -94,7 +93,6 @@ export default {
 		return {
 			updateTodayJob: null,
 			updateTodayJobPreviousDate: null,
-			fullCalendarReady: false,
 		}
 	},
 	computed: {
@@ -211,14 +209,31 @@ export default {
 			const calendarApi = this.$refs.fullCalendar.getApi()
 			calendarApi.refetchEvents()
 		}, 50),
-		async options(newOptions) {
-			if (!this.fullCalendarReady && newOptions) {
-				this.fullCalendarReady = true
-				// Wait until the component is mounted and the ref is available
-				await this.$nextTick()
-				this.onFullCalendarReady()
-			}
-		},
+	},
+	/**
+	 * FullCalendar 5 is using calculated px values for the width
+	 * of its views.
+	 * Hence a simple `width: 100%` won't assure that the calendar-grid
+	 * is always using the full available width.
+	 *
+	 * Toggling the AppNavigation or AppSidebar will change the amount
+	 * of available space, but it will not be covered by the window
+	 * resize event, because the actual window size did not change.
+	 *
+	 * To make sure, that the calendar-grid is always using all space,
+	 * we have to register a resize-observer here, that will automatically
+	 * update the fullCalendar size, when the available space changes.
+	 */
+	 mounted() {
+		if (window.ResizeObserver) {
+			const resizeObserver = new ResizeObserver(debounce(() => {
+				this.$refs.fullCalendar
+					.getApi()
+					.updateSize()
+			}, 100))
+
+			resizeObserver.observe(this.$refs.fullCalendar.$el)
+		}
 	},
 	async created() {
 		this.updateTodayJob = setInterval(() => {
@@ -290,36 +305,6 @@ export default {
 				this.$store.dispatch('setInitialView', { initialView })
 			}
 		}, 5000),
-
-		/**
-		 * Called once when FullCalendar is ready. This event is delayed until the component is
-		 * mounted and its ref is available.
-		 */
-		onFullCalendarReady() {
-			/**
-			 * FullCalendar 5 is using calculated px values for the width
-			 * of its views.
-			 * Hence a simple `width: 100%` won't assure that the calendar-grid
-			 * is always using the full available width.
-			 *
-			 * Toggling the AppNavigation or AppSidebar will change the amount
-			 * of available space, but it will not be covered by the window
-			 * resize event, because the actual window size did not change.
-			 *
-			 * To make sure, that the calendar-grid is always using all space,
-			 * we have to register a resize-observer here, that will automatically
-			 * update the fullCalendar size, when the available space changes.
-			 */
-			if (window.ResizeObserver) {
-				const resizeObserver = new ResizeObserver(debounce(() => {
-					this.$refs.fullCalendar
-						.getApi()
-						.updateSize()
-				}, 100))
-
-				resizeObserver.observe(this.$refs.fullCalendar.$el)
-			}
-		},
 	},
 }
 </script>


### PR DESCRIPTION
Follow-up to  https://github.com/nextcloud/calendar/pull/5891
Reverts https://github.com/nextcloud/calendar/pull/5995

I converted the FullCalendar options to a computed prop again. It still works in private and public widgets. I assume this was just an oversight. This also means that we can get rid of some reactivity hacks as the computed prop is now properly reactive again.

## How to reproduce

1. Open the calendar app.
2. Switch to  month view.
3. Navigate to the next month using the top left navigation buttons.
4. Click on some day.
5. Observe the grid changing back to the previous month which includes today. 

## Regression testing

Things that I tested successfully:

1. Main calendar grid view in the app.
2. Resize observer still works (see #5995).
6. Private widgets in a Talk room (internal link).
7. Public widgets in a Talk room (public link share).