### PR TITLE
[stable5.2] fix(deps): bump @nextcloud/vue to ^8.25.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "calendar",
-      "version": "5.2.0",
+      "version": "5.2.1",
       "license": "agpl",
       "dependencies": {
         "@fullcalendar/core": "6.1.15",
@@ -32,7 +32,7 @@
         "@nextcloud/moment": "^1.3.2",
         "@nextcloud/router": "^3.0.1",
         "@nextcloud/timezones": "^0.1.1",
-        "@nextcloud/vue": "^8.23.1",
+        "@nextcloud/vue": "^8.25.1",
         "autosize": "^6.0.1",
         "color-convert": "^3.0.1",
         "color-string": "^2.0.1",
@@ -3863,9 +3863,9 @@
       }
     },
     "node_modules/@nextcloud/vue": {
-      "version": "8.24.0",
-      "resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-8.24.0.tgz",
-      "integrity": "sha512-eMwV6verEW8j5XrHXDHz/gm+nnfUDKzXccCQFNvlu32fsxInyWVqe/6b2Fn1SkQmuZsa9YY0ejhzmFHjMZ1/1g==",
+      "version": "8.25.1",
+      "resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-8.25.1.tgz",
+      "integrity": "sha512-tePbb9xiM94fkRGqbJXSVuSSseHOem8MS8ulRpmMIWB/g0BqROtigb7VHaVLKAsxgywPN/TqeMeyKFC8cQjptw==",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@floating-ui/dom": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "@nextcloud/moment": "^1.3.2",
     "@nextcloud/router": "^3.0.1",
     "@nextcloud/timezones": "^0.1.1",
-    "@nextcloud/vue": "^8.23.1",
+    "@nextcloud/vue": "^8.25.1",
     "autosize": "^6.0.1",
     "color-convert": "^3.0.1",
     "color-string": "^2.0.1",


### PR DESCRIPTION
Fixes a regression in the avatar component.