### PR TITLE
fix: sort talk conversations by most recent activity

### DIFF
--- a/src/components/Editor/AddTalkModal.vue
+++ b/src/components/Editor/AddTalkModal.vue
@@ -18,7 +18,7 @@
 				<NcEmptyContent v-else-if="talkConversations.length === 0"
 					:description="t('calendar','No Talk room available')" />
 				<ul v-else>
-					<li v-for="conversation in talkConversations"
+					<li v-for="conversation in sortedTalkConversations"
 						:key="conversation.id"
 						:class="{ selected: selectedRoom && selectedRoom.id === conversation.id }"
 						class="talk-room-list__item"
@@ -100,6 +100,12 @@ export default {
 	},
 	computed: {
 		...mapStores(useCalendarObjectInstanceStore, ['calendarObjectInstance']),
+		/**
+		 * @return {object[]} Talk conversations sorted by most recent activity
+		 */
+		sortedTalkConversations() {
+			return this.talkConversations.toSorted((a, b) => b.lastActivity - a.lastActivity)
+		},
 	},
 	async mounted() {
 		await this.fetchTalkConversations()


### PR DESCRIPTION
Fix https://github.com/nextcloud/calendar/issues/6676

| Before | After |
| --- | --- |
| ![spectacle_20250128_143821](https://github.com/user-attachments/assets/7920ccbc-45a2-4a0c-b157-6b29f87805ff) | ![spectacle_20250128_143958](https://github.com/user-attachments/assets/12871cd9-c57e-4c2f-bd08-b39ac7645e85) |