### PR TITLE
fix: avatar status icon text misalignment

### DIFF
--- a/src/components/Editor/AvatarParticipationStatus.vue
+++ b/src/components/Editor/AvatarParticipationStatus.vue
@@ -176,8 +176,8 @@ export default {
 </script>
 <style lang="scss" scoped>
 :deep(.avatar-participation-status__indicator) {
-	bottom: 20px;
-	left: 43px;
+	bottom: 2px !important;
+	left: 81px;
 	position: relative;
 	opacity: .8;
 }


### PR DESCRIPTION
before
![Screenshot from 2024-12-18 17-51-04](https://github.com/user-attachments/assets/f7a64101-bb15-4004-b1f3-ac67dfaf7603)

after
![Screenshot from 2024-12-18 18-14-13](https://github.com/user-attachments/assets/46329dad-2335-4f1e-b0e9-8241980a6035)

