### PR TITLE
fix(freebusy): free busy ignoring user's time zone

### DIFF
--- a/src/components/Editor/FreeBusy/FreeBusy.vue
+++ b/src/components/Editor/FreeBusy/FreeBusy.vue
@@ -466,7 +466,7 @@ export default {
 					this.attendees.map((a) => a.attendeeProperty),
 					startSearch,
 					endSearchDate,
-					this.timeZoneId,
+					this.timezoneId,
 				)
 
 				const freeSlots = getFirstFreeSlot(


### PR DESCRIPTION
Addresses the following console error message:

```
[ERROR] calendar: FreeBusyEventSource: Timezone undefined not found, falling back to UTC.
```