### PR TITLE
chore: revert moment plugin factory pattern

### DIFF
--- a/src/components/CalendarGrid.vue
+++ b/src/components/CalendarGrid.vue
@@ -33,7 +33,7 @@ import select from '../fullcalendar/interaction/select.js'
 // Import localization plugins
 import { getDateFormattingConfig } from '../fullcalendar/localization/dateFormattingConfig.js'
 import { getFullCalendarLocale } from '../fullcalendar/localization/localeProvider.js'
-import momentPluginFactory from '../fullcalendar/localization/momentPlugin.js'
+import momentPlugin from '../fullcalendar/localization/momentPlugin.js'
 
 // Import rendering handlers
 import dayHeaderDidMount from '../fullcalendar/rendering/dayHeaderDidMount.js'
@@ -162,7 +162,7 @@ export default {
 		 */
 		plugins() {
 			return [
-				momentPluginFactory(),
+				momentPlugin,
 				VTimezoneNamedTimezone,
 				dayGridPlugin,
 				interactionPlugin,

--- a/src/components/Editor/FreeBusy/FreeBusy.vue
+++ b/src/components/Editor/FreeBusy/FreeBusy.vue
@@ -134,7 +134,7 @@ import freeBusyResourceEventSource from '../../../fullcalendar/eventSources/free
 // Import localization plugins
 import { getDateFormattingConfig } from '../../../fullcalendar/localization/dateFormattingConfig.js'
 import { getFullCalendarLocale } from '../../../fullcalendar/localization/localeProvider.js'
-import momentPluginFactory from '../../../fullcalendar/localization/momentPlugin.js'
+import momentPlugin from '../../../fullcalendar/localization/momentPlugin.js'
 
 // Import timezone plugins
 import VTimezoneNamedTimezone from '../../../fullcalendar/timezones/vtimezoneNamedTimezoneImpl.js'
@@ -246,7 +246,7 @@ export default {
 		plugins() {
 			return [
 				resourceTimelinePlugin,
-				momentPluginFactory(),
+				momentPlugin,
 				VTimezoneNamedTimezone,
 				interactionPlugin,
 			]

--- a/src/fullcalendar/localization/momentPlugin.js
+++ b/src/fullcalendar/localization/momentPlugin.js
@@ -6,13 +6,8 @@ import moment from '@nextcloud/moment'
 import { createPlugin } from '@fullcalendar/core'
 import useSettingsStore from '../../store/settings.js'
 
-// TODO: We don't really need to use a factory pattern here anymore. It was introduced to fix a
-//       reactivity bug with Vuex. Since we use Pinia now and don't need to pass the store all the
-//       way down it can be refactored/reverted.
-//       Ref commit 207b7a13655ae7f1e01ee0e7d40b5109a37c6174
-
 /**
- * Creates a new moment object using the locale from the given Pinia store
+ * Creates a new moment object using the locale from the global Pinia store
  *
  * @param {object[]} data FullCalendar object containing the date etc.
  * @param {number[]} data.array Input data to initialize moment
@@ -24,11 +19,13 @@ const momentFactory = ({ array }) => {
 }
 
 /**
- * Construct a cmdFormatter that can be used to construct a FullCalendar plugin
+ * Formats a date with given cmdStr
  *
+ * @param {string} cmdStr The formatting string
+ * @param {object} arg An Object containing the date, etc.
  * @return {function(string, string):string} cmdFormatter function
  */
-const cmdFormatterFactory = () => (cmdStr, arg) => {
+const cmdFormatter = (cmdStr, arg) => {
 	// With our specific DateFormattingConfig,
 	// cmdStr will always be a moment parsable string
 	// like LT, etc.
@@ -53,14 +50,7 @@ const cmdFormatterFactory = () => (cmdStr, arg) => {
 	return momentFactory(arg.start).format(cmdStr)
 }
 
-/**
- * Construct a moment plugin for FullCalendar using the locale from the given Vuex store
- *
- * @return {object} The FullCalendar plugin
- */
-export default function momentPluginFactory() {
-	return createPlugin({
-		name: '@nextcloud/moment-plugin',
-		cmdFormatter: cmdFormatterFactory(),
-	})
-}
+export default createPlugin({
+	name: '@nextcloud/moment-plugin',
+	cmdFormatter,
+})


### PR DESCRIPTION
We use Pinia now and we don't have to pass a store to the moment plugin anymore. The factory pattern is thus not required anymore.