### PR TITLE
Move changelog license header to a separate file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,3 @@
-<!--
-  - SPDX-FileCopyrightText: 2016-2024 Nextcloud GmbH and Nextcloud contributors
-  - SPDX-FileCopyrightText: 2014-2026 ownCloud, Inc.
-  - SPDX-License-Identifier: AGPL-3.0-or-later
--->
 # Changelog
 
 ## 5.0.0 - Unreleased

--- a/CHANGELOG.md.license
+++ b/CHANGELOG.md.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2016-2024 Nextcloud GmbH and Nextcloud contributors
+SPDX-FileCopyrightText: 2014-2026 ownCloud, Inc.
+SPDX-License-Identifier: AGPL-3.0-or-later


### PR DESCRIPTION
Fix https://github.com/nextcloud/calendar/actions/runs/13660296339/job/38189668415?pr=6782 (on stable branches)

I split it into two commits because only the standalone license file needs to be backported.