### PR TITLE
fix(editor): calendar picker width

### DIFF
--- a/src/components/Editor/CalendarPickerHeader.vue
+++ b/src/components/Editor/CalendarPickerHeader.vue
@@ -26,7 +26,6 @@
 		<NcActions type="tertiary"
 			class="calendar-picker-header__picker"
 			:class="{
-				'calendar-picker-header__picker--fix-width': isReadOnly && value && value.isSharedWithMe,
 				'calendar-picker-header__picker--has-menu': !isReadOnly && calendars.length > 1,
 			}"
 			:menu-name="value.displayName"
@@ -38,18 +37,20 @@
 						:style="{ 'background-color': value.color }" />
 				</div>
 			</template>
-			<NcActionButton v-for="calendar in calendars"
-				:key="calendar.id"
-				:close-after-click="true"
-				@click="$emit('update:value', calendar)">
-				<template #icon>
-					<div class="calendar-picker-header__icon">
-						<div class="calendar-picker-header__icon__dot"
-							:style="{ 'background-color': calendar.color }" />
-					</div>
-				</template>
-				{{ calendar.displayName }}
-			</NcActionButton>
+			<template>
+				<NcActionButton v-for="calendar in calendars"
+					:key="calendar.id"
+					:close-after-click="true"
+					@click="$emit('update:value', calendar)">
+					<template #icon>
+						<div class="calendar-picker-header__icon">
+							<div class="calendar-picker-header__icon__dot"
+								:style="{ 'background-color': calendar.color }" />
+						</div>
+					</template>
+					{{ calendar.displayName }}
+				</NcActionButton>
+			</template>
 		</NcActions>
 	</div>
 </template>
@@ -97,8 +98,6 @@ export default {
 <style lang="scss">
 .event-popover {
 	.calendar-picker-header {
-		width: calc(100% - 79px);
-
 		button {
 			margin-left: -9px;
 
@@ -115,8 +114,6 @@ export default {
 
 .app-sidebar {
 	.calendar-picker-header {
-		width: calc(100% - 30px);
-
 		button {
 			margin-left: -14px;
 
@@ -134,11 +131,16 @@ export default {
 
 <style lang="scss" scoped>
 .calendar-picker-header {
+	display: flex;
 	align-self: flex-start;
 	margin-bottom: 5px;
 
+	// Leave room for the three dot and close buttons
+	max-width: calc(100% - 79px);
+
 	&__picker {
-		width: 100%;
+		display: flex;
+		min-width: 0;
 
 		&--has-menu {
 			// Inject menu down icon via CSS because only text can be specified in the template
@@ -155,15 +157,10 @@ export default {
 			}
 		}
 
-		// For some reason the NcActions component behaves weirdly when a calendar is shared
-		// read-only with the user. This is an ugly workaround to fix the width of the button.
-		&--fix-width {
-			width: unset;
-			max-width: 100%;
-		}
-
-		:deep(button.button-vue) {
-			max-width: 100%;
+		// Fix long calendar name ellipsis
+		:deep(.v-popper) {
+			display: flex;
+			min-width: 0;
 		}
 
 		// Keep full opacity for disabled buttons


### PR DESCRIPTION
Follow-up to https://github.com/nextcloud/calendar/pull/6032

**Before:**
![grafik](https://github.com/nextcloud/calendar/assets/1479486/db2f32ce-39b6-4ccf-bac6-a02f214bb633)

# Simple Editor

## Edit View

### Multiple calendar options

| Short name | Long name |
| --- | --- |
| ![grafik](https://github.com/nextcloud/calendar/assets/1479486/b336dbe0-290d-43ec-b5c5-c4f1d1648ee1) | ![grafik](https://github.com/nextcloud/calendar/assets/1479486/6ef05f05-145e-418e-87c2-319a4f8857dd) |

### Single calendar option

| Short name | Long name |
| --- | --- |
| ![grafik](https://github.com/nextcloud/calendar/assets/1479486/54513276-f3a2-4eaf-a008-66cd4c1155d3) | ![grafik](https://github.com/nextcloud/calendar/assets/1479486/80de28ce-8829-480a-afe8-ff4f6ead6207) |

## Read-only View (shared calendar)

| Short name | Long name |
| --- | --- |
| ![grafik](https://github.com/nextcloud/calendar/assets/1479486/49500302-2e98-48a7-a133-77d1ef9b4ae7) | ![grafik](https://github.com/nextcloud/calendar/assets/1479486/d445ca9c-16e9-4185-99f4-bf5b90727c0e) |

# Sidebar Editor

### Multiple calendar options

| Short name | Long name |
| --- | --- |
| ![grafik](https://github.com/nextcloud/calendar/assets/1479486/60679d86-42c5-410c-98ff-d497bac487e2) | ![grafik](https://github.com/nextcloud/calendar/assets/1479486/5ba1f34e-33d4-490b-b796-81dcbb688bcd) |

### Single calendar option

| Short name | Long name |
| --- | --- |
| ![grafik](https://github.com/nextcloud/calendar/assets/1479486/fc12ae4a-33eb-4615-b15a-aef0a195b4fa) | ![grafik](https://github.com/nextcloud/calendar/assets/1479486/627849e4-ce9f-46ad-b087-359e4eea987e) |

### Read-only view (shared calendar)

| Short name | Long name |
| --- | --- |
| ![grafik](https://github.com/nextcloud/calendar/assets/1479486/117f8630-a23f-4c74-87eb-6514651c4bec) | ![grafik](https://github.com/nextcloud/calendar/assets/1479486/1813cac6-f3b0-4c58-9f93-3cd70cecdc30) |

---

This also fixes the popover position which would sometimes be anchored in the middle of the editor instead of the picker action button itself.

![grafik](https://github.com/nextcloud/calendar/assets/1479486/218ca21f-42b1-42a4-a51d-5a85b160f6bf)