### PR TITLE
Make time text color in calendar grid be main text color

### DIFF
--- a/src/fullcalendar/rendering/eventDidMount.js
+++ b/src/fullcalendar/rendering/eventDidMount.js
@@ -98,6 +98,7 @@ export default function({ event, el }) {
 		|| el.classList.contains('fc-event-nc-declined')
 	) {
 		const titleElement = el.querySelector('.fc-event-title')
+		const timeElement = el.querySelector('.fc-event-time')
 		const dotElement = el.querySelector('.fc-daygrid-event-dot')
 
 		if (dotElement) {
@@ -108,6 +109,10 @@ export default function({ event, el }) {
 		}
 
 		titleElement.style.color = 'var(--color-main-text)'
+		if (timeElement) {
+			timeElement.style.color = 'var(--color-main-text)'
+		}
+
 		el.style.background = 'transparent'
 		el.title = t('calendar', 'All participants declined')
 


### PR DESCRIPTION
| Before | After |
| - | - |
| ![image](https://github.com/user-attachments/assets/30c2e430-c695-4fe5-8868-affc4fe0739d) | ![image](https://github.com/user-attachments/assets/5e47b5cc-ebfb-4302-82f5-2a7ae5ce1b64) |