### PR TITLE
fix: default calendar needs to support VEVENTs

### DIFF
--- a/src/components/AppNavigation/Settings.vue
+++ b/src/components/AppNavigation/Settings.vue
@@ -297,7 +297,9 @@ export default {
 		},
 		defaultCalendarOptions() {
 			return this.$store.state.calendars.calendars
-				.filter(calendar => !calendar.readOnly && !calendar.isSharedWithMe)
+				.filter(calendar => !calendar.readOnly
+					&& !calendar.isSharedWithMe
+					&& calendar.supportsEvents)
 		},
 		/**
 		 * The default calendar for incoming inivitations


### PR DESCRIPTION
To improve the situation in https://github.com/nextcloud/server/issues/45503

Omit calendars that don't support VEVENTs from the default calendar picker.