### PR TITLE
fix(editor): Allow edits as attending organizer

### DIFF
--- a/src/mixins/EditorMixin.js
+++ b/src/mixins/EditorMixin.js
@@ -217,6 +217,20 @@ export default {
 			return this.userAsAttendee !== null
 		},
 		/**
+		 * Returns whether the user is an attendee of the event
+		 *
+		 * @return {boolean|null}
+		 */
+		isViewedByOrganizer() {
+			if (this.isReadOnly || !this.principalsStore.getCurrentUserPrincipalEmail || !this.calendarObjectInstance.organizer) {
+				return null
+			}
+
+			const principal = removeMailtoPrefix(this.principalsStore.getCurrentUserPrincipalEmail)
+			const organizer = this.calendarObjectInstance.organizer
+			return removeMailtoPrefix(organizer.uri) === principal
+		},
+		/**
 		 * Returns the attendee property corresponding to the current user
 		 *
 		 * @return {?object}

--- a/src/views/EditSidebar.vue
+++ b/src/views/EditSidebar.vue
@@ -61,9 +61,9 @@
 				<CalendarPickerHeader :value="selectedCalendar"
 					:calendars="calendars"
 					:is-read-only="isReadOnly || !canModifyCalendar"
-					:is-viewed-by-attendee="isViewedByAttendee"
+					:is-viewed-by-attendee="isViewedByOrganizer !== true"
 					@update:value="changeCalendar" />
-				<NcPopover v-if="isViewedByAttendee" :focus-trap="false">
+				<NcPopover v-if="isViewedByOrganizer !== true" :focus-trap="false">
 					<template #trigger>
 						<NcButton type="tertiary-no-background">
 							<template #icon>
@@ -80,7 +80,7 @@
 			</div>
 
 			<PropertyTitle :value="title"
-				:is-read-only="isReadOnly || isViewedByAttendee"
+				:is-read-only="isReadOnly || isViewedByOrganizer !== true"
 				@update:value="updateTitle" />
 
 			<PropertyTitleTimePicker :start-date="startDate"
@@ -88,7 +88,7 @@
 				:end-date="endDate"
 				:end-timezone="endTimezone"
 				:is-all-day="isAllDay"
-				:is-read-only="isReadOnly || isViewedByAttendee"
+				:is-read-only="isReadOnly || isViewedByOrganizer !== true"
 				:can-modify-all-day="canModifyAllDay"
 				:user-timezone="currentUserTimezone"
 				:append-to-body="true"
@@ -117,7 +117,7 @@
 				</NcButton>
 			</div>
 			<PropertyText class="property-location"
-				:is-read-only="isReadOnly || isViewedByAttendee"
+				:is-read-only="isReadOnly || isViewedByOrganizer !== true"
 				:prop-model="rfcProps.location"
 				:value="location"
 				:linkify-links="true"
@@ -151,7 +151,7 @@
 					:prop-model="rfcProps.status"
 					:value="status"
 					@update:value="updateStatus" />
-				<PropertySelect :is-read-only="isReadOnly || isViewedByAttendee"
+				<PropertySelect :is-read-only="isReadOnly || isViewedByOrganizer !== true"
 					:prop-model="rfcProps.accessClass"
 					:value="accessClass"
 					@update:value="updateAccessClass" />
@@ -180,7 +180,7 @@
 				<!-- TODO: You can't edit recurrence-rule of no-range recurrence-exception -->
 				<Repeat :calendar-object-instance="calendarObjectInstance"
 					:recurrence-rule="calendarObjectInstance.recurrenceRule"
-					:is-read-only="isReadOnly || isViewedByAttendee"
+					:is-read-only="isReadOnly || isViewedByOrganizer !== true"
 					:is-editing-master-item="isEditingMasterItem"
 					:is-recurrence-exception="isRecurrenceException"
 					@force-this-and-all-future="forceModifyingFuture" />
@@ -259,7 +259,7 @@
 				<InviteesList v-if="!isLoading"
 					:calendar="selectedCalendar"
 					:calendar-object-instance="calendarObjectInstance"
-					:is-read-only="isReadOnly || isViewedByAttendee"
+					:is-read-only="isReadOnly || isViewedByOrganizer !== true"
 					:is-shared-with-me="isSharedWithMe"
 					:show-header="false"
 					@update-dates="updateDates" />
@@ -284,7 +284,7 @@
 			<div class="app-sidebar-tab__content">
 				<ResourceList v-if="!isLoading"
 					:calendar-object-instance="calendarObjectInstance"
-					:is-read-only="isReadOnly || isViewedByAttendee" />
+					:is-read-only="isReadOnly || isViewedByOrganizer !== true" />
 			</div>
 			<SaveButtons v-if="showSaveButtons"
 				class="app-sidebar-tab__buttons"
@@ -466,7 +466,7 @@ export default {
 
 		},
 		isCreateTalkRoomButtonVisible() {
-			return this.talkEnabled && !this.isViewedByAttendee
+			return this.talkEnabled && !this.isViewedByOrganizer !== true
 		},
 
 	},

--- a/src/views/EditSimple.vue
+++ b/src/views/EditSimple.vue
@@ -52,7 +52,7 @@
 
 				<template v-else>
 					<div class="event-popover__top-actions">
-						<NcPopover v-if="isViewedByAttendee" :focus-trap="false">
+						<NcPopover v-if="isViewedByOrganizer !== true" :focus-trap="false">
 							<template #trigger>
 								<NcButton type="tertiary-no-background">
 									<template #icon>
@@ -112,11 +112,11 @@
 					<CalendarPickerHeader :value="selectedCalendar"
 						:calendars="calendars"
 						:is-read-only="isReadOnlyOrViewing || !canModifyCalendar"
-						:is-viewed-by-attendee="isViewedByAttendee"
+						:is-viewed-by-attendee="isViewedByOrganizer !== true"
 						@update:value="changeCalendar" />
 
 					<PropertyTitle :value="titleOrPlaceholder"
-						:is-read-only="isReadOnlyOrViewing || isViewedByAttendee"
+						:is-read-only="isReadOnlyOrViewing || isViewedByOrganizer !== true"
 						@update:value="updateTitle" />
 
 					<PropertyTitleTimePicker :start-date="startDate"
@@ -124,7 +124,7 @@
 						:end-date="endDate"
 						:end-timezone="endTimezone"
 						:is-all-day="isAllDay"
-						:is-read-only="isReadOnlyOrViewing || isViewedByAttendee"
+						:is-read-only="isReadOnlyOrViewing || isViewedByOrganizer !== true"
 						:can-modify-all-day="canModifyAllDay"
 						:user-timezone="currentUserTimezone"
 						:wrap="false"
@@ -136,7 +136,7 @@
 						@update-end-timezone="updateEndTimezone"
 						@toggle-all-day="toggleAllDay" />
 
-					<PropertyText :is-read-only="isReadOnlyOrViewing || isViewedByAttendee"
+					<PropertyText :is-read-only="isReadOnlyOrViewing || isViewedByOrganizer !== true"
 						:prop-model="rfcProps.location"
 						:value="location"
 						:linkify-links="true"
@@ -153,7 +153,7 @@
 						:hide-buttons="true"
 						:hide-errors="true"
 						:show-header="true"
-						:is-read-only="isReadOnlyOrViewing || isViewedByAttendee"
+						:is-read-only="isReadOnlyOrViewing || isViewedByOrganizer !== true"
 						:is-shared-with-me="isSharedWithMe"
 						:calendar="selectedCalendar"
 						:calendar-object-instance="calendarObjectInstance"


### PR DESCRIPTION
https://github.com/nextcloud/calendar/pull/6778 hid actions that attendees shouldn't execute. However, there can be ORGANIZERs that are also listed as ATTENDEE. Don't ask me how, it happens. Then we hide the actions also from the actual organizer.