### PR TITLE
[stable4.7] fix(freebusy): free busy ignoring user's time zone

### DIFF
--- a/src/components/Editor/FreeBusy/FreeBusy.vue
+++ b/src/components/Editor/FreeBusy/FreeBusy.vue
@@ -485,7 +485,7 @@ export default {
 					this.attendees.map((a) => a.attendeeProperty),
 					startSearch,
 					endSearchDate,
-					this.timeZoneId
+					this.timezoneId
 				)
 
 				const freeSlots = getFirstFreeSlot(


### PR DESCRIPTION
Manual backport of #6665