### PR TITLE
fix: firefox avatar icon styling inconsistency

### DIFF
--- a/src/components/Editor/AvatarParticipationStatus.vue
+++ b/src/components/Editor/AvatarParticipationStatus.vue
@@ -177,7 +177,8 @@ export default {
 <style lang="scss" scoped>
 :deep(.avatar-participation-status__indicator) {
 	bottom: 2px !important;
-	left: 81px;
+	justify-self: unset !important;
+	left: 43px;
 	position: relative;
 	opacity: .8;
 }


### PR DESCRIPTION
the issue on FF only:
![462-206-max](https://github.com/user-attachments/assets/ef465790-563c-4766-99ef-212029a075c5)

what is happening:
In Chromium the base position of the icon horizontally is "middle of the avatar" while in Firefox it is "on the left".

I have no idea, why it shown like that. Looks like it applies `justify-self: center`; from` material-design-icon`. But that shouldn't happen. Because it is not in a flex container. Chrome shows a warning that this property cannot be applied. But it is actually applied. Screenshot below.
![Screenshot from 2025-01-09 13-51-15](https://github.com/user-attachments/assets/5852d8de-e8fb-4e33-a5bf-33f5c7395e65)



Then the icon is moved using absolute position (left: 81px). And because the base position is different, it is different afterwards. 81px is a value used relative to chromium's invalid rendering.
The layout is  bad in general. ✅ icon and "Invitation accepted" string are children of a small avatar and then moved via position absolute/relative to a fixed place in pixels, paddings are inconsistent as well. I guess we do that, to make it work for an unstable layout.
If we dont want to spend 1h+ debuging very simple things, we should consider redoing it.
