### PR TITLE
feat: allow inviting contact groups

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -39,6 +39,8 @@ return [
 		['name' => 'contact#searchPhoto', 'url' => '/v1/autocompletion/photo', 'verb' => 'POST'],
 		// Circles
 		['name' => 'contact#getCircleMembers', 'url' => '/v1/circles/getmembers', 'verb' => 'GET'],
+		// Contact Groups
+		['name' => 'contact#getContactGroupMembers', 'url' => '/v1/autocompletion/groupmembers', 'verb' => 'POST'],
 		// Settings
 		['name' => 'settings#setConfig', 'url' => '/v1/config/{key}', 'verb' => 'POST'],
 		// Tools

--- a/lib/Service/ContactsService.php
+++ b/lib/Service/ContactsService.php
@@ -1,0 +1,144 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * SPDX-FileCopyrightText: 2014 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+namespace OCA\Calendar\Service;
+
+class ContactsService {
+
+
+	/**
+	 * @param array $contact
+	 * @return bool
+	 */
+	public function isSystemBook(array $contact): bool {
+		// Information about system users is fetched via DAV nowadays
+		return (isset($contact['isLocalSystemBook']) && $contact['isLocalSystemBook'] === true);
+	}
+
+	/**
+	 * @param array $contact
+	 * @return bool
+	 */
+	public function hasEmail(array $contact): bool {
+		if (!isset($contact['EMAIL'])) {
+			return false;
+		}
+
+		if (!is_array($contact['EMAIL']) && !empty($contact['EMAIL'])) {
+			return true;
+		}
+
+		if (!empty($contact['EMAIL'][0])) {
+			return true;
+		}
+
+		return false;
+	}
+
+	/**
+	 * Extract name from an array containing a contact's information
+	 *
+	 * @param array $contact
+	 * @return string
+	 */
+	public function getNameFromContact(array $contact): string {
+		return $contact['FN'] ?? '';
+	}
+
+	/**
+	 * Get photo uri from contact
+	 *
+	 * @param array $contact
+	 * @return string|null
+	 */
+	public function getPhotoUri(array $contact): ?string {
+		if (!isset($contact['PHOTO'])) {
+			return null;
+		}
+
+		$raw = $contact['PHOTO'];
+		$uriPrefix = 'VALUE=uri:';
+		if (str_starts_with($raw, $uriPrefix)) {
+			$strpos = strpos($raw, 'http');
+			return $strpos !== false ? substr($raw, $strpos) : null;
+		}
+
+		return null;
+	}
+
+	/**
+	 * @param array $contact
+	 * @return string[]
+	 */
+	public function getEmail(array $contact): array {
+		if (\is_string($contact['EMAIL'])) {
+			return [$contact['EMAIL']];
+		}
+		return $contact['EMAIL'];
+	}
+
+	/**
+	 * @param array $contact
+	 * @return string|null
+	 */
+	public function getTimezoneId(array $contact): ?string {
+		if (!isset($contact['TZ'])) {
+			return null;
+		}
+
+		if (\is_array($contact['TZ'])) {
+			return $contact['TZ'][0];
+		}
+		return $contact['TZ'];
+	}
+
+	/**
+	 * @param array $contact
+	 * @return string|null
+	 */
+	public function getLanguageId(array $contact): ?string {
+		if (!isset($contact['LANG'])) {
+			return null;
+		}
+
+		if (\is_array($contact['LANG'])) {
+			return $contact['LANG'][0];
+		}
+		return $contact['LANG'];
+	}
+
+	/**
+	 * @param array $groups
+	 * @param string $search
+	 * @return array
+	 */
+	public function filterGroupsWithCount(array $groups, string $search): array {
+		//filter to be unique
+		$categories = [];
+		foreach ($groups as $group) {
+			$categories[] = array_filter(explode(',', $group['CATEGORIES']), static function ($cat) use ($search) {
+				return str_contains(strtolower($cat), strtolower($search));
+			});
+		}
+		return array_count_values(array_merge(...$categories));
+	}
+
+	/**
+	 * @param array $contact
+	 * @return array
+	 */
+	public function getAddress(array $contact): array {
+		if (\is_string($contact['ADR'])) {
+			$contact['ADR'] = [$contact['ADR']];
+		}
+		$addresses = [];
+		foreach ($contact['ADR'] as $address) {
+			$addresses[] = trim(preg_replace("/\n+/", "\n", str_replace(';', "\n", $address)));
+		}
+		return $addresses;
+	}
+}

--- a/src/components/Editor/Invitees/InviteesList.vue
+++ b/src/components/Editor/Invitees/InviteesList.vue
@@ -351,6 +351,27 @@ export default {
 			this.recentAttendees.push(address)
 		},
 		addAttendee({ commonName, email, calendarUserType, language, timezoneId, member }) {
+			let modifiedMember = null
+			if (calendarUserType === 'INDIVIDUAL' && member) {
+				const modifiedMemberIndex = this.calendarObjectInstance.attendees.findIndex(function(attendee) {
+					if (attendee.uri === email) {
+						return true
+					}
+					return false
+				})
+				modifiedMember = this.calendarObjectInstance.attendees[modifiedMemberIndex]
+			}
+
+			if (modifiedMember) {
+				const group = modifiedMember.attendeeProperty.member
+				this.calendarObjectInstanceStore.removeAttendee({
+					calendarObjectInstance: this.calendarObjectInstance,
+					attendee: modifiedMember,
+				})
+				member = member.split(',')
+				member.push(group)
+			}
+
 			this.calendarObjectInstanceStore.addAttendee({
 				calendarObjectInstance: this.calendarObjectInstance,
 				commonName,

--- a/src/components/Editor/Invitees/InviteesListItem.vue
+++ b/src/components/Editor/Invitees/InviteesListItem.vue
@@ -35,27 +35,32 @@
 				</template>
 			</NcButton>
 			<Actions v-if="isViewedByOrganizer">
-				<ActionCheckbox :checked="attendee.rsvp"
+				<ActionCheckbox v-if="!members.length"
+					:checked="attendee.rsvp"
 					@change="toggleRSVP">
 					{{ $t('calendar', 'Request reply') }}
 				</ActionCheckbox>
 
-				<ActionRadio :name="radioName"
+				<ActionRadio v-if="!members.length"
+					:name="radioName"
 					:checked="isChair"
 					@change="changeRole('CHAIR')">
 					{{ $t('calendar', 'Chairperson') }}
 				</ActionRadio>
-				<ActionRadio :name="radioName"
+				<ActionRadio v-if="!members.length"
+					:name="radioName"
 					:checked="isRequiredParticipant"
 					@change="changeRole('REQ-PARTICIPANT')">
 					{{ $t('calendar', 'Required participant') }}
 				</ActionRadio>
-				<ActionRadio :name="radioName"
+				<ActionRadio v-if="!members.length"
+					:name="radioName"
 					:checked="isOptionalParticipant"
 					@change="changeRole('OPT-PARTICIPANT')">
 					{{ $t('calendar', 'Optional participant') }}
 				</ActionRadio>
-				<ActionRadio :name="radioName"
+				<ActionRadio v-if="!members.length"
+					:name="radioName"
 					:checked="isNonParticipant"
 					@change="changeRole('NON-PARTICIPANT')">
 					{{ $t('calendar', 'Non-participant') }}

--- a/src/store/calendarObjectInstance.js
+++ b/src/store/calendarObjectInstance.js
@@ -421,7 +421,7 @@ export default defineStore('calendarObjectInstance', {
 		 * @param {string=} data.language Preferred language of the attendee
 		 * @param {string=} data.timezoneId Preferred timezone of the attendee
 		 * @param {object=} data.organizer Principal of the organizer to be set if not present
-		 * @param data.member
+		 * @param {string|array} data.member Group membership(s)
 		 */
 		addAttendee({
 			calendarObjectInstance,
@@ -437,7 +437,6 @@ export default defineStore('calendarObjectInstance', {
 			member = null,
 		}) {
 			const attendee = AttendeeProperty.fromNameAndEMail(commonName, uri)
-
 			if (calendarUserType !== null) {
 				attendee.userType = calendarUserType
 			}
@@ -492,14 +491,25 @@ export default defineStore('calendarObjectInstance', {
 			attendee,
 		}) {
 			calendarObjectInstance.eventComponent.removeAttendee(attendee.attendeeProperty)
-
 			// Also remove members if attendee is a group
 			if (attendee.attendeeProperty.userType === 'GROUP') {
 				attendee.members.forEach(function(member) {
-					calendarObjectInstance.eventComponent.removeAttendee(member.attendeeProperty)
-					const index = calendarObjectInstance.attendees.indexOf(member)
-					if (index !== -1) {
-						calendarObjectInstance.attendees.splice(index, 1)
+					if (Array.isArray(member.attendeeProperty.member) && member.attendeeProperty.member.length > 1) {
+						const removeIndex = member.attendeeProperty.member.findIndex(function(groupname) {
+							if (groupname === attendee.uri) {
+								return true
+							}
+							return false
+						})
+						if (removeIndex !== -1) {
+							member.attendeeProperty.member.splice(removeIndex, 1)
+						}
+					} else {
+						calendarObjectInstance.eventComponent.removeAttendee(member.attendeeProperty)
+						const index = calendarObjectInstance.attendees.indexOf(member)
+						if (index !== -1) {
+							calendarObjectInstance.attendees.splice(index, 1)
+						}
 					}
 				})
 			}

--- a/src/views/EditSidebar.vue
+++ b/src/views/EditSidebar.vue
@@ -526,7 +526,6 @@ export default {
 				this.showPreloader = true
 				if (!this.isPrivate()) {
 					this.showModalNewAttachments.map(async (attachment, i) => {
-						// console.log('Add share', attachment)
 						this.sharedProgress = Math.ceil(100 * (i + 1) / total)
 
 						// add share + change attachment

--- a/tests/php/unit/Controller/ContactControllerTest.php
+++ b/tests/php/unit/Controller/ContactControllerTest.php
@@ -8,13 +8,14 @@ declare(strict_types=1);
 namespace OCA\Calendar\Controller;
 
 use ChristophWurst\Nextcloud\Testing\TestCase;
+use OCA\Calendar\Service\ContactsService;
 use OCP\App\IAppManager;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\Contacts\IManager;
 use OCP\IRequest;
 use OCP\IUserManager;
 use PHPUnit\Framework\MockObject\MockObject;
-use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
 
 class ContactControllerTest extends TestCase {
 	/** @var string */
@@ -31,6 +32,7 @@ class ContactControllerTest extends TestCase {
 
 	/** @var IUserManager|MockObject */
 	private $userManager;
+	private ContactsService|MockObject $service;
 
 	/** @var ContactController */
 	protected $controller;
@@ -43,23 +45,24 @@ class ContactControllerTest extends TestCase {
 		$this->manager = $this->createMock(IManager::class);
 		$this->appManager = $this->createMock(IAppManager::class);
 		$this->userManager = $this->createMock(IUserManager::class);
-		$this->logger = $this->createMock(LoggerInterface::class);
+		$this->service = $this->createMock(ContactsService::class);
+		$this->logger = $this->createMock(NullLogger::class);
 		$this->controller = new ContactController($this->appName,
 			$this->request,
 			$this->manager,
 			$this->appManager,
 			$this->userManager,
+			$this->service,
 			$this->logger,
 		);
 	}
 
 	public function testSearchLocationDisabled():void {
-		$this->manager->expects($this->once())
+		$this->manager->expects(self::once())
 			->method('isEnabled')
-			->with()
 			->willReturn(false);
 
-		$this->manager->expects($this->never())
+		$this->manager->expects(self::never())
 			->method('search');
 
 		$response = $this->controller->searchLocation('search 123');
@@ -70,57 +73,89 @@ class ContactControllerTest extends TestCase {
 	}
 
 	public function testSearchLocation():void {
+		$user1 = [
+			'FN' => 'Person 1',
+			'ADR' => [
+				'33 42nd Street;Random Town;Some State;;United States',
+				';;5 Random Ave;12782 Some big city;Yet another state;United States',
+			],
+			'EMAIL' => [
+				'foo1@example.com',
+				'foo2@example.com',
+			],
+			'LANG' => [
+				'de',
+				'en'
+			],
+			'TZ' => [
+				'Europe/Berlin',
+				'UTC'
+			],
+			'PHOTO' => 'VALUE=uri:http://foo.bar'
+		];
+		$user2 = [
+			'FN' => 'Person 2',
+			'EMAIL' => 'foo3@example.com',
+		];
+		$user3 = [
+			'ADR' => [
+				'ABC Street 2;01337 Village;;Germany',
+			],
+			'LANG' => 'en_us',
+			'TZ' => 'Australia/Adelaide',
+			'PHOTO' => 'VALUE:BINARY:4242424242'
+		];
+		$user4 = [
+			'isLocalSystemBook' => true,
+			'FN' => 'Person 3',
+			'ADR' => [
+				'ABC Street 2;01337 Village;;Germany',
+			],
+			'LANG' => 'en_us',
+			'TZ' => 'Australia/Adelaide',
+			'PHOTO' => 'VALUE:BINARY:4242424242'
+		];
+
 		$this->manager->expects(self::once())
 			->method('isEnabled')
-			->with()
 			->willReturn(true);
-
+		$this->service
+			->method('isSystemBook')
+			->willReturnMap([
+				[$user1, false],
+				[$user2, false],
+				[$user3, false],
+				[$user4, true],
+			]);
+		$this->service
+			->method('getNameFromContact')
+			->willReturnMap([
+				[$user1, 'Person 1'],
+				[$user3, ''],
+			]);
+		$this->service->method('getPhotoUri')
+			->willReturnMap([
+				[$user1, 'http://foo.bar'],
+				[$user3, null]
+			]);
+		$this->service->method('getAddress')
+			->willReturnMap([
+				[$user1, [
+					"33 42nd Street\nRandom Town\nSome State\nUnited States",
+					"5 Random Ave\n12782 Some big city\nYet another state\nUnited States",
+				]],
+				[$user3, [
+					"ABC Street 2\n01337 Village\nGermany",
+				]],
+			]);
 		$this->manager->expects(self::once())
 			->method('search')
 			->with('search 123', ['FN', 'ADR'])
 			->willReturn([
-				[
-					'FN' => 'Person 1',
-					'ADR' => [
-						'33 42nd Street;Random Town;Some State;;United States',
-						';;5 Random Ave;12782 Some big city;Yet another state;United States',
-					],
-					'EMAIL' => [
-						'foo1@example.com',
-						'foo2@example.com',
-					],
-					'LANG' => [
-						'de',
-						'en'
-					],
-					'TZ' => [
-						'Europe/Berlin',
-						'UTC'
-					],
-					'PHOTO' => 'VALUE=uri:http://foo.bar'
-				],
-				[
-					'FN' => 'Person 2',
-					'EMAIL' => 'foo3@example.com',
-				],
-				[
-					'ADR' => [
-						'ABC Street 2;01337 Village;;Germany',
-					],
-					'LANG' => 'en_us',
-					'TZ' => 'Australia/Adelaide',
-					'PHOTO' => 'VALUE:BINARY:4242424242'
-				],
-				[
-					'isLocalSystemBook' => true,
-					'FN' => 'Person 3',
-					'ADR' => [
-						'ABC Street 2;01337 Village;;Germany',
-					],
-					'LANG' => 'en_us',
-					'TZ' => 'Australia/Adelaide',
-					'PHOTO' => 'VALUE:BINARY:4242424242'
-				],
+				$user1,
+				$user2,
+				$user3,
+				$user4,
 			]);
 
 		$response = $this->controller->searchLocation('search 123');
@@ -145,31 +180,44 @@ class ContactControllerTest extends TestCase {
 		$this->assertEquals(200, $response->getStatus());
 	}
 
-	public function testSearchAttendeeDisabled():void {
-		$this->manager->expects($this->once())
-			->method('isEnabled')
-			->with()
-			->willReturn(false);
-
-		$this->manager->expects($this->never())
-			->method('search');
-
-		$response = $this->controller->searchAttendee('search 123');
-
-		$this->assertInstanceOf(JSONResponse::class, $response);
-		$this->assertEquals([], $response->getData());
-		$this->assertEquals(200, $response->getStatus());
-	}
-
-	public function testSearchAttendee():void {
+	public function testGetGroupMembersNoResults() {
 		$this->manager->expects(self::once())
 			->method('isEnabled')
-			->with()
 			->willReturn(true);
 
+		$groupname = 'groupname';
 		$this->manager->expects(self::once())
 			->method('search')
-			->with('search 123', ['FN', 'EMAIL'])
+			->with($groupname, ['CATEGORIES'])
+			->willReturn([]);
+
+		$this->controller->getContactGroupMembers($groupname);
+	}
+
+	public function testGetGroupMembers() {
+		$this->manager->expects(self::once())
+			->method('isEnabled')
+			->willReturn(true);
+		$this->service->expects(self::once())
+			->method('hasEmail')
+			->willReturn(true);
+		$this->service->expects(self::once())
+			->method('getNameFromContact')
+			->willReturn('Person 1');
+		$this->service->expects(self::once())
+			->method('getLanguageId')
+			->willReturn('en_us');
+		$this->service->expects(self::once())
+			->method('getTimezoneId')
+			->willReturn('Australia/Adelaide');
+		$this->service->expects(self::once())
+			->method('getEmail')
+			->willReturn(['foo1@example.com']);
+
+		$groupname = 'group';
+		$this->manager->expects(self::once())
+			->method('search')
+			->with($groupname, ['CATEGORIES'])
 			->willReturn([
 				[
 					'FN' => 'Person 1',
@@ -189,11 +237,13 @@ class ContactControllerTest extends TestCase {
 						'Europe/Berlin',
 						'UTC'
 					],
-					'PHOTO' => 'VALUE=uri:http://foo.bar'
+					'PHOTO' => 'VALUE=uri:http://foo.bar',
+					'CATEGORIES' => 'groupname,group',
 				],
 				[
 					'FN' => 'Person 2',
 					'EMAIL' => 'foo3@example.com',
+					'CATEGORIES' => 'groups,asecondgroup',
 				],
 				[
 					'ADR' => [
@@ -201,7 +251,8 @@ class ContactControllerTest extends TestCase {
 					],
 					'LANG' => 'en_us',
 					'TZ' => 'Australia/Adelaide',
-					'PHOTO' => 'VALUE:BINARY:4242424242'
+					'PHOTO' => 'VALUE:BINARY:4242424242',
+					'CATEGORIES' => 'agroupthatswrong,asecondgroup',
 				],
 				[
 					'isLocalSystemBook' => true,
@@ -209,10 +260,139 @@ class ContactControllerTest extends TestCase {
 					'ADR' => [
 						'ABC Street 2;01337 Village;;Germany',
 					],
+					'EMAIL' => 'foo4@example.com',
 					'LANG' => 'en_us',
 					'TZ' => 'Australia/Adelaide',
-					'PHOTO' => 'VALUE:BINARY:4242424242'
+					'PHOTO' => 'VALUE:BINARY:4242424242',
+					'CATEGORIES' => 'groupppppp',
 				],
+			]);
+
+		$groupmembers = $this->controller->getContactGroupMembers($groupname);
+		$this->assertCount(1, $groupmembers->getData());
+	}
+
+	public function testSearchAttendeeDisabled():void {
+		$this->manager->expects(self::once())
+			->method('isEnabled')
+			->willReturn(false);
+
+		$this->manager->expects(self::never())
+			->method('search');
+
+		$response = $this->controller->searchAttendee('search 123');
+
+		$this->assertInstanceOf(JSONResponse::class, $response);
+		$this->assertEquals([], $response->getData());
+		$this->assertEquals(200, $response->getStatus());
+	}
+
+	public function testSearchAttendee():void {
+		$user1 = [
+			'FN' => 'Person 1',
+			'ADR' => [
+				'33 42nd Street;Random Town;Some State;;United States',
+				';;5 Random Ave;12782 Some big city;Yet another state;United States',
+			],
+			'EMAIL' => [
+				'foo1@example.com',
+				'foo2@example.com',
+			],
+			'LANG' => [
+				'de',
+				'en'
+			],
+			'TZ' => [
+				'Europe/Berlin',
+				'UTC'
+			],
+			'PHOTO' => 'VALUE=uri:http://foo.bar'
+		];
+		$user2 = [
+			'FN' => 'Person 2',
+			'EMAIL' => 'foo3@example.com',
+		];
+		$user3 = [
+			'ADR' => [
+				'ABC Street 2;01337 Village;;Germany',
+			],
+			'LANG' => 'en_us',
+			'TZ' => 'Australia/Adelaide',
+			'PHOTO' => 'VALUE:BINARY:4242424242'
+		];
+		$user4 = [
+			'isLocalSystemBook' => true,
+			'FN' => 'Person 3',
+			'ADR' => [
+				'ABC Street 2;01337 Village;;Germany',
+			],
+			'LANG' => 'en_us',
+			'TZ' => 'Australia/Adelaide',
+			'PHOTO' => 'VALUE:BINARY:4242424242',
+			'CATEGORIES' => 'search 123'
+		];
+
+		$this->manager->expects(self::once())
+			->method('isEnabled')
+			->willReturn(true);
+		$this->service
+			->method('hasEmail')
+			->willReturnMap([
+				[$user1, true],
+				[$user2, true],
+				[$user3, false],
+				[$user4, true],
+			]);
+		$this->service
+			->method('isSystemBook')
+			->willReturnMap([
+				[$user1, false],
+				[$user2, false],
+				[$user3, false],
+				[$user4, true],
+			]);
+		$this->service
+			->method('getNameFromContact')
+			->willReturnMap([
+				[$user1, 'Person 1'],
+				[$user2, 'Person 2'],
+				[$user3, ''],
+			]);
+		$this->service->expects(self::exactly(2))
+			->method('getLanguageId')
+			->willReturnMap([
+				[$user1, 'de'],
+				[$user3, 'en_us'],
+			]);
+		$this->service->expects(self::exactly(2))
+			->method('getTimezoneId')
+			->willReturnMap([
+				[$user1, 'Europe/Berlin'],
+				[$user3, 'Australia/Adelaide'],
+			]);
+		$this->service->expects(self::exactly(2))
+			->method('getEmail')
+			->willReturnMap([
+				[$user1, [
+					'foo1@example.com',
+					'foo2@example.com',
+				]
+				],
+				[$user2, ['foo3@example.com']],
+				[$user3, ['foo5@example.com']],
+			]);
+		$this->service->method('getPhotoUri')
+			->willReturnMap([
+				[$user1, 'http://foo.bar'],
+				[$user2, null],
+				[$user3, null],
+				[$user4, null],
+			]);
+		$this->manager->expects(self::exactly(2))
+			->method('search')
+			->willReturnMap([
+				['search 123', ['FN', 'EMAIL'], [], [$user1, $user2, $user3, $user4]],
+				['search 123', ['CATEGORIES'], [], [$user4]]
 			]);
 
 		$response = $this->controller->searchAttendee('search 123');
@@ -228,6 +408,7 @@ class ContactControllerTest extends TestCase {
 				'lang' => 'de',
 				'tzid' => 'Europe/Berlin',
 				'photo' => 'http://foo.bar',
+				'type' => 'individual'
 			], [
 				'name' => 'Person 2',
 				'emails' => [
@@ -236,80 +417,102 @@ class ContactControllerTest extends TestCase {
 				'lang' => null,
 				'tzid' => null,
 				'photo' => null,
+				'type' => 'individual'
 			]
 		], $response->getData());
 		$this->assertEquals(200, $response->getStatus());
 	}
 
 	public function testSearchPhotoDisabled():void {
-		$this->manager->expects($this->once())
+		$this->manager->expects(self::once())
 			->method('isEnabled')
-			->with()
 			->willReturn(false);
 
-		$this->manager->expects($this->never())
+		$this->manager->expects(self::never())
 			->method('search');
 
 		$response = $this->controller->searchAttendee('search 123');
 
-		$this->assertInstanceOf(JSONResponse::class, $response);
 		$this->assertEquals([], $response->getData());
 		$this->assertEquals(200, $response->getStatus());
 	}
 
 	public function testSearchPhoto():void {
+		$user1 = [
+			'FN' => 'Person 1',
+			'ADR' => [
+				'33 42nd Street;Random Town;Some State;;United States',
+				';;5 Random Ave;12782 Some big city;Yet another state;United States',
+			],
+			'EMAIL' => [
+				'foo1@example.com',
+				'foo2@example.com',
+			],
+			'LANG' => [
+				'de',
+				'en'
+			],
+			'TZ' => [
+				'Europe/Berlin',
+				'UTC'
+			],
+			'PHOTO' => 'VALUE=uri:http://foo123.bar'
+		];
+		$user2 = [
+			'FN' => 'Person 2',
+			'EMAIL' => 'foo3@example.com',
+			'PHOTO' => 'VALUE=uri:http://foo.bar'
+		];
+		$user3 = [
+			'ADR' => [
+				'ABC Street 2;01337 Village;;Germany',
+			],
+			'LANG' => 'en_us',
+			'TZ' => 'Australia/Adelaide',
+			'PHOTO' => 'VALUE:BINARY:4242424242'
+		];
+		$user4 = [
+			'isLocalSystemBook' => true,
+			'FN' => 'Person 3',
+			'ADR' => [
+				'ABC Street 2;01337 Village;;Germany',
+			],
+			'EMAIL' => 'foo5@example.com',
+			'LANG' => 'en_us',
+			'TZ' => 'Australia/Adelaide',
+			'PHOTO' => 'VALUE=uri:http://foo456.bar'
+		];
+
 		$this->manager->expects(self::once())
 			->method('isEnabled')
-			->with()
 			->willReturn(true);
-
+		$this->service->method('hasEmail')->willReturnMap([
+			[$user1, true],
+			[$user2, true],
+			[$user3, false],
+			[$user3, true],
+		]);
+		$this->service->method('isSystemBook');
+		$this->service->method('getEmail')
+			->willReturnMap([
+				[$user1, [
+					'foo1@example.com',
+					'foo2@example.com',
+				]
+				],
+				[$user2, ['foo3@example.com']],
+				[$user3, ['foo5@example.com']],
+			]);
+		$this->service->method('getNameFromContact')->willReturn('Person 2');
+		$this->service->method('getPhotoUri')->willReturn('http://foo.bar');
 		$this->manager->expects(self::once())
 			->method('search')
 			->with('foo3@example.com', ['EMAIL'])
 			->willReturn([
-				[
-					'FN' => 'Person 1',
-					'ADR' => [
-						'33 42nd Street;Random Town;Some State;;United States',
-						';;5 Random Ave;12782 Some big city;Yet another state;United States',
-					],
-					'EMAIL' => [
-						'foo1@example.com',
-						'foo2@example.com',
-					],
-					'LANG' => [
-						'de',
-						'en'
-					],
-					'TZ' => [
-						'Europe/Berlin',
-						'UTC'
-					],
-					'PHOTO' => 'VALUE=uri:http://foo123.bar'
-				],
-				[
-					'FN' => 'Person 2',
-					'EMAIL' => 'foo3@example.com',
-					'PHOTO' => 'VALUE=uri:http://foo.bar'
-				],
-				[
-					'ADR' => [
-						'ABC Street 2;01337 Village;;Germany',
-					],
-					'LANG' => 'en_us',
-					'TZ' => 'Australia/Adelaide',
-					'PHOTO' => 'VALUE:BINARY:4242424242'
-				],
-				[
-					'isLocalSystemBook' => true,
-					'FN' => 'Person 3',
-					'ADR' => [
-						'ABC Street 2;01337 Village;;Germany',
-					],
-					'LANG' => 'en_us',
-					'TZ' => 'Australia/Adelaide',
-					'PHOTO' => 'VALUE=uri:http://foo456.bar'
-				],
+				$user1,
+				$user2,
+				$user3,
+				$user4,
 			]);
 
 		$response = $this->controller->searchPhoto('foo3@example.com');

--- a/tests/php/unit/Service/ContactsServiceTest.php
+++ b/tests/php/unit/Service/ContactsServiceTest.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2014 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+namespace OCA\Calendar\Service;
+
+use ChristophWurst\Nextcloud\Testing\TestCase;
+
+class ContactsServiceTest extends TestCase {
+	private ContactsService $service;
+
+	public function setUp(): void {
+		$this->service = new ContactsService();
+	}
+
+	public function testGetEmail(): void {
+		$contact = ['EMAIL' => 'test@test.com'];
+		$this->assertEquals(['test@test.com'], $this->service->getEmail($contact));
+	}
+
+	public function testIsSystemBook(): void {
+		$contact = ['isLocalSystemBook' => true];
+		$this->assertTrue($this->service->isSystemBook($contact));
+	}
+
+	public function testIsNotSystemBook(): void {
+		$contact = ['isLocalSystemBook' => false];
+		$this->assertFalse($this->service->isSystemBook($contact));
+	}
+
+	public function testNotSetSystemBook(): void {
+		$this->assertFalse($this->service->isSystemBook([]));
+	}
+
+	public function testHasEmail(): void {
+		$contact = ['EMAIL' => 'test@test.com'];
+		$this->assertTrue($this->service->hasEmail($contact));
+	}
+
+	public function testHasNoEmail(): void {
+		$this->assertFalse($this->service->hasEmail([]));
+	}
+
+	public function testGetPhotoUri(): void {
+		$contact = ['PHOTO' => 'VALUE=uri:http://test'];
+		$this->assertEquals('http://test', $this->service->getPhotoUri($contact));
+	}
+
+	public function testGetPhotoInvalidUri(): void {
+		$contact = ['PHOTO' => 'VALUE=uri:thisisnotit'];
+		$this->assertNull($this->service->getPhotoUri($contact));
+	}
+
+	public function testGetPhotoUriNoPhoto(): void {
+		$this->assertNull($this->service->getPhotoUri([]));
+	}
+
+	public function testFilterGroupsWithCount(): void {
+		$contact = [
+			['CATEGORIES' => 'The Proclaimers,I\'m gonna be,When I go out,I would walk 500 Miles,I would walk 500 more'],
+			['CATEGORIES' => 'The Proclaimers,When I\'m lonely,I would walk 500 Miles,I would walk 500 more'],
+		];
+
+		$searchterm = 'walk';
+
+		$expected = [
+			'I would walk 500 Miles' => 2,
+			'I would walk 500 more' => 2,
+		];
+
+		$this->assertEqualsCanonicalizing($expected, $this->service->filterGroupsWithCount($contact, $searchterm));
+	}
+
+	public function testGetTimezoneId(): void {
+		$contact = ['TZ' => ['UTC']];
+		$this->assertEquals('UTC', $this->service->getTimezoneId($contact));
+	}
+
+	public function testGetLanguageId(): void {
+		$contact = ['LANG' => ['de_de']];
+		$this->assertEquals('de_de', $this->service->getLanguageId($contact));
+	}
+
+	public function testGetNameFromContact(): void {
+		$contact = ['FN' => 'test'];
+		$this->assertEquals('test', $this->service->getNameFromContact($contact));
+	}
+	
+	public function testGetNameFromContactNoName(): void {
+		$this->assertEquals('', $this->service->getNameFromContact([]));
+	}
+}


### PR DESCRIPTION
Fixes https://github.com/nextcloud/calendar/issues/167

To Do

- [x] Duplicate Members - create a single attendee and add the duplicate group ids to the `MEMEBR` property
- [ ] Does it actually send invitation emails
- [x] ~~use `nc:groupname@group` instead of `mailto:` prefix?~~ doesn't work