### PR TITLE
[stable4.7] Revert "fix: scope global sidebar styles to the app"

### DIFF
--- a/css/app-sidebar.scss
+++ b/css/app-sidebar.scss
@@ -21,7 +21,7 @@
  *
  */
 
-.app-calendar .app-sidebar,
+.app-sidebar,
 .event-popover .event-popover__inner {
 	.editor-invitee-list-empty-message,
 	.editor-reminders-list-empty-message,


### PR DESCRIPTION
This reverts commit 4a5e3525deccf5f92542c2fdca8ba69769e82ff8.

Manual backport of https://github.com/nextcloud/calendar/pull/6091