### PR TITLE
CalendarObjectInstance: reset attendee participation status on duplication of an event

### DIFF
--- a/src/models/event.js
+++ b/src/models/event.js
@@ -178,8 +178,9 @@ const mapEventComponentToEventObject = (eventComponent) => {
  *
  * @param {object} eventObject The calendar-object-instance object
  * @param {EventComponent} eventComponent The calendar-js EventComponent object
+ * @param {boolean} resetAttendeeStatus Whether or not to reset the attendee status
  */
-const copyCalendarObjectInstanceIntoEventComponent = (eventObject, eventComponent) => {
+const copyCalendarObjectInstanceIntoEventComponent = (eventObject, eventComponent, resetAttendeeStatus = false) => {
 	eventComponent.title = eventObject.title
 	eventComponent.location = eventObject.location
 	eventComponent.description = eventObject.description
@@ -206,6 +207,11 @@ const copyCalendarObjectInstanceIntoEventComponent = (eventObject, eventComponen
 	}
 
 	for (const attendee of eventObject.attendees) {
+		if (resetAttendeeStatus) {
+			attendee.attendeeProperty.participationStatus = 'NEEDS-ACTION'
+			attendee.attendeeProperty.rsvp = true
+		}
+
 		eventComponent.addProperty(attendee.attendeeProperty)
 	}
 

--- a/src/store/calendarObjectInstance.js
+++ b/src/store/calendarObjectInstance.js
@@ -1478,7 +1478,7 @@ export default defineStore('calendarObjectInstance', {
 				isAllDay: oldEventComponent.isAllDay(),
 			})
 			const eventComponent = getObjectAtRecurrenceId(calendarObject, startDate.jsDate)
-			copyCalendarObjectInstanceIntoEventComponent(oldCalendarObjectInstance, eventComponent)
+			copyCalendarObjectInstanceIntoEventComponent(oldCalendarObjectInstance, eventComponent, true)
 			const calendarObjectInstance = mapEventComponentToEventObject(eventComponent)
 
 			await this.setCalendarObjectInstanceForNewEvent({


### PR DESCRIPTION
Fix https://github.com/nextcloud/calendar/issues/5793

That `eventComponent` is black magic...