### PR TITLE
ci: Enforce conventional commits

### DIFF
--- a/.github/workflows/conventional_commits.yml
+++ b/.github/workflows/conventional_commits.yml
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
+# SPDX-License-Identifier: MIT
+name: Conventional Commits
+
+on:
+  pull_request:
+    types: [opened, ready_for_review, reopened, synchronize]
+    branches:
+      - stable*
+
+jobs:
+  build:
+    name: Conventional Commits
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
+      - uses: webiny/action-conventional-commits@8bc41ff4e7d423d56fa4905f6ff79209a78776c7 # v1.3.0

--- a/README.md
+++ b/README.md
@@ -84,3 +84,5 @@ If you contribute, participate or interact with this community, please respect [
 
 This guide will help you get started: 
 - :dancer: :smile: [Opening a pull request](https://opensource.guide/how-to-contribute/#opening-a-pull-request) 
+
+Commits in this repository follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary).


### PR DESCRIPTION
stable5.0 is clean for https://github.com/nextcloud/calendar/pull/6507 but we should try to enforce the commit style in this repo too.