### PR TITLE
[stable4.7] ci(package): bump upload-artifact action to v4

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -25,7 +25,7 @@ jobs:
           sudo dpkg -i krankerl_0.14.0_amd64.deb
       - name: Package app
         run: krankerl package
-      - uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3
+      - uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4
         with:
           path: build/artifacts/calendar.tar.gz
           if-no-files-found: error


### PR DESCRIPTION
Older versions fail instantly as they were deprecated a long time ago.