### PR TITLE
fix: sidebar editor tab scrolling

### DIFF
--- a/css/app-sidebar.scss
+++ b/css/app-sidebar.scss
@@ -70,9 +70,7 @@
 	}
 
 	.app-sidebar-tab {
-		display: flex;
-		flex-direction: column;
-		justify-content: space-between;
+		// Make the whole sidebar scrollable instead of just the active tab
 		overflow: unset !important;
 		max-height: unset !important;
 		height: auto !important;
@@ -619,10 +617,6 @@
 
 		.v-select {
 			min-width: unset !important;
-		}
-
-		&__input {
-			width: 100%;
 		}
 	}
 


### PR DESCRIPTION
Regression from https://github.com/nextcloud/calendar/pull/6081

The rule specificity changed so some styles were no longer overwritten by nc-vue.