### PR TITLE
[stable5.0] fix(release): Specify committer for automated releases

### DIFF
--- a/.github/workflows/appstore-conventional-build-publish.yml
+++ b/.github/workflows/appstore-conventional-build-publish.yml
@@ -37,6 +37,8 @@ jobs:
         uses: TriPSs/conventional-changelog-action@v3
         with:
           github-token: ${{ secrets.RELEASE_PAT }}
+          git-user-email: nextcloud-command@users.noreply.github.com
+          git-user-name: Nextcloud Command Bot
           skip-git-pull: "true"
           pre-commit: build/pre-commit.js
           release-count: 0


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/6375ea64-7c37-4448-a4b1-fc8f44736918)

^ looks suspicious, but it was me through the automation. By specifying our command bot as committer I hope to make it more transparent that releases are legit, but automated.