### PR TITLE
Remove 500ms focus delay from PropertyTitle

### DIFF
--- a/src/directives/focus.js
+++ b/src/directives/focus.js
@@ -5,8 +5,6 @@
 
 export default {
 	inserted(el) {
-		setTimeout(() => {
-			el.focus()
-		}, 500)
+		el.focus()
 	},
 }


### PR DESCRIPTION
02a2914 was a great commit but 3 years later I am unsure why the arbitrary 500ms delay is necessary. I want to remove it.

Use case: I have a userscript that enables Google Calendar keybindings (eg. e to edit) and this delay significantly impedes my workflow (when editing the name of an event). The entire name-editing process should take 500ms total, but with the current configuration the user must wait *at least* 500ms for the input to focus.

I tested the removal of the delay via devtools resource override on Edge and the focus still works consistently. I hope this minor change can make the event name editing pipeline more performant for everyone.