### PR TITLE
fix: show generic participation status for the organizer

### DIFF
--- a/src/components/Editor/AvatarParticipationStatus.vue
+++ b/src/components/Editor/AvatarParticipationStatus.vue
@@ -118,14 +118,7 @@ export default {
 					}
 				}
 
-				if (this.attendeeIsOrganizer && !this.isViewedByOrganizer) {
-					return {
-						...acceptedIcon,
-						text: t('calendar', 'Invited you'),
-					}
-				}
-
-				if (this.isViewedByOrganizer) {
+				if (this.attendeeIsOrganizer) {
 					return {
 						...acceptedIcon,
 						text: t('calendar', 'Invitation accepted'),


### PR DESCRIPTION
The participation status `Invited you` doesn't make sense when I'm viewing an event in a shared calendar to which I'm not directly invited.

The following screenshots show an event created by user1 in a shared calendar to which user3 has read-only access. User1 invited user2 to the event. It is viewed from the perspective of the unrelated user3.

| Before | After |
| --- | --- |
| ![spectacle_20250318_104147](https://github.com/user-attachments/assets/6840616e-2323-47f5-b0af-b3abf15ce9c6) | ![image](https://github.com/user-attachments/assets/95be5025-d784-4ae4-bfa6-120583e283ba) |

