### PR TITLE
fix(editor): show add talk button if there are no attendees yet

### DIFF
--- a/src/views/EditSidebar.vue
+++ b/src/views/EditSidebar.vue
@@ -466,7 +466,7 @@ export default {
 
 		},
 		isCreateTalkRoomButtonVisible() {
-			return this.talkEnabled && !this.isViewedByOrganizer === false
+			return this.talkEnabled && this.isViewedByOrganizer !== false
 		},
 
 	},


### PR DESCRIPTION
Regression from https://github.com/nextcloud/calendar/pull/6809 and https://github.com/nextcloud/calendar/pull/6882


The "Add Talk conversation" button should be shown if there are no attendees yet. It should only be hidden if the given user is an attendee and can't edit the event.