### PR TITLE
fix: scope global sidebar styles to the app

### DIFF
--- a/css/app-sidebar.scss
+++ b/css/app-sidebar.scss
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-.app-sidebar,
+.app-calendar .app-sidebar,
 .event-popover .event-popover__inner {
 	.editor-invitee-list-empty-message,
 	.editor-reminders-list-empty-message,


### PR DESCRIPTION
## How to reproduce?

1. Install Talk.
2. Open a chat room and open the right sidebar.
3. Observe the header of the right sidebar.