### PR TITLE
chore(release): v5.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,32 @@
 # Changelog
 
-## 5.2.0 - unreleased
+## 5.2.0 - 2025-03-18
 ### Added
-* Conditional styling for participation status
-* Object type for Talk rooms
+- Conditional styling for participation status
+- Object type for Talk rooms
+### Fixed
+- Always show alarm unit in pural
+- Close modal after creating conversation
+- Date selector resetting time
+- Do not show attendee actions in viewing mode
+- Do not show attendee list when there are no attendees in viewing mode
+- Do not show items from deleted calendars in widget
+- EditSideBar bug
+- Force height for descr and location
+- Free busy ignoring user's time zone
+- Free busy not updating date
+- Keyboard shortcut modal not being responsive
+- Monthly recurrance type and bymonthday selection
+- Remove toggle functionality from public view
+- Rephraze ambiguous "group" invites
+- Restrict attendees edit priveleges in the frontend
+- Restrict calendar visibility toggle to checkbox only
+- Show display name instead of user id in availability integration
+- Show generic participation status for the organizer
+- Slot header format not respecting user's locale
+- Sort talk conversations by most recent activity
+- Update vulnerable dependencies
+- Yearly recurrance options - month selection
 
 ## 5.0.0 - Unreleased
 ### Added

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -20,7 +20,7 @@
 * ☑️ Tasks! See tasks with a due date directly in the calendar
 * 🙈 **We’re not reinventing the wheel!** Based on the great [c-dav library](https://github.com/nextcloud/cdav-library), [ical.js](https://github.com/mozilla-comm/ical.js) and [fullcalendar](https://github.com/fullcalendar/fullcalendar) libraries.
 	]]></description>
-	<version>5.2.0-rc.1</version>
+	<version>5.2.0</version>
 	<licence>agpl</licence>
 	<author homepage="https://github.com/st3iny">Richard Steinmetz</author>
 	<author homepage="https://github.com/SebastianKrupinski">Sebastian Krupinski </author>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "calendar",
-  "version": "5.2.0-rc.1",
+  "version": "5.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "calendar",
-      "version": "5.2.0-rc.1",
+      "version": "5.2.0",
       "license": "agpl",
       "dependencies": {
         "@fullcalendar/core": "6.1.15",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "calendar",
   "description": "A calendar app for Nextcloud. Easily sync events from various devices, share and edit them online.",
-  "version": "5.2.0-rc.1",
+  "version": "5.2.0",
   "author": "Georg Ehrke <oc.list@georgehrke.com>",
   "contributors": [
     "Georg Ehrke <oc.list@georgehrke.com>",


### PR DESCRIPTION
# Changelog

## 5.2.0 - 2025-03-18
### Added
- Conditional styling for participation status
- Object type for Talk rooms
### Fixed
- Always show alarm unit in pural
- Close modal after creating conversation
- Date selector resetting time
- Do not show attendee actions in viewing mode
- Do not show attendee list when there are no attendees in viewing mode
- Do not show items from deleted calendars in widget
- EditSideBar bug
- Force height for descr and location
- Free busy ignoring user's time zone
- Free busy not updating date
- Keyboard shortcut modal not being responsive
- Monthly recurrance type and bymonthday selection
- Remove toggle functionality from public view
- Rephraze ambiguous "group" invites
- Restrict attendees edit priveleges in the frontend
- Restrict calendar visibility toggle to checkbox only
- Show display name instead of user id in availability integration
- Show generic participation status for the organizer
- Slot header format not respecting user's locale
- Sort talk conversations by most recent activity
- Update vulnerable dependencies
- Yearly recurrance options - month selection