### PR TITLE
fix(freebusy): time zone handling

### DIFF
--- a/src/components/Editor/FreeBusy/FreeBusy.vue
+++ b/src/components/Editor/FreeBusy/FreeBusy.vue
@@ -394,12 +394,10 @@ export default {
 		 * @return {object}
 		 */
 		options() {
-			const timezone = getTimezoneManager().getTimezoneForId(this.timezoneId)
-
 			return {
 				// Initialization:
 				initialView: 'resourceTimelineDay',
-				initialDate: this.currentStart.getInTimezone(timezone).jsDate,
+				initialDate: this.currentStartInUserTimezone,
 				schedulerLicenseKey: 'GPL-My-Project-Is-Open-Source',
 				// Data
 				eventSources: this.eventSources,

--- a/src/components/Editor/Invitees/InviteesList.vue
+++ b/src/components/Editor/Invitees/InviteesList.vue
@@ -41,7 +41,7 @@
 		<OrganizerNoEmailError v-else-if="!isReadOnly && isListEmpty && !hasUserEmailAddress && !hideErrors" />
 
 		<div v-if="!hideButtons" class="invitees-list-button-group">
-			<NcButton v-if="!isReadOnly"
+			<NcButton v-if="!isReadOnly && !(calendarObjectInstance.isAllDay && !calendarObjectInstance.canModifyAllDay)"
 				class="invitees-list-button-group__button"
 				:disabled="isListEmpty || !isOrganizer"
 				@click="openFreeBusy">
@@ -50,8 +50,9 @@
 			<FreeBusy v-if="showFreeBusyModel"
 				:attendees="calendarObjectInstance.attendees"
 				:organizer="calendarObjectInstance.organizer"
-				:start-date="calendarObjectInstance.startDate"
-				:end-date="calendarObjectInstance.endDate"
+				:start-date="calendarObjectInstance.eventComponent.startDate"
+				:end-date="calendarObjectInstance.eventComponent.endDate"
+				:is-all-day="calendarObjectInstance.isAllDay"
 				:event-title="calendarObjectInstance.title"
 				:already-invited-emails="alreadyInvitedEmails"
 				:show-done-button="true"

--- a/src/views/ContactsMenuAvailability.vue
+++ b/src/views/ContactsMenuAvailability.vue
@@ -8,6 +8,7 @@
 		:dialog-name="dialogName"
 		:start-date="startDate"
 		:end-date="endDate"
+		:is-all-day="false"
 		:organizer="organizer"
 		:attendees="attendees"
 		:disable-find-time="true"
@@ -28,7 +29,7 @@ import loadMomentLocalization from '../utils/moment.js'
 import { initializeClientForUserView } from '../services/caldavService.js'
 import getTimezoneManager from '../services/timezoneDataProviderService.js'
 import FreeBusy from '../components/Editor/FreeBusy/FreeBusy.vue'
-import { AttendeeProperty } from '@nextcloud/calendar-js'
+import { AttendeeProperty, DateTimeValue } from '@nextcloud/calendar-js'
 
 export default {
 	name: 'ContactsMenuAvailability',
@@ -69,13 +70,13 @@ export default {
 			})
 		},
 		startDate() {
-			return new Date()
+			return DateTimeValue.fromJSDate(new Date(), false)
 		},
 		endDate() {
 			// Let's assign a slot of one hour as a default for now
-			const date = new Date(this.startDate)
+			const date = this.startDate.jsDate
 			date.setHours(date.getHours() + 1)
-			return date
+			return DateTimeValue.fromJS(date, false)
 		},
 		organizer() {
 			if (!this.principalsStore.getCurrentUserPrincipal) {

--- a/src/views/EditSidebar.vue
+++ b/src/views/EditSidebar.vue
@@ -483,6 +483,14 @@ export default {
 		 * @param {object} dates The new start and end date
 		 */
 		updateDates(dates) {
+			if (this.isAllDay) {
+				if (!this.canModifyAllDay) {
+					throw new Error('Impossible to convert all day event to regular event')
+				}
+
+				this.toggleAllDay()
+			}
+
 			this.updateStartDate(dates.start)
 			this.updateEndDate(dates.end)
 		},


### PR DESCRIPTION
Fix https://github.com/nextcloud/calendar/issues/6702

This PR fixes an array of issues in the time zone handling and slot suggestion logic of the free busy or "find a time" modal.

## Fixes

1. Disable the "find a time" button for recurring all day events. (They can't be converted into regular events so it makes no sense.)
2. Disable slot suggestion for all day events until the user manually selects a slot in the grid. Again, it doesn't make sense to find a time for an all day event. (There will be a hint/help message instead of the automatic slot suggestion.)
3. Handle time zones correctly. Use the event's start and end time zones. Convert everything to the user's configured time zone to be consistent with the calendar grid.
4. Use the user's configured time zone to format slot suggestions (and all other displayed dates).

## How to reproduce time zone problems?

1. Create an event (not all day).
2. Configure some other time zone far away, e.g. something in North America. 
3. Invite someone and open the find a time modal.
4. Watch the time and date conversion break.
	1. Slots are not formatted correctly according to the user's time zone.
	2. Selected time in the grid does not match the configured time in the event editor.
	3. Selecting some time, saving and returning to the editor will yield a completely different time in the event.

## Obligatory meme to cope with reality

![image](https://github.com/user-attachments/assets/187418d0-f80e-4985-a9cf-53b86c9b4909)