### PR TITLE
fix(appointments): Set organiser email to correct langauge

### DIFF
--- a/lib/Service/Appointments/MailService.php
+++ b/lib/Service/Appointments/MailService.php
@@ -12,6 +12,7 @@ use OCA\Calendar\Db\AppointmentConfig;
 use OCA\Calendar\Db\Booking;
 use OCA\Calendar\Exception\ServiceException;
 use OCP\Defaults;
+use OCP\IConfig;
 use OCP\IDateTimeFormatter;
 use OCP\IL10N;
 use OCP\IURLGenerator;
@@ -53,7 +54,8 @@ class MailService {
 		IURLGenerator $urlGenerator,
 		IDateTimeFormatter $dateFormatter,
 		IFactory $lFactory,
-		IManager $notificationManager) {
+		IManager $notificationManager,
+		private IConfig $userConfig) {
 		$this->userManager = $userManager;
 		$this->mailer = $mailer;
 		$this->l10n = $l10n;
@@ -212,7 +214,7 @@ class MailService {
 		IL10N $l10n,
 		Booking $booking,
 		AppointmentConfig $config,
-		bool $recipient):void {
+		bool $recipient): void {
 		$template->addBodyListItem($booking->getDisplayName(), $l10n->t('Appointment for:'));
 
 		// determain timezone depending on who is getting the message (Requestee/Requester)
@@ -259,10 +261,9 @@ class MailService {
 		return \OCP\Util::getDefaultEmailAddress('appointments-noreply');
 	}
 
-	public function sendOrganizerBookingInformationEmail(Booking $booking, AppointmentConfig $config, string $calendar) {
+	public function sendOrganizerBookingInformationEmail(Booking $booking, AppointmentConfig $config, string $calendar): void {
 		/** @var IUser $user */
 		$user = $this->userManager->get($config->getUserId());
-
 		if ($user === null) {
 			throw new ServiceException('Could not find organizer');
 		}
@@ -282,21 +283,23 @@ class MailService {
 		$template = $this->mailer->createEMailTemplate('calendar.confirmOrganizer');
 		$template->addHeader();
 
+		$lang = $this->userConfig->getUserValue($user->getUID(), 'core', 'lang', null);
+		$l10n = $this->lFactory->get('calendar', $lang);
 		// Subject
-		$subject = $this->l10n->t('You have a new appointment booking "%s" from %s', [$config->getName(), $booking->getDisplayName()]);
+		$subject = $l10n->t('You have a new appointment booking "%s" from %s', [$config->getName(), $booking->getDisplayName()]);
 		$template->setSubject($subject);
 
 		// Heading
-		$summary = $this->l10n->t('Dear %s, %s (%s) booked an appointment with you.', [$user->getDisplayName(), $booking->getDisplayName(), $booking->getEmail()]);
+		$summary = $l10n->t('Dear %s, %s (%s) booked an appointment with you.', [$user->getDisplayName(), $booking->getDisplayName(), $booking->getEmail()]);
 		$template->addHeading($summary);
 
-		$template->addBodyListItem($booking->getDisplayName() . ' (' . $booking->getEmail() . ')', $this->l10n->t('Appointment with:'));
+		$template->addBodyListItem($booking->getDisplayName() . ' (' . $booking->getEmail() . ')', $l10n->t('Appointment with:'));
 		if (!empty($config->getDescription())) {
-			$template->addBodyListItem($config->getDescription(), $this->l10n->t('Description:'));
+			$template->addBodyListItem($config->getDescription(), $l10n->t('Description:'));
 		}
 
 		// Create Booking overview
-		$this->addBulletList($template, $this->l10n, $booking, $config, true);
+		$this->addBulletList($template, $l10n, $booking, $config, true);
 		$template->addFooter();
 
 		$attachment = $this->mailer->createAttachment($calendar, 'appointment.ics', 'text/calendar');
@@ -319,7 +322,7 @@ class MailService {
 		}
 	}
 
-	public function sendOrganizerBookingInformationNotification(Booking $booking, AppointmentConfig $config) {
+	public function sendOrganizerBookingInformationNotification(Booking $booking, AppointmentConfig $config): void {
 		$tzid = $config->getAvailabilityAsArray()['timezoneId']; // extract time zone from appointment configuration
 		$dtstart = new \DateTime("now", new \DateTimeZone($booking->getTimezone())); // generate DateTime with booking time zone
 		$dtstart->setTimestamp($booking->getStart()); // set booking time stamp

--- a/tests/php/unit/Service/Appointments/MailServiceTest.php
+++ b/tests/php/unit/Service/Appointments/MailServiceTest.php
@@ -15,6 +15,7 @@ use OCA\Calendar\Exception\ServiceException;
 use OCA\Calendar\Service\Appointments\MailService;
 use OCP\Calendar\ICalendarQuery;
 use OCP\Defaults;
+use OCP\IConfig;
 use OCP\IDateTimeFormatter;
 use OCP\IL10N;
 use OCP\IUser;
@@ -58,6 +59,7 @@ class MailServiceTest extends TestCase {
 
 	/** @var MailService */
 	private $mailService;
+	private IConfig|MockObject $userConfig;
 
 	protected function setUp(): void {
 		parent::setUp();
@@ -75,6 +77,7 @@ class MailServiceTest extends TestCase {
 		$this->dateFormatter = $this->createMock(IDateTimeFormatter::class);
 		$this->lFactory = $this->createMock(IFactory::class);
 		$this->notificationManager = $this->createMock(IManager::class);
+		$this->userConfig = $this->createMock(IConfig::class);
 		$this->mailService = new MailService(
 			$this->mailer,
 			$this->userManager,
@@ -85,6 +88,7 @@ class MailServiceTest extends TestCase {
 			$this->dateFormatter,
 			$this->lFactory,
 			$this->notificationManager,
+			$this->userConfig
 		);
 	}
 
@@ -537,6 +541,9 @@ class MailServiceTest extends TestCase {
 		$this->mailer->expects(self::once())
 			->method('createEmailTemplate')
 			->willReturn($emailTemplate);
+		$this->userConfig->expects(self::once())
+			->method('getUserValue')
+			->willReturn('en');
 		$emailTemplate->expects(self::once())
 			->method('addHeader');
 		$emailTemplate->expects(self::once())
@@ -556,8 +563,9 @@ class MailServiceTest extends TestCase {
 		$this->lFactory->expects(self::once())
 			->method('findGenericLanguage')
 			->willReturn('en');
-		$this->lFactory->expects(self::once())
-			->method('get');
+		$this->lFactory->expects(self::exactly(2))
+			->method('get')
+			->willReturn($this->l10n);
 		$this->dateFormatter->expects(self::once())
 			->method('formatDateTimeRelativeDay')
 			->willReturn('Test');
@@ -607,6 +615,9 @@ class MailServiceTest extends TestCase {
 		$this->mailer->expects(self::once())
 			->method('createMessage')
 			->willReturn($mailMessage);
+		$this->userConfig->expects(self::once())
+			->method('getUserValue')
+			->willReturn('en');
 		$mailMessage->expects(self::once())
 			->method('setFrom')
 			->willReturn($mailMessage);
@@ -639,8 +650,9 @@ class MailServiceTest extends TestCase {
 		$this->lFactory->expects(self::once())
 			->method('findGenericLanguage')
 			->willReturn('en');
-		$this->lFactory->expects(self::once())
-			->method('get');
+		$this->lFactory->expects(self::exactly(2))
+			->method('get')
+			->willReturn($this->l10n);
 		$this->dateFormatter->expects(self::once())
 			->method('formatDateTimeRelativeDay')
 			->with(self::anything(), self::anything(), self::anything(), new \DateTimeZone('Europe/Berlin'))
@@ -690,6 +702,9 @@ class MailServiceTest extends TestCase {
 		$this->mailer->expects(self::once())
 			->method('createMessage')
 			->willReturn($mailMessage);
+		$this->userConfig->expects(self::once())
+			->method('getUserValue')
+			->willReturn('en');
 		$mailMessage->expects(self::once())
 			->method('setFrom')
 			->willReturn($mailMessage);
@@ -722,8 +737,9 @@ class MailServiceTest extends TestCase {
 		$this->lFactory->expects(self::once())
 			->method('findGenericLanguage')
 			->willReturn('en');
-		$this->lFactory->expects(self::once())
-			->method('get');
+		$this->lFactory->expects(self::exactly(2))
+			->method('get')
+			->willReturn($this->l10n);
 		$this->dateFormatter->expects(self::once())
 			->method('formatDateTimeRelativeDay')
 			->willReturn('Test');


### PR DESCRIPTION
Fixes https://github.com/nextcloud/calendar/issues/6156

![image](https://github.com/user-attachments/assets/fa4fb03f-95ab-4d51-a357-76d42c0b79b2)
