### PR TITLE
feat: allow calendar-wide transparency settings

### DIFF
--- a/src/models/calendar.js
+++ b/src/models/calendar.js
@@ -54,6 +54,8 @@ const getDefaultCalendarObject = (props = {}) => Object.assign({}, {
 	calendarObjects: [],
 	// Time-ranges that have already been fetched for this calendar
 	fetchedTimeRanges: [],
+	// Scheduling transparency
+	transparency: 'opaque',
 }, props)
 
 /**
@@ -86,6 +88,10 @@ const mapDavCollectionToCalendar = (calendar, currentUserPrincipal) => {
 	const url = calendar.url
 	const publishURL = calendar.publishURL || null
 	const timezone = calendar.timezone || null
+	// If this property is not present on a calendar collection,
+	// then the default value CALDAV:opaque MUST be assumed.
+	// https://datatracker.ietf.org/doc/html/rfc6638#section-9.1
+	const transparency = calendar.transparency || 'opaque'
 
 	let isSharedWithMe = false
 	if (!currentUserPrincipal) {
@@ -140,6 +146,7 @@ const mapDavCollectionToCalendar = (calendar, currentUserPrincipal) => {
 		canBePublished,
 		shares,
 		timezone,
+		transparency,
 		dav: calendar,
 	})
 }

--- a/src/store/calendars.js
+++ b/src/store/calendars.js
@@ -538,6 +538,25 @@ export default defineStore('calendars', {
 		},
 
 		/**
+		 * Change a calendars transparency
+		 *
+		 * @param {object} data destructuring object
+		 * @param {object} data.calendar the calendar to modify
+		 * @param {string} data.transparency the new transparency
+		 * @return {Promise}
+		 */
+		async changeCalendarTransparency({ calendar, transparency }) {
+			if (calendar.dav.transparency === transparency) {
+				return
+			}
+
+			calendar.dav.transparency = transparency
+
+			await calendar.dav.update()
+			this.calendarsById[calendar.id].transparency = transparency
+		},
+
+		/**
 		 * Share calendar with User or Group
 		 *
 		 * @param {object} data destructuring object

--- a/tests/javascript/unit/models/calendar.test.js
+++ b/tests/javascript/unit/models/calendar.test.js
@@ -37,7 +37,8 @@ describe('Test suite: Calendar model (models/calendar.js)', () => {
 			canBePublished: false,
 			dav: false,
 			calendarObjects: [],
-			fetchedTimeRanges: []
+			fetchedTimeRanges: [],
+			transparency: 'opaque',
 		})
 	})
 
@@ -67,7 +68,8 @@ describe('Test suite: Calendar model (models/calendar.js)', () => {
 			canBePublished: false,
 			dav: false,
 			calendarObjects: [],
-			fetchedTimeRanges: []
+			fetchedTimeRanges: [],
+			transparency: 'opaque',
 		})
 	})
 
@@ -85,6 +87,7 @@ describe('Test suite: Calendar model (models/calendar.js)', () => {
 			publishURL: undefined,
 			enabled: true,
 			timezone: 'BEGIN:VCALENDAR...END:VCALENDAR',
+			transparency: 'opaque',
 		}
 
 		expect(mapDavCollectionToCalendar(cdavObject, {
@@ -107,6 +110,7 @@ describe('Test suite: Calendar model (models/calendar.js)', () => {
 			supportsTasks: false,
 			isSharedWithMe: false,
 			timezone: 'BEGIN:VCALENDAR...END:VCALENDAR',
+			transparency: 'opaque',
 			url: '/foo/bar',
 			calendarObjects: [],
 			fetchedTimeRanges: [],
@@ -129,7 +133,8 @@ describe('Test suite: Calendar model (models/calendar.js)', () => {
 			order: undefined,
 			publishURL: undefined,
 			timezone: 'BEGIN:VCALENDAR...END:VCALENDAR',
-			enabled: false
+			transparency: 'transparent',
+			enabled: false,
 		}
 
 		expect(mapDavCollectionToCalendar(cdavObject, {
@@ -152,6 +157,7 @@ describe('Test suite: Calendar model (models/calendar.js)', () => {
 			supportsTasks: false,
 			isSharedWithMe: false,
 			timezone: 'BEGIN:VCALENDAR...END:VCALENDAR',
+			transparency: 'transparent',
 			url: '/foo/bar',
 			calendarObjects: [],
 			fetchedTimeRanges: [],
@@ -196,6 +202,7 @@ describe('Test suite: Calendar model (models/calendar.js)', () => {
 			supportsTasks: false,
 			isSharedWithMe: false,
 			timezone: null,
+			transparency: 'opaque',
 			url: '/foo/bar',
 			calendarObjects: [],
 			fetchedTimeRanges: [],
@@ -240,6 +247,7 @@ describe('Test suite: Calendar model (models/calendar.js)', () => {
 			supportsTasks: false,
 			isSharedWithMe: true,
 			timezone: null,
+			transparency: 'opaque',
 			url: '/foo/bar',
 			calendarObjects: [],
 			fetchedTimeRanges: [],
@@ -284,6 +292,7 @@ describe('Test suite: Calendar model (models/calendar.js)', () => {
 			supportsTasks: false,
 			isSharedWithMe: false,
 			timezone: null,
+			transparency: 'opaque',
 			url: '/foo/bar',
 			calendarObjects: [],
 			fetchedTimeRanges: [],
@@ -328,6 +337,7 @@ describe('Test suite: Calendar model (models/calendar.js)', () => {
 			supportsTasks: false,
 			isSharedWithMe: false,
 			timezone: null,
+			transparency: 'opaque',
 			url: '/foo/bar',
 			calendarObjects: [],
 			fetchedTimeRanges: [],
@@ -372,6 +382,7 @@ describe('Test suite: Calendar model (models/calendar.js)', () => {
 			supportsTasks: false,
 			isSharedWithMe: false,
 			timezone: null,
+			transparency: 'opaque',
 			url: '/foo/bar',
 			calendarObjects: [],
 			fetchedTimeRanges: [],
@@ -416,6 +427,7 @@ describe('Test suite: Calendar model (models/calendar.js)', () => {
 			supportsTasks: false,
 			isSharedWithMe: false,
 			timezone: null,
+			transparency: 'opaque',
 			url: '/foo/bar',
 			calendarObjects: [],
 			fetchedTimeRanges: [],
@@ -516,6 +528,7 @@ describe('Test suite: Calendar model (models/calendar.js)', () => {
 			supportsTasks: false,
 			isSharedWithMe: false,
 			timezone: null,
+			transparency: 'opaque',
 			url: '/foo/bar',
 			calendarObjects: [],
 			fetchedTimeRanges: [],
@@ -632,6 +645,7 @@ describe('Test suite: Calendar model (models/calendar.js)', () => {
 			supportsTasks: false,
 			isSharedWithMe: true,
 			timezone: null,
+			transparency: 'opaque',
 			url: '/foo/bar',
 			calendarObjects: [],
 			fetchedTimeRanges: [],
@@ -677,6 +691,7 @@ describe('Test suite: Calendar model (models/calendar.js)', () => {
 			supportsTasks: false,
 			isSharedWithMe: false,
 			timezone: 'BEGIN:VCALENDAR...END:VCALENDAR',
+			transparency: 'opaque',
 			url: '/remote.php/dav/calendars/admin/personal/',
 			calendarObjects: [],
 			fetchedTimeRanges: [],


### PR DESCRIPTION
Fixes https://github.com/nextcloud/calendar/issues/3193

~Needs https://github.com/nextcloud/cdav-library/pull/908~
~Needs https://github.com/nextcloud/cdav-library/pull/909~

How to test:

- Uncheck the checkbox in the Edit Calendar Modal
- Check oc_calendars row for the calendar - the value for the transparency should change to 1 for transparent when the checkbox is unchecked.