### PR TITLE
fix(freebusy): slot header format not respecting user's locale

### DIFF
--- a/src/fullcalendar/localization/dateFormattingConfig.js
+++ b/src/fullcalendar/localization/dateFormattingConfig.js
@@ -35,6 +35,7 @@ const getDateFormattingConfig = () => {
 				listDayFormat: 'LL, dddd',
 				listDaySideFormat: false,
 			},
+			resourceTimelineDay: defaultConfig,
 		},
 	}
 }


### PR DESCRIPTION
Fix https://github.com/nextcloud/calendar/issues/6463

## Before

Regardless of a user's locale setting.

![Image](https://github.com/user-attachments/assets/15433f21-1a34-49d4-a1a7-ff8fd498e913)

## After

| Locale | Screenshot | 
| --- | --- |
| en_US | ![image](https://github.com/user-attachments/assets/939bb043-c14c-4013-920b-8c2fb3e33074) | 
| de | ![image](https://github.com/user-attachments/assets/29254562-39c2-4176-aec2-b6e3dabbd43e) |
