### PR TITLE
FullCalendar CSS: make events in weekly view have the correct width

### DIFF
--- a/css/fullcalendar.scss
+++ b/css/fullcalendar.scss
@@ -235,6 +235,11 @@
 	}
 }
 
+.fc-timegrid-event-harness-inset {
+	right: -0.3vw !important;
+	left: -0.1vw !important;
+}
+
 .fc-v-event {
 	min-height: 4em;
 


### PR DESCRIPTION
Fix https://github.com/nextcloud/calendar/issues/6226

The solution is a bit hacky, but I can't think of anything better...

| Before | After |
| - | - |
| ![image](https://github.com/user-attachments/assets/758c7edd-0796-4361-ab55-97a5da4870be) | ![image](https://github.com/user-attachments/assets/1b5beea0-9908-49e2-afcb-9c5f8db88846) |