### PR TITLE
[stable5.0] fix: adjust url for task links

### DIFF
--- a/src/fullcalendar/interaction/eventClick.js
+++ b/src/fullcalendar/interaction/eventClick.js
@@ -109,6 +109,6 @@ function handleToDoClick(event, route, window, isWidget = false) {
 		showInfo(t('calendar', 'Please ask your administrator to enable the Tasks App.'))
 		return
 	}
-	const url = `apps/tasks/#/calendars/${calendarId}/tasks/${taskId}`
+	const url = `apps/tasks/calendars/${calendarId}/tasks/${taskId}`
 	window.location = window.location.protocol + '//' + window.location.host + generateUrl(url)
 }

--- a/tests/javascript/unit/fullcalendar/interaction/eventClick.test.js
+++ b/tests/javascript/unit/fullcalendar/interaction/eventClick.test.js
@@ -323,7 +323,7 @@ describe('fullcalendar/eventClick test suite', () => {
 			}})
 
 		expect(generateUrl).toHaveBeenCalledTimes(1)
-		expect(generateUrl).toHaveBeenNthCalledWith(1, 'apps/tasks/#/calendars/reminders/tasks/EAFB112A-4556-404A-B807-B1E040D0F7A0.ics')
+		expect(generateUrl).toHaveBeenNthCalledWith(1, 'apps/tasks/calendars/reminders/tasks/EAFB112A-4556-404A-B807-B1E040D0F7A0.ics')
 
 		expect(window.location).toEqual('http://nextcloud.testing/generated-url')
 	})


### PR DESCRIPTION
Manual backport of https://github.com/nextcloud/calendar/pull/6550