### PR TITLE
ci: allow coverage upload to fail

### DIFF
--- a/.github/workflows/npm-test.yml
+++ b/.github/workflows/npm-test.yml
@@ -37,7 +37,7 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           file: ./coverage/coverage-final.json
           flags: javascript
-          fail_ci_if_error: true
+          fail_ci_if_error: ${{ !github.event.pull_request.head.repo.fork }}
 
   summary:
     runs-on: ubuntu-latest

--- a/.github/workflows/php-test.yml
+++ b/.github/workflows/php-test.yml
@@ -50,7 +50,7 @@ jobs:
         token: ${{ secrets.CODECOV_TOKEN }}
         file: nextcloud/apps/calendar/clover.unit.xml
         flags: php
-        fail_ci_if_error: true
+        fail_ci_if_error: ${{ !github.event.pull_request.head.repo.fork }}
         verbose: true
 
   integration-tests:


### PR DESCRIPTION
Otherwise, PRs from (community) forks will never have green CI. In my opinion we can tolerate having no coverage info from the occasional community contributor as long as the tests are successful.