### PR TITLE
fix: always show alarm unit in pural

### DIFF
--- a/src/components/Editor/Alarm/AlarmTimeUnitSelect.vue
+++ b/src/components/Editor/Alarm/AlarmTimeUnitSelect.vue
@@ -54,28 +54,28 @@ export default {
 
 			if (this.unit === 'seconds') {
 				options.push({
-					label: this.$n('calendar', 'second', 'seconds', this.count),
+					label: this.$t('calendar', 'seconds'),
 					unit: 'seconds',
 				})
 			}
 
 			if (!this.isAllDay || ['minutes', 'hours'].indexOf(this.unit) !== -1) {
 				options.push({
-					label: this.$n('calendar', 'minute', 'minutes', this.count),
+					label: this.$t('calendar', 'minutes'),
 					unit: 'minutes',
 				})
 				options.push({
-					label: this.$n('calendar', 'hour', 'hours', this.count),
+					label: this.$t('calendar', 'hours'),
 					unit: 'hours',
 				})
 			}
 
 			options.push({
-				label: this.$n('calendar', 'day', 'days', this.count),
+				label: this.$t('calendar', 'days'),
 				unit: 'days',
 			})
 			options.push({
-				label: this.$n('calendar', 'week', 'weeks', this.count),
+				label: this.$t('calendar', 'weeks'),
 				unit: 'weeks',
 			})
 


### PR DESCRIPTION
Fix https://github.com/nextcloud/calendar/issues/3441

This is a simple fix for the collision of translations for `second`. Please refer to https://github.com/nextcloud/calendar/issues/3441#issuecomment-984052425 for more information.

IMO, the impact is minimal and acceptable. Users will only notice it if they create an alarm with a relative time of 1 hour, minute, second, etc.

| Before | After |
| --- | --- |
| ![image](https://github.com/user-attachments/assets/f9abff7a-7073-4bd6-b83e-6de0f666432d) | ![image](https://github.com/user-attachments/assets/da13af78-93f4-498d-9ae7-4949d0c9b0ca) |