### PR TITLE
Settings: set proper width for all NcSelects to be the same width

### DIFF
--- a/src/components/AppNavigation/Settings.vue
+++ b/src/components/AppNavigation/Settings.vue
@@ -501,3 +501,9 @@ export default {
 	},
 }
 </script>
+
+<style scoped>
+.settings-fieldset-interior-item, :deep(.v-select.select) {
+	width: 100%;
+}
+</style>


### PR DESCRIPTION
Fix https://github.com/nextcloud/calendar/issues/6138

| A | B |
| - | - |
| ![Screenshot from 2024-07-24 10-47-42](https://github.com/user-attachments/assets/b14d9d1b-57f8-4db3-84b4-1bfa091e0773) | ![Screenshot from 2024-07-24 10-46-42](https://github.com/user-attachments/assets/7d82e1c5-10ec-4bb5-beb2-e23d3e5f4ad4) |