### PR TITLE
fix(editor): Rephraze ambiguous "group" invites

### DIFF
--- a/src/components/Editor/Invitees/InviteesListSearch.vue
+++ b/src/components/Editor/Invitees/InviteesListSearch.vue
@@ -95,7 +95,7 @@ export default {
 	},
 	computed: {
 		placeholder() {
-			return this.$t('calendar', 'Search for emails, users, contacts, teams or groups')
+			return this.$t('calendar', 'Search for emails, users, contacts, contact groups or teams')
 		},
 		noResult() {
 			return this.$t('calendar', 'No match found')


### PR DESCRIPTION
The app can invite *Contact groups* but not *Nextcloud groups*

Raised at https://github.com/nextcloud/calendar/issues/2955#issuecomment-2720732187.