### PR TITLE
chore: add stable5.2 to the npm audit fix action and transifex integration

### DIFF
--- a/.github/workflows/npm-audit-fix.yml
+++ b/.github/workflows/npm-audit-fix.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        branches: ['main', 'stable5.1', 'stable4.7']
+        branches: ['main', 'stable5.2', 'stable5.1', 'stable4.7']
 
     name: npm-audit-fix-${{ matrix.branches }}
 

--- a/.tx/backport
+++ b/.tx/backport
@@ -1,2 +1,3 @@
 stable4.7
 stable5.1
+stable5.2


### PR DESCRIPTION
The old branch `stable5.1` can be removed once the final release is out. It will be be fully superseded by `stable5.2`.