### PR TITLE
fix: time zone picker when using the simple editor

### DIFF
--- a/src/components/Shared/DatePicker.vue
+++ b/src/components/Shared/DatePicker.vue
@@ -2,6 +2,7 @@
   - @copyright Copyright (c) 2019 Georg Ehrke <oc.list@georgehrke.com>
   -
   - @author Georg Ehrke <oc.list@georgehrke.com>
+  - @author 2024 Richard Steinmetz <richard@steinmetz.cloud>
   -
   - @license AGPL-3.0-or-later
   -
@@ -54,16 +55,17 @@
 				</template>
 			</NcButton>
 			<Popover :shown.sync="showTimezonePopover"
-				:focus-trap="false"
 				open-class="timezone-popover-wrapper">
-				<div class="timezone-popover-wrapper__title">
-					<strong>
-						{{ $t('calendar', 'Please select a time zone:') }}
-					</strong>
-				</div>
-				<TimezonePicker class="timezone-popover-wrapper__timezone-select"
-					:value="timezoneId"
-					@input="changeTimezone" />
+				<template>
+					<div class="timezone-popover-wrapper__title">
+						<strong>
+							{{ $t('calendar', 'Please select a time zone:') }}
+						</strong>
+					</div>
+					<TimezonePicker class="timezone-popover-wrapper__timezone-select"
+						:value="timezoneId"
+						@input="changeTimezone" />
+				</template>
 			</Popover>
 		</template>
 		<template v-if="!isAllDay"


### PR DESCRIPTION
Fix https://github.com/nextcloud/calendar/issues/6025

## Before
https://github.com/nextcloud/calendar/assets/1479486/9eb7422b-2a55-453d-a801-18f6b1f55d53

## After
https://github.com/nextcloud/calendar/assets/1479486/cd1d4f57-67f4-40a3-ac92-566af5782cd6