### PR TITLE
feat(talkintegration): filter out event type rooms from suggestions

### DIFF
--- a/src/components/Editor/AddTalkModal.vue
+++ b/src/components/Editor/AddTalkModal.vue
@@ -67,6 +67,7 @@ import { mapStores } from 'pinia'
 const CONVERSATION_TYPE_GROUP = 2
 const CONVERSATION_TYPE_PUBLIC = 3
 const CONVERSATION_OBJECT_TYPE_VIDEO_VERIFICATION = 'share:password'
+const CONVERSATION_OBJECT_TYPE_EVENT = 'event'
 const PARTICIPANT_TYPE_OWNER = 1
 const PARTICIPANT_TYPE_MODERATOR = 2
 
@@ -124,7 +125,8 @@ export default {
 						|| conversation.participantType === PARTICIPANT_TYPE_MODERATOR)
 					&& (conversation.type === CONVERSATION_TYPE_GROUP
 						|| (conversation.type === CONVERSATION_TYPE_PUBLIC
-							&& conversation.objectType !== CONVERSATION_OBJECT_TYPE_VIDEO_VERIFICATION)),
+							&& conversation.objectType !== CONVERSATION_OBJECT_TYPE_VIDEO_VERIFICATION))
+					&& conversation.objectType !== CONVERSATION_OBJECT_TYPE_EVENT
 				)
 			} catch (error) {
 				console.error('Error fetching Talk conversations:', error)


### PR DESCRIPTION
As discussed in https://github.com/nextcloud/spreed/issues/14689

| Before | After |
|--------|--------|
| ![Screenshot from 2025-03-20 16-33-40](https://github.com/user-attachments/assets/6158bdb5-fbae-463b-bbbc-1c34577fd0ce) | ![Screenshot from 2025-03-20 16-34-07](https://github.com/user-attachments/assets/fbc44b53-c9b7-48ba-8051-46a54c919446) |

Test event is a room created by Calendar via the Talk integration.