### PR TITLE
Revert "fix: scope global sidebar styles to the app"

### DIFF
--- a/css/app-sidebar.scss
+++ b/css/app-sidebar.scss
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-.app-calendar .app-sidebar,
+.app-sidebar,
 .event-popover .event-popover__inner {
 	.editor-invitee-list-empty-message,
 	.editor-reminders-list-empty-message,


### PR DESCRIPTION
This reverts commit 2460c539e8b7fdd0b867012006e0f0484ba91d48.

The fix broke the sidebar tabs.