### PR TITLE
fix: send date as string instead of epoch

### DIFF
--- a/lib/Controller/BookingController.php
+++ b/lib/Controller/BookingController.php
@@ -8,7 +8,6 @@ declare(strict_types=1);
 namespace OCA\Calendar\Controller;
 
 use DateTime;
-use DateTimeImmutable;
 use DateTimeZone;
 use InvalidArgumentException;
 use OCA\Calendar\AppInfo\Application;
@@ -87,23 +86,21 @@ class BookingController extends Controller {
 	 *
 	 * @return JsonResponse
 	 */
-	public function getBookableSlots(int $appointmentConfigId,
-		int $startTime,
-		string $timeZone): JsonResponse {
+	public function getBookableSlots(
+		int $appointmentConfigId,
+		string $dateSelected,
+		string $timeZone,
+	): JsonResponse {
 		try {
 			$tz = new DateTimeZone($timeZone);
 		} catch (Exception $e) {
 			$this->logger->error('Timezone invalid', ['exception' => $e]);
 			return JsonResponse::fail('Invalid time zone', Http::STATUS_UNPROCESSABLE_ENTITY);
 		}
-		// UI sends epoch start of day adjusted for system users calendar
-		// E.g "Mon, 18 Nov 2024 05:00:00 +0000" (America/Toronto)
-		$startDate = (new DateTimeImmutable("@$startTime"));
-		// Convert start date to requesters selected timezone adjusted start and end of day in epoch
-		// E.g "Mon, 18 Nov 2024 06:00:00 +0000" (America/Mexico_City)
-		$startTimeInTz = (new DateTime($startDate->format('Y-m-d'), $tz))
+		// Convert selected date to requesters selected timezone adjusted start and end of day in epoch
+		$startTimeInTz = (new DateTime($dateSelected, $tz))
 			->getTimestamp();
-		$endTimeInTz = (new DateTime($startDate->format('Y-m-d'), $tz))
+		$endTimeInTz = (new DateTime($dateSelected, $tz))
 			->modify('+1 day')
 			->getTimestamp();
 

--- a/src/services/appointmentService.js
+++ b/src/services/appointmentService.js
@@ -8,13 +8,13 @@ import { generateUrl } from '@nextcloud/router'
 
 /**
  * @param config {object} the appointment config object
- * @param start {Number} interval start time as unix timestamp
+ * @param date {string} selected availability date in yyyy-m-d format
  * @param timeZone {String} target time zone for the time stamps
  */
-export async function findSlots(config, start, timeZone) {
-	const url = generateUrl('/apps/calendar/appointment/{id}/slots?startTime={start}&timeZone={timeZone}', {
+export async function findSlots(config, date, timeZone) {
+	const url = generateUrl('/apps/calendar/appointment/{id}/slots?dateSelected={date}&timeZone={timeZone}', {
 		id: config.id,
-		start,
+		date,
 		timeZone,
 	})
 

--- a/src/views/Appointments/Booking.vue
+++ b/src/views/Appointments/Booking.vue
@@ -195,12 +195,14 @@ export default {
 			this.slots = []
 			this.loadingSlots = true
 
-			const startOfDay = new Date(this.selectedDate.getTime())
+			const selectedDay = this.selectedDate.getFullYear().toString() + '-'
+								+ (this.selectedDate.getMonth() + 1).toString() + '-'
+								+ this.selectedDate.getDate().toString()
 
 			try {
 				this.slots = await findSlots(
 					this.config,
-					Math.round(startOfDay.getTime() / 1000),
+					selectedDay,
 					this.timeZone,
 				)
 			} catch (e) {


### PR DESCRIPTION
Resolves: https://github.com/nextcloud/calendar/issues/6528

Testing Recommendation
1. Test with existing appointment schedule and fresh appointment schedule (make sure when creating a new appointment schedule the browser time zone matches the calendar time zone, as there is another bug that will affect this)
2. Test by selecting different time zones negative (North America/South America), positive (Australia/China/Etc) and matching the appointment schedule
3. Test by changing browser time zone (either override browser setting or change system time zone). You can check your browser time zone here: https://webbrowsertools.com/timezone/
4. Test by selecting time zones with an offset greater than the current time. (if the current time is 10.00 select zone that has offset of +11 hours, if the time is 14.00 select timezone that is -11 hours, this would in the past roll the date back one day)
5. Test by selecting dates close to year end and start
6. Compare all slot times to a external source I recommend https://www.worldtimebuddy.com/ or https://www.timeanddate.com/worldclock/converter.html you can preset all testing time zones and compare the times