### PR TITLE
fix: do not show attendee actions in viewing mode

### DIFF
--- a/src/components/Editor/Invitees/InviteesListItem.vue
+++ b/src/components/Editor/Invitees/InviteesListItem.vue
@@ -35,7 +35,7 @@
 						:size="20" />
 				</template>
 			</NcButton>
-			<Actions v-if="isViewedByOrganizer">
+			<Actions v-if="!isReadOnly && isViewedByOrganizer">
 				<ActionCheckbox v-if="!members.length"
 					:checked="attendee.rsvp"
 					@change="toggleRSVP">


### PR DESCRIPTION
Resolves: Issue with attendee action showing in popover viewing mode. The action also had no affect since the modal was only in viewing mode.

Before:
![Screenshot 2025-03-09 102519](https://github.com/user-attachments/assets/c6ad40b7-f844-4c76-901b-246e606c9079)

After:
![Screenshot 2025-03-09 105310](https://github.com/user-attachments/assets/6e100347-b891-4c58-ba8b-7fad69b6036a)
