### PR TITLE
[stable4.7] fix: calendar picker width in disabled state

### DIFF
--- a/src/components/Editor/CalendarPickerHeader.vue
+++ b/src/components/Editor/CalendarPickerHeader.vue
@@ -129,8 +129,6 @@ export default {
 	margin-bottom: 5px;
 
 	&__picker {
-		width: 100%;
-
 		// For some reason the NcActions component behaves weirdly when a calendar is shared
 		// read-only with the user. This is an ugly workaround to fix the width of the button.
 		&--fix-width {


### PR DESCRIPTION
Only happens when there is a single calendar available and the calendar picker is "disabled".

| Before | After |
| --- | --- |
| ![grafik](https://github.com/nextcloud/calendar/assets/1479486/db2f32ce-39b6-4ccf-bac6-a02f214bb633) | ![grafik](https://github.com/nextcloud/calendar/assets/1479486/e4757ff5-6552-42f6-b51b-2d621d6d2211) |