### PR TITLE
Fix margin when dragging on selected events

### DIFF
--- a/css/fullcalendar.scss
+++ b/css/fullcalendar.scss
@@ -289,7 +289,7 @@
 
 // Leave some space for dragging
 .fc-timeGridDay-view, .fc-timeGridWeek-view {
-	.fc-event-draggable, .fc-event-mirror {
+	.fc-event {
 		width: 90%;
 	}
 


### PR DESCRIPTION
| Before | After |
| - | - |
| ![swappy-20250413_194533](https://github.com/user-attachments/assets/077b6fd8-bf33-4918-9d80-91088d0d63d6) | ![image](https://github.com/user-attachments/assets/f08e096c-3152-46e3-b34c-09b7c25923aa) |

There used to be no margin when clicking on events even though that is the correct behaviour, the margin is needed in order to be able to drag events more easily.