### PR TITLE
feat: disable autocompletion for event property field

### DIFF
--- a/src/components/Editor/Properties/PropertyTitle.vue
+++ b/src/components/Editor/Properties/PropertyTitle.vue
@@ -10,6 +10,7 @@
 			<input v-if="!isReadOnly"
 				v-focus
 				type="text"
+				autocomplete="off"
 				:placeholder="t('calendar', 'Event title')"
 				:value="value"
 				@input.prevent.stop="changeValue">


### PR DESCRIPTION
Motivation:

I just added 8 events to my calendar, and my password manager asked me to unlock the vault for the auto suggestions for every event title. The password manager should do better, but autocompletion for the field seems to have little use and Google Calendar also uses autocomplete off for the event title.