### PR TITLE
Fix: avoid hotkeys in contenteditable

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -27,7 +27,7 @@ const pinia = createPinia()
 // register global components
 Vue.directive('ClickOutside', ClickOutside)
 Vue.use(VTooltip)
-Vue.use(VueShortKey, { prevent: ['input', 'textarea'] })
+Vue.use(VueShortKey, { prevent: ['input', 'textarea', '.rich-contenteditable__input'] })
 
 // CSP config for webpack dynamic chunk loading
 // eslint-disable-next-line


### PR DESCRIPTION
fixes https://github.com/nextcloud/assistant/issues/16

[NcRichContenteditable](https://nextcloud-vue-components.netlify.app/#/Components/NcRichContenteditable) uses a `div` for text input so shortkeys defined via `vue-shortkey` do not get avoided unless they are explicitly excluded