### PR TITLE
fix: Events with overlapping time visually overlap

### DIFF
--- a/css/fullcalendar.scss
+++ b/css/fullcalendar.scss
@@ -235,9 +235,8 @@
 	}
 }
 
-.fc-timegrid-event-harness-inset {
-	right: -0.3vw !important;
-	left: -0.1vw !important;
+.fc-timegrid-col-events{
+	margin: 0 !important;
 }
 
 .fc-v-event {


### PR DESCRIPTION
Fix #6281
| b | a |
|--------|--------|
| <img width="208" alt="image" src="https://github.com/user-attachments/assets/e82f5140-ddb4-4bdd-9d5c-2d2fe5a4d936"> | <img width="208" alt="image" src="https://github.com/user-attachments/assets/0c0ae377-ce13-4345-ac58-d19fa272fe68"> | 