### PR TITLE
fix(attachmentService, propfindErrorParse): add an error message for when a file is not compatible for windows

### DIFF
--- a/src/services/attachmentService.js
+++ b/src/services/attachmentService.js
@@ -8,6 +8,7 @@ import { generateOcsUrl, generateRemoteUrl } from '@nextcloud/router'
 import { showError, showSuccess } from '@nextcloud/dialogs'
 import { translate as t } from '@nextcloud/l10n'
 import { parseXML } from 'webdav'
+import { parseUploadError } from '../utils/propfindErrorParse.js'
 
 /**
  * Makes a share link for a given file or directory.
@@ -136,10 +137,17 @@ const uploadLocalAttachment = async function(folder, files, dav, componentAttach
 					}))
 					attachments.push(data)
 				}
-			}).catch(() => {
-				showError(t('calendar', 'An error occurred during uploading file {fileName}', {
-					fileName: file.name,
-				}))
+			}).catch(async (exception) => {
+				if (exception.response) {
+					const message = await parseUploadError(exception)
+					if (message) {
+						showError(message)
+					} else {
+						showError(t('calendar', 'An error occurred during uploading file {fileName}', {
+							fileName: file.name,
+						}))
+					}
+				}
 			})
 			promises.push(res)
 		}

--- a/src/utils/propfindErrorParse.js
+++ b/src/utils/propfindErrorParse.js
@@ -1,0 +1,28 @@
+/**
+ * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { t } from '@nextcloud/l10n'
+
+/**
+ * Parse PROPFIND error when uploading a file and return a readable message.
+ *
+ * @param exception the error object
+ */
+async function parseUploadError(exception) {
+	try {
+		const responseText = await exception.response.data
+		const parser = new DOMParser()
+		const xmlDoc = parser.parseFromString(responseText, 'application/xml')
+		const messageElement = xmlDoc.getElementsByTagName('s:message')[0]
+
+		return messageElement?.textContent
+	} catch (parseError) {
+		console.error(t('spreed', 'Error while parsing a PROPFIND error'), parseError)
+	}
+}
+
+export {
+	parseUploadError,
+}


### PR DESCRIPTION
Fix https://github.com/nextcloud/calendar/issues/6245

Mostly copied from https://github.com/nextcloud/spreed/blob/main/src/utils/propfindErrorParse.ts