### PR TITLE
refactor: clean up public calendar list item

### DIFF
--- a/src/components/AppNavigation/CalendarList/PublicCalendarListItem.vue
+++ b/src/components/AppNavigation/CalendarList/PublicCalendarListItem.vue
@@ -74,8 +74,6 @@ import {
 
 import Download from 'vue-material-design-icons/Download.vue'
 import LinkVariant from 'vue-material-design-icons/LinkVariant.vue'
-import useCalendarsStore from '../../../store/calendars.js'
-import { mapStores } from 'pinia'
 
 export default {
 	name: 'PublicCalendarListItem',
@@ -107,7 +105,6 @@ export default {
 		}
 	},
 	computed: {
-		...mapStores(useCalendarsStore),
 		/**
 		 * Download url of the calendar
 		 *
@@ -176,12 +173,6 @@ export default {
 					this.showCopySubscriptionLinkError = false
 				}, 2000)
 			}
-		},
-		async toggleEnabled() {
-			await this.calendarsStore.toggleCalendarEnabled({
-				calendar: this.calendar,
-				updateDav: false,
-			})
 		},
 	},
 }


### PR DESCRIPTION
Follow-up to https://github.com/nextcloud/calendar/pull/6681

Remove some dead code from the public calendar list item component. It is not possible to toggle them and the method is not used anymore.