### PR TITLE
fix(l10n): add context for translators (second vs. seconds)

### DIFF
--- a/src/components/Editor/Repeat/RepeatFirstLastSelect.vue
+++ b/src/components/Editor/Repeat/RepeatFirstLastSelect.vue
@@ -17,6 +17,7 @@
 
 <script>
 import { NcSelect } from '@nextcloud/vue'
+import { getTranslatedOrdinalNumber } from '../../../filters/recurrenceRuleFormat.js'
 
 export default {
 	name: 'RepeatFirstLastSelect',
@@ -41,28 +42,10 @@ export default {
 	},
 	computed: {
 		options() {
-			return [{
-				label: this.$t('calendar', 'first'),
-				value: 1,
-			}, {
-				label: this.$t('calendar', 'second'),
-				value: 2,
-			}, {
-				label: this.$t('calendar', 'third'),
-				value: 3,
-			}, {
-				label: this.$t('calendar', 'fourth'),
-				value: 4,
-			}, {
-				label: this.$t('calendar', 'fifth'),
-				value: 5,
-			}, {
-				label: this.$t('calendar', 'second to last'),
-				value: -2,
-			}, {
-				label: this.$t('calendar', 'last'),
-				value: -1,
-			}]
+			return [1, 2, 3, 4, 5, -2, -1].map((ordinal) => ({
+				label: getTranslatedOrdinalNumber(ordinal),
+				value: ordinal,
+			}))
 		},
 		selected() {
 			return this.options.find(option => option.value === this.bySetPosition)

--- a/src/filters/recurrenceRuleFormat.js
+++ b/src/filters/recurrenceRuleFormat.js
@@ -185,12 +185,13 @@ function getTranslatedMonths(byMonthList) {
  * @param {number} bySetPositionNum The by-set-position number to get the translation of
  * @return {string}
  */
-function getTranslatedOrdinalNumber(bySetPositionNum) {
+export function getTranslatedOrdinalNumber(bySetPositionNum) {
 	switch (bySetPositionNum) {
 	case 1:
 		return t('calendar', 'first')
 
 	case 2:
+		// TRANSLATORS This refers to the second item in a series, not to the unit of time
 		return t('calendar', 'second')
 
 	case 3:


### PR DESCRIPTION
Ref https://github.com/nextcloud/calendar/issues/3441#issuecomment-2672825421

Add context for translators to disambiguate second and seconds.