### PR TITLE
fix: max-width for long timezones names

### DIFF
--- a/src/views/Appointments/Booking.vue
+++ b/src/views/Appointments/Booking.vue
@@ -287,6 +287,10 @@ export default {
 .booking__time-zone {
 	margin-top: 280px;
 	position: relative;
+
+	:deep(.v-select.select) {
+		max-width: 260px;
+	}
 }
 
 .booking__date-header {
@@ -312,7 +316,6 @@ export default {
 :deep(.mx-datepicker-main) {
 	border: 0;
 }
-
 h2, h3, h4, h5 {
 	margin-top: 0;
 }


### PR DESCRIPTION
fixes  #6570

to avoid any breaking changes on other parts where ncselect is used, lets force it on calendar

![Screenshot from 2025-01-08 12-39-08](https://github.com/user-attachments/assets/0cda553c-c14f-43cf-88e7-67ef54800986)
