### PR TITLE
[stable4.7] fix: composer out of sync files

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -71,11 +71,11 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=7.4 <=8.3"
+        "php": ">= 8.0 <=8.3"
     },
     "platform-dev": [],
     "platform-overrides": {
-        "php": "7.4"
+        "php": "8.0"
     },
     "plugin-api-version": "2.3.0"
 }


### PR DESCRIPTION
Manual backport of https://github.com/nextcloud/calendar/pull/6058

background: https://github.com/nextcloud/calendar/pull/5607 is incomplete. composer.json was changed without composer.lock, so the two files got out of sync