### PR TITLE
InviteesListSearch: make avatar status not clip

### DIFF
--- a/src/components/Editor/Invitees/InviteesListSearch.vue
+++ b/src/components/Editor/Invitees/InviteesListSearch.vue
@@ -295,3 +295,9 @@ export default {
 	},
 }
 </script>
+
+<style scoped>
+:deep(.avatardiv) {
+	overflow: visible !important;
+}
+</style>


### PR DESCRIPTION
Fix https://github.com/nextcloud/calendar/issues/6227

| After | Before |
| - | - |
| ![image](https://github.com/user-attachments/assets/bd48460c-8fe4-4509-8d86-e5ed55ca4738) | ![image](https://github.com/user-attachments/assets/5db2444e-49a5-4786-92d3-61942015cd53) |

The culprit was NcSelect styling (as per usual)