### PR TITLE
fix(notifications): Notifier::prepare() threw \InvalidArgumentExcepti…

### DIFF
--- a/lib/Notification/Notifier.php
+++ b/lib/Notification/Notifier.php
@@ -12,6 +12,7 @@ use OCP\IURLGenerator;
 use OCP\L10N\IFactory;
 use OCP\Notification\INotification;
 use OCP\Notification\INotifier;
+use OCP\Notification\UnknownNotificationException;
 
 class Notifier implements INotifier {
 	private IFactory $factory;
@@ -39,7 +40,7 @@ class Notifier implements INotifier {
 	public function prepare(INotification $notification, string $languageCode): INotification {
 		if ($notification->getApp() !== Application::APP_ID) {
 			// Not my app => throw
-			throw new \InvalidArgumentException();
+			throw new UnknownNotificationException();
 		}
 
 		// Read the language from the notification
@@ -83,7 +84,7 @@ class Notifier implements INotifier {
 				]);
 				break;
 			default:
-				throw  new \InvalidArgumentException();
+				throw  new UnknownNotificationException();
 		}
 
 		return $notification;


### PR DESCRIPTION
…on which is deprecated

Possible since Nextcloud 30, and that's the minimum on main, so should be okay?

If a user has any notifications this log is generated all the time:

> OCA\Calendar\Notification\Notifier::prepare() threw \InvalidArgumentException which is deprecated. Throw \OCP\Notification\UnknownNotificationException when the notification is not known to your notifier and otherwise handle all \InvalidArgumentException yourself
