### PR TITLE
chore(workflows): fix issue labels

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,6 +1,6 @@
 name: "Bug"
 description: "Have you encountered a bug?"
-labels: ["bug", "0 - to triage"]
+labels: ["bug", "0. to triage"]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,6 +1,6 @@
 name: "Feature request"
 description: "You have a neat idea that should be implemented?"
-labels: ["enhancement", "0 - to triage"]
+labels: ["enhancement", "0. to triage"]
 body:
   - type: markdown
     attributes:


### PR DESCRIPTION
Issue labels don't work any more since they use the old `0 - to triage` and `1 -  to develop`