### PR TITLE
fix: simple editor size and jumping

### DIFF
--- a/src/components/Editor/Properties/PropertyText.vue
+++ b/src/components/Editor/Properties/PropertyText.vue
@@ -21,6 +21,7 @@
 				:rows="rows"
 				:name="readableName"
 				:value="value"
+				:class="{ 'textarea--description': isDescription }"
 				@focus="handleToggleTextareaFocus(true)"
 				@blur="handleToggleTextareaFocus(false)"
 				@input.prevent.stop="changeValue" />
@@ -60,6 +61,12 @@ export default {
 		PropertyMixin,
 		PropertyLinksMixin,
 	],
+	props: {
+		isDescription: {
+			type: Boolean,
+			default: false,
+		},
+	},
 	computed: {
 		display() {
 			if (this.isReadOnly) {
@@ -94,3 +101,9 @@ export default {
 	},
 }
 </script>
+<style lang="scss" scoped>
+.textarea--description {
+	height: 120px;
+	overflow-y: auto;
+}
+</style>

--- a/src/components/Editor/Properties/PropertyTitleTimePicker.vue
+++ b/src/components/Editor/Properties/PropertyTitleTimePicker.vue
@@ -335,9 +335,12 @@ export default {
 	overflow-y: clip !important;
 	flex-grow: 2;
 	flex-shrink: 1;
-	width: 210px;
+	width: 180px;
 	margin: 0;
 	min-width: unset;
+}
+:deep(.v-select.select) {
+	min-width: 180px !important;
 }
 
 .property-title-time-picker__time-pickers {

--- a/src/views/EditSimple.vue
+++ b/src/views/EditSimple.vue
@@ -130,6 +130,7 @@
 						:prop-model="rfcProps.description"
 						:value="description"
 						:linkify-links="true"
+						:is-description="true"
 						@update:value="updateDescription" />
 
 					<InviteesList class="event-popover__invitees"
@@ -445,7 +446,7 @@ export default {
 <style lang="scss" scoped>
 .event-popover__inner {
 	width: unset !important;
-	min-width: 300px !important;
+	min-width: 500px !important;
 }
 .modal-mask {
 	position: fixed;


### PR DESCRIPTION
fixes #6630 

this pr fixes 2 issues, the popover jumping and the description being smaller when you start typing

https://github.com/user-attachments/assets/461f6631-24fc-4d61-9395-c9a95033662d





