### PR TITLE
fix: do not show attendee list when there are no attendees in viewing mode

### DIFF
--- a/src/views/EditSimple.vue
+++ b/src/views/EditSimple.vue
@@ -148,7 +148,8 @@
 						:is-description="true"
 						@update:value="updateDescription" />
 
-					<InviteesList class="event-popover__invitees"
+					<InviteesList v-if="!isViewing || (isViewing && hasAttendees)"
+						class="event-popover__invitees"
 						:hide-buttons="true"
 						:hide-errors="true"
 						:show-header="true"
@@ -273,6 +274,7 @@ export default {
 			placement: 'auto',
 			hasLocation: false,
 			hasDescription: false,
+			hasAttendees: false,
 			boundaryElement: null,
 			isVisible: true,
 			isViewing: true,
@@ -325,12 +327,16 @@ export default {
 		calendarObjectInstance() {
 			this.hasLocation = false
 			this.hasDescription = false
+			this.hasAttendees = false
 
 			if (typeof this.calendarObjectInstance.location === 'string' && this.calendarObjectInstance.location.trim() !== '') {
 				this.hasLocation = true
 			}
 			if (typeof this.calendarObjectInstance.description === 'string' && this.calendarObjectInstance.description.trim() !== '') {
 				this.hasDescription = true
+			}
+			if (Array.isArray(this.calendarObjectInstance.attendees) && this.calendarObjectInstance.attendees.length > 0) {
+				this.hasAttendees = true
 			}
 		},
 		isNew: {


### PR DESCRIPTION
Resolves: Issue with attendee list showing blank place holder when there are no attendees. We do not show blank place holders for location or description, attendees list should function the same way, less in more.

Before:
![image](https://github.com/user-attachments/assets/098f9a36-6c12-448a-91e1-570dcd7eb345)

After - Viewing Mode - No attendees
![Screenshot 2025-03-09 111552](https://github.com/user-attachments/assets/02689983-53f8-40fc-9b67-596e29e619ce)

After - Editing Mode - No attendees
![Screenshot 2025-03-09 112142](https://github.com/user-attachments/assets/00521693-5891-4675-bd43-a7f65c1ae09d)

After - Viewing Mode - With attendees
![Screenshot 2025-03-09 112058](https://github.com/user-attachments/assets/c0bf440d-355b-4181-82cf-581d0d517756)

After - Editing Mode - With attendees
![Screenshot 2025-03-09 112109](https://github.com/user-attachments/assets/63352a0d-3616-4edd-8ff1-1255941ef071)
