### PR TITLE
Revert "[stable4.7] fix: calendar picker width in disabled state"

### DIFF
--- a/src/components/Editor/CalendarPickerHeader.vue
+++ b/src/components/Editor/CalendarPickerHeader.vue
@@ -129,6 +129,8 @@ export default {
 	margin-bottom: 5px;
 
 	&__picker {
+		width: 100%;
+
 		// For some reason the NcActions component behaves weirdly when a calendar is shared
 		// read-only with the user. This is an ugly workaround to fix the width of the button.
 		&--fix-width {


### PR DESCRIPTION
Breaks the picker when it's not disabled :see_no_evil: I was able to reproduce the initial problem on main as well and will open a proper fix + backport.

![grafik](https://github.com/nextcloud/calendar/assets/1479486/7e82a435-4826-4dd8-80b1-9bdb8c270a39)