### PR TITLE
feat(editor): improve attendee and resource status display

### DIFF
--- a/src/components/Editor/Invitees/InviteesList.vue
+++ b/src/components/Editor/Invitees/InviteesList.vue
@@ -20,6 +20,7 @@
 			:is-shared-with-me="isSharedWithMe"
 			:organizer="calendarObjectInstance.organizer"
 			:organizer-selection="organizerSelection"
+			:is-viewed-by-organizer="isViewedByOrganizer"
 			@change-organizer="changeOrganizer" />
 		<InviteesListItem v-for="invitee in limitedInviteesWithoutOrganizer"
 			:key="invitee.email"
@@ -27,6 +28,7 @@
 			:is-read-only="isReadOnly"
 			:organizer-display-name="organizerDisplayName"
 			:members="invitee.members"
+			:is-viewed-by-organizer="isViewedByOrganizer"
 			@remove-attendee="removeAttendee" />
 		<div v-if="limit > 0 && inviteesWithoutOrganizer.length > limit"
 			class="invitees-list__more">
@@ -286,6 +288,10 @@ export default {
 			}
 
 			return false
+		},
+		isViewedByOrganizer() {
+			const organizerEmail = removeMailtoPrefix(this.calendarObjectInstance.organizer.uri)
+			return organizerEmail === this.principalsStore.getCurrentUserPrincipalEmail
 		},
 		statusHeader() {
 			if (!this.isReadOnly) {

--- a/src/components/Editor/Invitees/InviteesListItem.vue
+++ b/src/components/Editor/Invitees/InviteesListItem.vue
@@ -10,6 +10,7 @@
 			:is-resource="false"
 			:avatar-link="avatarLink"
 			:participation-status="attendee.participationStatus"
+			:schedule-status="attendee.attendeeProperty.getParameterFirstValue('SCHEDULE-STATUS')"
 			:organizer-display-name="organizerDisplayName"
 			:common-name="commonName"
 			:is-group="isGroup" />
@@ -136,6 +137,10 @@ export default {
 			default: () => [],
 			required: false,
 		},
+		isViewedByOrganizer: {
+			type: Boolean,
+			default: false,
+		},
 	},
 	data() {
 		return {
@@ -190,10 +195,6 @@ export default {
 		},
 		isNonParticipant() {
 			return this.attendee.role === 'NON-PARTICIPANT'
-		},
-		isViewedByOrganizer() {
-			// TODO: check if also viewed by organizer
-			return !this.isReadOnly
 		},
 		isGroup() {
 			return this.attendee.attendeeProperty.userType === 'GROUP'

--- a/src/components/Editor/Invitees/OrganizerListItem.vue
+++ b/src/components/Editor/Invitees/OrganizerListItem.vue
@@ -11,6 +11,7 @@
 			:is-resource="isResource"
 			:common-name="commonName"
 			:organizer-display-name="commonName"
+			:schedule-status="organizer.attendeeProperty.getParameterFirstValue('SCHEDULE-STATUS')"
 			participation-status="ACCEPTED" />
 		<div class="invitees-list-item__displayname">
 			{{ commonName }}
@@ -77,6 +78,10 @@ export default {
 			type: Boolean,
 			required: true,
 		},
+		isViewedByOrganizer: {
+			type: Boolean,
+			default: false,
+		},
 	},
 	computed: {
 		/**
@@ -100,9 +105,6 @@ export default {
 			}
 
 			return ''
-		},
-		isViewedByOrganizer() {
-			return true
 		},
 		isResource() {
 			// The organizer does not have a tooltip

--- a/src/components/Editor/Resources/ResourceList.vue
+++ b/src/components/Editor/Resources/ResourceList.vue
@@ -15,6 +15,7 @@
 			:resource="resource"
 			:is-read-only="isReadOnly"
 			:organizer-display-name="organizerDisplayName"
+			:is-viewed-by-organizer="isViewedByOrganizer"
 			@remove-resource="removeResource" />
 
 		<NoAttendeesView v-if="isListEmpty && hasUserEmailAddress"
@@ -34,6 +35,7 @@
 			:is-read-only="false"
 			:organizer-display-name="organizerDisplayName"
 			:is-suggestion="true"
+			:is-viewed-by-organizer="isViewedByOrganizer"
 			@add-suggestion="addResource" />
 	</div>
 </template>
@@ -104,6 +106,10 @@ export default {
 		hasUserEmailAddress() {
 			const emailAddress = this.principalsStore.getCurrentUserPrincipal?.emailAddress
 			return !!emailAddress
+		},
+		isViewedByOrganizer() {
+			const organizerEmail = removeMailtoPrefix(this.calendarObjectInstance.organizer.uri)
+			return organizerEmail === this.principalsStore.getCurrentUserPrincipalEmail
 		},
 	},
 	watch: {

--- a/src/components/Editor/Resources/ResourceListItem.vue
+++ b/src/components/Editor/Resources/ResourceListItem.vue
@@ -11,6 +11,7 @@
 			:is-suggestion="isSuggestion"
 			:avatar-link="commonName"
 			:participation-status="participationStatus"
+			:schedule-status="resource.attendeeProperty.getParameterFirstValue('SCHEDULE-STATUS')"
 			:organizer-display-name="organizerDisplayName"
 			:common-name="commonName" />
 		<div class="resource-list-item__displayname">
@@ -92,6 +93,10 @@ export default {
 			type: Boolean,
 			default: false,
 		},
+		isViewedByOrganizer: {
+			type: Boolean,
+			default: false,
+		},
 	},
 	data() {
 		return {
@@ -109,10 +114,6 @@ export default {
 			}
 
 			return this.resource.uri
-		},
-		isViewedByOrganizer() {
-			// TODO: check if also viewed by organizer
-			return !this.isReadOnly
 		},
 		isAccessible() {
 			return this.hasFeature('WHEELCHAIR-ACCESSIBLE')


### PR DESCRIPTION
Resolves https://github.com/nextcloud/calendar/issues/4983

I refactored the logic and moved it to a computed prop to facilitate making use of the schedule status as well.

I also implemented some custom status messages if the scheduling fails for some reason (statuses `3.x` and `5.x`).

## Screenshots

### Organizer's view

| Invitees | Resources |
| --- | --- |
| ![image](https://github.com/user-attachments/assets/588690b6-a578-4585-91a0-99a8110ee271) | ![spectacle_20241124_205940](https://github.com/user-attachments/assets/e5ddf31c-1be6-499f-92c0-27927772ab2c) |

(In the example above, the user `test` was just added and the event was not saved yet. The same applies to the resource `Croc`.)

### Attendee's view

![image](https://github.com/user-attachments/assets/519fcf98-eb33-43a5-8bcf-fb9f6d61e353)