### PR TITLE
Event attachments: Enable directory selection

### DIFF
--- a/src/components/Editor/Attachments/AttachmentsList.vue
+++ b/src/components/Editor/Attachments/AttachmentsList.vue
@@ -220,7 +220,9 @@ export default {
 			if (attachment.xNcHasPreview) {
 				return generateUrl(`/core/preview?fileId=${attachment.xNcFileId}&x=100&y=100&a=0`)
 			}
-			return attachment.formatType ? OC.MimeType.getIconUrl(attachment.formatType) : null
+			return attachment.formatType
+				? OC.MimeType.getIconUrl(attachment.formatType)
+				: OC.MimeType.getIconUrl('folder')
 		},
 		getBaseName(name) {
 			return name.split('/').pop()

--- a/src/components/Editor/Attachments/AttachmentsList.vue
+++ b/src/components/Editor/Attachments/AttachmentsList.vue
@@ -156,6 +156,7 @@ export default {
 		async openFilesModal() {
 			const picker = getFilePickerBuilder(t('calendar', 'Choose a file to add as attachment'))
 				.setMultiSelect(false)
+				.allowDirectories(true)
 				.addButton({
 					label: t('calendar', 'Pick'),
 					type: 'primary',

--- a/src/store/calendarObjectInstance.js
+++ b/src/store/calendarObjectInstance.js
@@ -1513,7 +1513,7 @@ export default defineStore('calendarObjectInstance', {
 		 * @param {object} data The destructuring object for data
 		 * @param {object} data.calendarObjectInstance The calendarObjectInstance object
 		 * @param {Date} data.startDate The new start-date
-		 * @param {boolean} onlyTime Only update time
+		 * @param {boolean} data.onlyTime Only update time
 		 */
 		changeStartDate({
 			calendarObjectInstance,
@@ -1570,7 +1570,7 @@ export default defineStore('calendarObjectInstance', {
 		 * @param {object} data The destructuring object for data
 		 * @param {object} data.calendarObjectInstance The calendarObjectInstance object
 		 * @param {Date} data.endDate The new end-date
-		 * @param {boolean} onlyTime Only update time
+		 * @param {boolean} data.onlyTime Only update time
 		 */
 		changeEndDate({
 			calendarObjectInstance,

--- a/src/views/EditSidebar.vue
+++ b/src/views/EditSidebar.vue
@@ -516,7 +516,9 @@ export default {
 			if (attachment.xNcHasPreview) {
 				return generateUrl(`/core/preview?fileId=${attachment.xNcFileId}&x=100&y=100&a=0`)
 			}
-			return attachment.formatType ? OC.MimeType.getIconUrl(attachment.formatType) : null
+			return attachment.formatType
+				? OC.MimeType.getIconUrl(attachment.formatType)
+				: OC.MimeType.getIconUrl('folder')
 		},
 		acceptAttachmentsModal() {
 			if (!this.doNotShare) {


### PR DESCRIPTION
**Summary:**

It’s possible to attach files to an event. An internal or public share link is stored within the event.

On the main branch, adding a folder currently doesn’t work (while selection is possible, the folder isn’t actually added). It’s unclear to me from the initial implementation https://github.com/nextcloud/calendar/pull/4251 whether folder support was intended or not.

Folders typically don’t have a content type returned, so I added a fallback to display the folder icon.

| B | A |
|--------|--------|
| ![Screenshot From 2024-11-29 15-57-02](https://github.com/user-attachments/assets/2b233bb3-cb32-4794-946e-28517d384f6c) | ![Screenshot From 2024-11-29 15-39-05](https://github.com/user-attachments/assets/16db6acf-6d88-47fe-8949-0a4068580f95) | 

> [!WARNING]
> Adding another attendeed will generate a public share link instead of the internal link. This is apparently broken as well, I will try to address that in a follow up or log an issue.


**How to test:**

- Create an event
- Try to attach a folder
- Nothing happens on main, it works on this pr. 
