### PR TITLE
fix(attachments): add missing file picker confirm

### DIFF
--- a/src/components/Editor/Attachments/AttachmentsList.vue
+++ b/src/components/Editor/Attachments/AttachmentsList.vue
@@ -154,7 +154,14 @@ export default {
 			})
 		},
 		async openFilesModal() {
-			const picker = getFilePickerBuilder(t('calendar', 'Choose a file to add as attachment')).setMultiSelect(false).build()
+			const picker = getFilePickerBuilder(t('calendar', 'Choose a file to add as attachment'))
+				.setMultiSelect(false)
+				.addButton({
+					label: t('calendar', 'Pick'),
+					type: 'primary',
+					callback: (nodes) => logger.debug('Picked attachment', { nodes }),
+				})
+				.build()
 			try {
 				const filename = await picker.pick(t('calendar', 'Choose a file to share as a link'))
 				if (!this.isDuplicateAttachment(filename)) {


### PR DESCRIPTION
Nextcloud 29 (stable4.7) and below are not affected.

![grafik](https://github.com/user-attachments/assets/73a4d915-18ff-4c9c-abee-e7a9e20df1c5)