### PR TITLE
feat(talkintegration): add object type to talk room creation

### DIFF
--- a/src/services/talkService.js
+++ b/src/services/talkService.js
@@ -9,6 +9,7 @@ import { loadState } from '@nextcloud/initial-state'
 import { getCurrentUser } from '@nextcloud/auth'
 import logger from '../utils/logger.js'
 import { removeMailtoPrefix } from '../utils/attendee.js'
+import md5 from 'md5'
 
 /**
  * Creates a new public talk room
@@ -25,6 +26,8 @@ export async function createTalkRoom(eventTitle = null, eventDescription = null,
 		const response = await HTTPClient.post(generateOcsUrl('apps/spreed/api/' + apiVersion + '/', 2) + 'room', {
 			roomType: 3,
 			roomName: eventTitle || t('calendar', 'Talk conversation for event'),
+			objectType: 'event',
+			objectId: md5(new Date()),
 		})
 
 		const conversation = response.data.ocs.data


### PR DESCRIPTION
For https://github.com/nextcloud/spreed/issues/14401 we need an object type for the calendar- created Talk rooms.

This PR adds the object type "event" and passes is as an `objectType` when creating a talk room. Since there is only one room type created directly from the calendar, it should be ok to have this as a static value (same as the room type always being `3`).

@st3iny is there any chance to also pass the UUID for the `objectId`? I'm guessing it doesn't exists yet at this point in the process?