### PR TITLE
"Appointment schedule" notion instead of only "Appointments" for a better UX

### DIFF
--- a/src/components/AppNavigation/AppointmentConfigList.vue
+++ b/src/components/AppNavigation/AppointmentConfigList.vue
@@ -11,7 +11,7 @@
 	<div v-if="hasAtLeastOneCalendar"
 		class="appointment-config-list">
 		<AppNavigationCaption class="appointment-config-list__caption"
-			:name="t('calendar', 'Appointments')">
+			:name="t('calendar', 'Appointment schedules')">
 			<template v-if="hasUserEmailAddress"
 				#actions>
 				<ActionButton :close-after-click="true"
@@ -19,7 +19,7 @@
 					<template #icon>
 						<PlusIcon :size="20" decorative />
 					</template>
-					{{ t('calendar', 'Add new') }}
+					{{ t('calendar', 'Create new') }}
 				</ActionButton>
 			</template>
 		</AppNavigationCaption>

--- a/src/components/AppointmentConfigModal.vue
+++ b/src/components/AppointmentConfigModal.vue
@@ -199,10 +199,10 @@ export default {
 		...mapStores(useAppointmentConfigsStore, useCalendarsStore, useSettingsStore),
 		formTitle() {
 			if (this.isNew) {
-				return this.$t('calendar', 'Create appointment')
+				return this.$t('calendar', 'Create appointment schedule')
 			}
 
-			return this.$t('calendar', 'Edit appointment')
+			return this.$t('calendar', 'Edit appointment schedule')
 		},
 		saveButtonText() {
 			if (this.isNew) {

--- a/src/components/AppointmentConfigModal/Confirmation.vue
+++ b/src/components/AppointmentConfigModal/Confirmation.vue
@@ -49,10 +49,10 @@ export default {
 	computed: {
 		title() {
 			if (this.isNew) {
-				return this.$t('calendar', 'Appointment was created successfully')
+				return this.$t('calendar', 'Appointment schedule successfully created')
 			}
 
-			return this.$t('calendar', 'Appointment was updated successfully')
+			return this.$t('calendar', 'Appointment schedule successfully updated')
 		},
 		showCopyLinkButton() {
 			return navigator && navigator.clipboard


### PR DESCRIPTION
"Appointment" notion is no clear and creates confusion because this feature don't directly create an appointment but create an "appointment request form". I propose a new notion : "Appointment request form".
I made some wording change test with my browser dev tools. Please check below (real tests from reviewers are welcome) : 

![Capture d’écran du 2024-09-25 11-40-30](https://github.com/user-attachments/assets/8c166ed5-c4b5-4111-b9ea-0615f79a73bf)
![Capture d’écran du 2024-09-25 11-41-37](https://github.com/user-attachments/assets/b5026ef6-80ce-4370-8139-3220f896f900)
![Capture d’écran du 2024-09-25 11-48-00](https://github.com/user-attachments/assets/b576a3f4-4a87-466a-b4ef-568a47e3cfb9)
![Capture d’écran du 2024-09-25 11-51-43](https://github.com/user-attachments/assets/474f56a5-227c-4192-8713-bc9a8482a59d)
![Capture d’écran du 2024-09-25 11-52-29](https://github.com/user-attachments/assets/37ad60f6-9e5b-4010-9954-30f382b6b565)