### PR TITLE
Align invitee list item status information with the status icon

### DIFF
--- a/src/components/Editor/AvatarParticipationStatus.vue
+++ b/src/components/Editor/AvatarParticipationStatus.vue
@@ -185,7 +185,7 @@ export default {
 .avatar-participation-status__text {
 	opacity: .45;
 	left: 63px;
-	bottom: 40px;
+	bottom: 21px;
 	white-space: nowrap;
 	position: relative;
 	min-width: 220px;


### PR DESCRIPTION
Fix https://github.com/nextcloud/calendar/issues/6150

| A | B |
| - | - |
| ![Screenshot from 2024-07-15 15-11-57](https://github.com/user-attachments/assets/eaf45d73-78ed-4d59-a194-32bdcc71cf0b) | ![Screenshot from 2024-07-15 15-11-37](https://github.com/user-attachments/assets/a928d0c5-75b9-40dd-a465-e096964ce451) |

And to prove that it's aligned :)
![Screenshot from 2024-07-15 15-11-32](https://github.com/user-attachments/assets/9b5fb232-60a7-4b04-b298-09def27f83f4)

