### PR TITLE
[stable5.0] docs: Update app maintainers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+# App maintainers
+* @SebastianKrupinski @st3iny @tcitworld

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -22,8 +22,9 @@
 	]]></description>
 	<version>5.0.1</version>
 	<licence>agpl</licence>
-	<author>Anna Larch</author>
-	<author homepage="https://github.com/nextcloud/groupware">Nextcloud Groupware Team</author>
+	<author homepage="https://github.com/st3iny">Richard Steinmetz</author>
+	<author homepage="https://github.com/SebastianKrupinski">Sebastian Krupinski </author>
+	<author homepage="https://github.com/tcitworld">Thomas Citharel</author>
 	<namespace>Calendar</namespace>
 	<documentation>
 		<user>https://docs.nextcloud.com/server/latest/user_manual/en/groupware/calendar.html</user>


### PR DESCRIPTION
Backport of https://github.com/nextcloud/calendar/pull/