### PR TITLE
fix: make sidebar tabs spacing consistent

### DIFF
--- a/src/components/Editor/Invitees/InviteesList.vue
+++ b/src/components/Editor/Invitees/InviteesList.vue
@@ -365,8 +365,6 @@ export default {
 
 <style lang="scss" scoped>
 .invitees-list {
-	margin-top: 12px;
-
 	&__header {
 		display: flex;
 		gap: 5px;


### PR DESCRIPTION
| b | a |
|--------|--------|
| <img width="470" alt="image" src="https://github.com/user-attachments/assets/3cde8802-56ad-473b-890f-6ec73efa385e"> | <img width="470" alt="image" src="https://github.com/user-attachments/assets/c7f6660b-854f-40d6-ae2d-21054d0fb036"> | 