### PR TITLE
fix:remove create talk room from attendees tab

### DIFF
--- a/src/components/Editor/Invitees/InviteesList.vue
+++ b/src/components/Editor/Invitees/InviteesList.vue
@@ -39,13 +39,6 @@
 		<OrganizerNoEmailError v-else-if="!isReadOnly && isListEmpty && !hasUserEmailAddress && !hideErrors" />
 
 		<div v-if="!hideButtons" class="invitees-list-button-group">
-			<NcButton v-if="isCreateTalkRoomButtonVisible"
-				class="invitees-list-button-group__button"
-				:disabled="isCreateTalkRoomButtonDisabled"
-				@click="createTalkRoom">
-				{{ $t('calendar', 'Create Talk room for this event') }}
-			</NcButton>
-
 			<NcButton v-if="!isReadOnly"
 				class="invitees-list-button-group__button"
 				:disabled="isListEmpty || !isOrganizer"


### PR DESCRIPTION
Now that we have a dedicated talk button, #6595  on the location section, we dont need this button here anymore

before
![Screenshot from 2025-01-09 17-41-37](https://github.com/user-attachments/assets/a260aa4b-17c7-4f5e-a2e2-dbd8692bc2b3)
after
![Screenshot from 2025-01-09 17-37-16](https://github.com/user-attachments/assets/c7076521-3190-466e-a4d8-687037bc0b42)
