### PR TITLE
fix: use first day of week setting from server

### DIFF
--- a/src/fullcalendar/localization/localeProvider.js
+++ b/src/fullcalendar/localization/localeProvider.js
@@ -2,10 +2,7 @@
  * SPDX-FileCopyrightText: 2020 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
-import { translate as t, getLanguage } from '@nextcloud/l10n'
-import {
-	getFirstDayOfWeekFromMomentLocale,
-} from '../../utils/moment.js'
+import { translate as t, getLanguage, getFirstDay } from '@nextcloud/l10n'
 
 /**
  * Returns localization settings for the FullCalender package.
@@ -15,7 +12,7 @@ import {
  */
 const getFullCalendarLocale = () => {
 	return {
-		firstDay: getFirstDayOfWeekFromMomentLocale(),
+		firstDay: getFirstDay(),
 		locale: getLanguage(),
 		// TRANSLATORS W is an abbreviation for Week
 		weekText: t('calendar', 'W'),

--- a/src/utils/localization.js
+++ b/src/utils/localization.js
@@ -7,6 +7,7 @@ import {
 	getDayNames,
 	getDayNamesMin,
 	getDayNamesShort,
+	getFirstDay,
 	getMonthNames,
 	getMonthNamesShort,
 } from '@nextcloud/l10n'
@@ -31,7 +32,7 @@ const getLangConfigForVue2DatePicker = (momentLocale) => {
 			weekdays: getDayNames(),
 			weekdaysShort: getDayNamesShort(),
 			weekdaysMin: getDayNamesMin(),
-			firstDayOfWeek: moment.localeData(momentLocale).firstDayOfWeek(),
+			firstDayOfWeek: getFirstDay(),
 			firstWeekContainsDate: moment.localeData(momentLocale).firstDayOfYear(),
 			meridiem: moment.localeData(momentLocale).meridiem,
 			meridiemParse: moment.localeData(momentLocale).meridiemParse,

--- a/src/utils/moment.js
+++ b/src/utils/moment.js
@@ -2,7 +2,7 @@
  * SPDX-FileCopyrightText: 2018 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
-import { getLanguage, getLocale } from '@nextcloud/l10n'
+import { getFirstDay, getLanguage, getLocale } from '@nextcloud/l10n'
 import moment from '@nextcloud/moment'
 
 /**
@@ -38,7 +38,7 @@ export default async function loadMomentLocalization() {
 			llll: moment.localeData(realLocale).longDateFormat('llll'),
 		},
 		week: {
-			dow: moment.localeData(realLocale).firstDayOfWeek(),
+			dow: getFirstDay(),
 			doy: moment.localeData(realLocale).firstDayOfYear(),
 		},
 	})
@@ -76,13 +76,4 @@ async function getLocaleFor(locale) {
 	}
 
 	return 'en'
-}
-
-/**
- * Get's the first day of a week based on a moment locale
- *
- * @return {number}
- */
-export function getFirstDayOfWeekFromMomentLocale() {
-	return moment.localeData().firstDayOfWeek()
 }


### PR DESCRIPTION
Ref https://github.com/nextcloud/calendar/issues/384 (does not solve the issue but helps with it)

Initialize moment, FullCalender and our date picker using the global first day of week setting from server. It is currently derived from a user's locale and provided by `@nextcloud/l10n`.

This should make Calendar more consistent with the locale preview in the personal user settings (below the locale select).

https://github.com/nextcloud-libraries/nextcloud-l10n/blob/b65c8b6d9ff9c3178aeae466ccdc7a8e1406cf32/lib/date.ts#L5-L17