### PR TITLE
[stable5.2] Fix npm audit

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "calendar",
-      "version": "5.2.1",
+      "version": "5.2.2",
       "license": "agpl",
       "dependencies": {
         "@fullcalendar/core": "6.1.15",
@@ -2246,18 +2246,6 @@
         "vue": "^2.6.12"
       }
     },
-    "node_modules/@gerrit0/mini-shiki": {
-      "version": "1.27.2",
-      "resolved": "https://registry.npmjs.org/@gerrit0/mini-shiki/-/mini-shiki-1.27.2.tgz",
-      "integrity": "sha512-GeWyHz8ao2gBiUW4OJnQDxXQnFgZQwwQk05t/CVVgNBN7/rK8XZ7xY6YhLVv9tH3VppWWmr9DCl3MwemB/i+Og==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@shikijs/engine-oniguruma": "^1.27.2",
-        "@shikijs/types": "^1.27.2",
-        "@shikijs/vscode-textmate": "^10.0.1"
-      }
-    },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.13.0",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.13.0.tgz",
@@ -3469,35 +3457,35 @@
       }
     },
     "node_modules/@nextcloud/dialogs": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/@nextcloud/dialogs/-/dialogs-6.1.1.tgz",
-      "integrity": "sha512-RrvFPt8SgCkg8rC0PtMC0fvyEu77kKbY2cJ/j+6RLse3rFWcNGwgNZNuRkA/Nn4GgzQ7QNhKTqWknsy0ld6rNQ==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/@nextcloud/dialogs/-/dialogs-6.2.0.tgz",
+      "integrity": "sha512-gV9cf0aLABNEVPoqvBblc0uzKc5hS0xq7dljmLeS52CkW/39nboTCYAyT2FLLth6HiJ7RJ+uUFfNxAWb9Ze74Q==",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@mdi/js": "^7.4.47",
         "@nextcloud/auth": "^2.4.0",
         "@nextcloud/axios": "^2.5.1",
-        "@nextcloud/event-bus": "^3.3.1",
-        "@nextcloud/files": "^3.9.0",
+        "@nextcloud/event-bus": "^3.3.2",
+        "@nextcloud/files": "^3.10.2",
         "@nextcloud/initial-state": "^2.2.0",
-        "@nextcloud/l10n": "^3.1.0",
+        "@nextcloud/l10n": "^3.2.0",
         "@nextcloud/router": "^3.0.1",
         "@nextcloud/sharing": "^0.2.4",
         "@nextcloud/typings": "^1.9.1",
         "@types/toastify-js": "^1.12.3",
-        "@vueuse/core": "^11.2.0",
+        "@vueuse/core": "^11.3.0",
         "cancelable-promise": "^4.3.1",
         "p-queue": "^8.1.0",
         "toastify-js": "^1.12.0",
         "vue-frag": "^1.4.3",
-        "webdav": "^5.7.1"
+        "webdav": "^5.8.0"
       },
       "engines": {
         "node": "^20.0.0",
         "npm": "^10.0.0"
       },
       "peerDependencies": {
-        "@nextcloud/vue": "^8.16.0",
+        "@nextcloud/vue": "^8.23.1",
         "vue": "^2.7.16"
       }
     },
@@ -3677,9 +3665,9 @@
       }
     },
     "node_modules/@nextcloud/files": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/@nextcloud/files/-/files-3.10.1.tgz",
-      "integrity": "sha512-hYUK28ZEU4GTbMXd0/YXTUUKedWnzdr4Eva+6sTxiuJMnACJ4/pZvSzFL9i82fBXvR/0MI5DA6+1gryMyNv1ww==",
+      "version": "3.10.2",
+      "resolved": "https://registry.npmjs.org/@nextcloud/files/-/files-3.10.2.tgz",
+      "integrity": "sha512-8k6zN3nvGW8nEV5Db5DyfqcyK99RWw1iOSPIafi2RttiRQGpFzHlnF2EoM4buH5vWzI39WEvJnfuLZpkPX0cFw==",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@nextcloud/auth": "^2.4.0",
@@ -3688,10 +3676,9 @@
         "@nextcloud/logger": "^3.0.2",
         "@nextcloud/paths": "^2.2.1",
         "@nextcloud/router": "^3.0.1",
-        "@nextcloud/sharing": "^0.2.3",
+        "@nextcloud/sharing": "^0.2.4",
         "cancelable-promise": "^4.3.1",
         "is-svg": "^5.1.0",
-        "typedoc-plugin-missing-exports": "^3.1.0",
         "typescript-event-target": "^1.1.1",
         "webdav": "^5.7.1"
       },
@@ -3863,9 +3850,9 @@
       }
     },
     "node_modules/@nextcloud/vue": {
-      "version": "8.25.1",
-      "resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-8.25.1.tgz",
-      "integrity": "sha512-tePbb9xiM94fkRGqbJXSVuSSseHOem8MS8ulRpmMIWB/g0BqROtigb7VHaVLKAsxgywPN/TqeMeyKFC8cQjptw==",
+      "version": "8.26.0",
+      "resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-8.26.0.tgz",
+      "integrity": "sha512-7KyPAle4/tL2VzR0vVa5ssLAaAlDv54XJ1HPTPw9R4FIyqxDe9lICe1sRNG+uXsRY0NeYIKEmbJ3sqvbxaWdVQ==",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@floating-ui/dom": "^1.1.0",
@@ -4418,45 +4405,6 @@
       "engines": {
         "node": ">=14"
       }
-    },
-    "node_modules/@shikijs/engine-oniguruma": {
-      "version": "1.29.2",
-      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-1.29.2.tgz",
-      "integrity": "sha512-7iiOx3SG8+g1MnlzZVDYiaeHe7Ez2Kf2HrJzdmGwkRisT7r4rak0e655AcM/tF9JG/kg5fMNYlLLKglbN7gBqA==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@shikijs/types": "1.29.2",
-        "@shikijs/vscode-textmate": "^10.0.1"
-      }
-    },
-    "node_modules/@shikijs/types": {
-      "version": "1.29.2",
-      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-1.29.2.tgz",
-      "integrity": "sha512-VJjK0eIijTZf0QSTODEXCqinjBn0joAHQ+aPSBzrv4O2d/QSbsMw+ZeSRx03kV34Hy7NzUvV/7NqfYGRLrASmw==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@shikijs/vscode-textmate": "^10.0.1",
-        "@types/hast": "^3.0.4"
-      }
-    },
-    "node_modules/@shikijs/types/node_modules/@types/hast": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
-      "integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@types/unist": "*"
-      }
-    },
-    "node_modules/@shikijs/vscode-textmate": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-10.0.1.tgz",
-      "integrity": "sha512-fTIQwLF+Qhuws31iw7Ncl1R3HUDtGwIipiJ9iU+UsDUwMhegFcQKQHd51nZjb7CArq0MvON8rbgCGQYWHUKAdg==",
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/@sinclair/typebox": {
       "version": "0.27.8",
@@ -7015,7 +6963,8 @@
     "node_modules/cancelable-promise": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/cancelable-promise/-/cancelable-promise-4.3.1.tgz",
-      "integrity": "sha512-A/8PwLk/T7IJDfUdQ68NR24QHa8rIlnN/stiJEBo6dmVUkD4K14LswG0w3VwdeK/o7qOwRUR1k2MhK5Rpy2m7A=="
+      "integrity": "sha512-A/8PwLk/T7IJDfUdQ68NR24QHa8rIlnN/stiJEBo6dmVUkD4K14LswG0w3VwdeK/o7qOwRUR1k2MhK5Rpy2m7A==",
+      "license": "MIT"
     },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001668",
@@ -8616,6 +8565,7 @@
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
       "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "dev": true,
       "engines": {
         "node": ">=0.12"
       },
@@ -11217,9 +11167,9 @@
       }
     },
     "node_modules/http-proxy-middleware": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.7.tgz",
-      "integrity": "sha512-fgVY8AV7qU7z/MmXJ/rxwbrtQH4jBQ9m7kp3llF0liB7glmFeVZFBepQb32T3y8n8k2+AEYuMPCpinYW+/CuRA==",
+      "version": "2.0.9",
+      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.9.tgz",
+      "integrity": "sha512-c1IyJYLYppU574+YI7R4QyX2ystMtVXZwIdzazUIPIJsHuWNd+mho2j+bKoHftndicGj9yh+xjd+l0yj7VeT1Q==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -14230,16 +14180,6 @@
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "dev": true
     },
-    "node_modules/linkify-it": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
-      "integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "uc.micro": "^2.0.0"
-      }
-    },
     "node_modules/linkify-string": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/linkify-string/-/linkify-string-4.0.2.tgz",
@@ -14360,13 +14300,6 @@
         "yallist": "^2.1.2"
       }
     },
-    "node_modules/lunr": {
-      "version": "2.3.9",
-      "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.9.tgz",
-      "integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==",
-      "license": "MIT",
-      "peer": true
-    },
     "node_modules/makeerror": {
       "version": "1.0.12",
       "resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.12.tgz",
@@ -14388,31 +14321,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/markdown-it": {
-      "version": "14.1.0",
-      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.0.tgz",
-      "integrity": "sha512-a54IwgWPaeBCAAsv13YgmALOF1elABB08FxO9i+r4VFk5Vl4pKokRPeX8u5TCgSsPi6ec1otfLjdOpVcgbpshg==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "argparse": "^2.0.1",
-        "entities": "^4.4.0",
-        "linkify-it": "^5.0.0",
-        "mdurl": "^2.0.0",
-        "punycode.js": "^2.3.1",
-        "uc.micro": "^2.1.0"
-      },
-      "bin": {
-        "markdown-it": "bin/markdown-it.mjs"
-      }
-    },
-    "node_modules/markdown-it/node_modules/argparse": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "license": "Python-2.0",
-      "peer": true
     },
     "node_modules/material-colors": {
       "version": "1.2.6",
@@ -14625,13 +14533,6 @@
       "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.30.tgz",
       "integrity": "sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA==",
       "dev": true
-    },
-    "node_modules/mdurl": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
-      "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/media-typer": {
       "version": "0.3.0",
@@ -16631,16 +16532,6 @@
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
       "dev": true,
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/punycode.js": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
-      "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
-      "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -19715,68 +19606,11 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/typedoc": {
-      "version": "0.27.6",
-      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.27.6.tgz",
-      "integrity": "sha512-oBFRoh2Px6jFx366db0lLlihcalq/JzyCVp7Vaq1yphL/tbgx2e+bkpkCgJPunaPvPwoTOXSwasfklWHm7GfAw==",
-      "license": "Apache-2.0",
-      "peer": true,
-      "dependencies": {
-        "@gerrit0/mini-shiki": "^1.24.0",
-        "lunr": "^2.3.9",
-        "markdown-it": "^14.1.0",
-        "minimatch": "^9.0.5",
-        "yaml": "^2.6.1"
-      },
-      "bin": {
-        "typedoc": "bin/typedoc"
-      },
-      "engines": {
-        "node": ">= 18"
-      },
-      "peerDependencies": {
-        "typescript": "5.0.x || 5.1.x || 5.2.x || 5.3.x || 5.4.x || 5.5.x || 5.6.x || 5.7.x"
-      }
-    },
-    "node_modules/typedoc-plugin-missing-exports": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/typedoc-plugin-missing-exports/-/typedoc-plugin-missing-exports-3.1.0.tgz",
-      "integrity": "sha512-Sogbaj+qDa21NjB3SlIw4JXSwmcl/WOjwiPNaVEcPhpNG/MiRTtpwV81cT7h1cbu9StpONFPbddYWR0KV/fTWA==",
-      "license": "MIT",
-      "peerDependencies": {
-        "typedoc": "0.26.x || 0.27.x"
-      }
-    },
-    "node_modules/typedoc/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/typedoc/node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
-      "license": "ISC",
-      "peer": true,
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/typescript": {
       "version": "5.3.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
       "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
+      "devOptional": true,
       "peer": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -19791,13 +19625,6 @@
       "resolved": "https://registry.npmjs.org/typescript-event-target/-/typescript-event-target-1.1.1.tgz",
       "integrity": "sha512-dFSOFBKV6uwaloBCCUhxlD3Pr/P1a/tJdcmPrTXCHlEFD3faj0mztjcGn6VBAhQ0/Bdy8K3VWrrqwbt/ffsYsg==",
       "license": "MIT"
-    },
-    "node_modules/uc.micro": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
-      "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/unbox-primitive": {
       "version": "1.0.2",
@@ -21354,19 +21181,6 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
       "integrity": "sha512-ncTzHV7NvsQZkYe1DW7cbDLm0YpzHmZF5r/iyP3ZnQtMiJ+pjzisCiMNI+Sj+xQF5pXhSHxSB3uDbsBTzY/c2A==",
       "dev": true
-    },
-    "node_modules/yaml": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.7.0.tgz",
-      "integrity": "sha512-+hSoy/QHluxmC9kCIJyL/uyFmLmc+e5CFR5Wa+bpIhIj85LVb9ZH2nVnqrHoSvKogwODv0ClqZkmiSSaIH5LTA==",
-      "license": "ISC",
-      "peer": true,
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
     },
     "node_modules/yargs": {
       "version": "17.7.1",


### PR DESCRIPTION
# Audit report

This audit fix resolves 12 of the total 22 vulnerabilities found in your project.

## Updated dependencies
* [@nextcloud/dialogs](#user-content-\@nextcloud\/dialogs)
* [@nextcloud/l10n](#user-content-\@nextcloud\/l10n)
* [@nextcloud/moment](#user-content-\@nextcloud\/moment)
* [@nextcloud/webpack-vue-config](#user-content-\@nextcloud\/webpack-vue-config)
* [@vue/component-compiler-utils](#user-content-\@vue\/component-compiler-utils)
* [http-proxy-middleware](#user-content-http-proxy-middleware)
* [node-gettext](#user-content-node-gettext)
* [postcss](#user-content-postcss)
* [v-tooltip](#user-content-v-tooltip)
* [vue-loader](#user-content-vue-loader)
* [vue-resize](#user-content-vue-resize)
* [vue-template-compiler](#user-content-vue-template-compiler)
## Fixed vulnerabilities

### @nextcloud/dialogs <a href="#user-content-\@nextcloud\/dialogs" id="\@nextcloud\/dialogs">#</a>
* Caused by vulnerable dependency:
  * [@nextcloud/vue](#user-content-\@nextcloud\/vue)
  * [vue](#user-content-vue)
  * [vue-frag](#user-content-vue-frag)
* Affected versions: >=4.2.0-beta.1
* Package usage:
  * `node_modules/@nextcloud/dialogs`

### @nextcloud/l10n <a href="#user-content-\@nextcloud\/l10n" id="\@nextcloud\/l10n">#</a>
* Caused by vulnerable dependency:
  * [node-gettext](#user-content-node-gettext)
* Affected versions: 1.1.0 - 3.1.0
* Package usage:
  * `node_modules/@nextcloud/moment/node_modules/@nextcloud/l10n`

### @nextcloud/moment <a href="#user-content-\@nextcloud\/moment" id="\@nextcloud\/moment">#</a>
* Caused by vulnerable dependency:
  * [@nextcloud/l10n](#user-content-\@nextcloud\/l10n)
  * [node-gettext](#user-content-node-gettext)
* Affected versions: >=1.1.1
* Package usage:
  * `node_modules/@nextcloud/moment`

### @nextcloud/webpack-vue-config <a href="#user-content-\@nextcloud\/webpack-vue-config" id="\@nextcloud\/webpack-vue-config">#</a>
* Caused by vulnerable dependency:
  * [vue](#user-content-vue)
  * [vue-loader](#user-content-vue-loader)
  * [vue-template-compiler](#user-content-vue-template-compiler)
* Affected versions: <=6.2.0
* Package usage:
  * `node_modules/@nextcloud/webpack-vue-config`

### @vue/component-compiler-utils <a href="#user-content-\@vue\/component-compiler-utils" id="\@vue\/component-compiler-utils">#</a>
* Caused by vulnerable dependency:
  * [postcss](#user-content-postcss)
* Affected versions: *
* Package usage:
  * `node_modules/@vue/component-compiler-utils`

### http-proxy-middleware <a href="#user-content-http-proxy-middleware" id="http-proxy-middleware">#</a>
* http-proxy-middleware allows fixRequestBody to proceed even if bodyParser has failed
* Severity: **moderate** (CVSS 4)
* Reference: [https://github.com/advisories/GHSA-9gqv-wp59-fq42](https://github.com/advisories/GHSA-9gqv-wp59-fq42)
* Affected versions: 1.3.0 - 2.0.8
* Package usage:
  * `node_modules/http-proxy-middleware`

### node-gettext <a href="#user-content-node-gettext" id="node-gettext">#</a>
* node-gettext vulnerable to Prototype Pollution
* Severity: **high** (CVSS 5.9)
* Reference: [https://github.com/advisories/GHSA-g974-hxvm-x689](https://github.com/advisories/GHSA-g974-hxvm-x689)
* Affected versions: *
* Package usage:
  * `node_modules/node-gettext`

### postcss <a href="#user-content-postcss" id="postcss">#</a>
* PostCSS line return parsing error
* Severity: **moderate** (CVSS 5.3)
* Reference: [https://github.com/advisories/GHSA-7fh5-64p2-3v2j](https://github.com/advisories/GHSA-7fh5-64p2-3v2j)
* Affected versions: <8.4.31
* Package usage:
  * `node_modules/@vue/component-compiler-utils/node_modules/postcss`

### v-tooltip <a href="#user-content-v-tooltip" id="v-tooltip">#</a>
* Caused by vulnerable dependency:
  * [vue-resize](#user-content-vue-resize)
* Affected versions: 2.0.0-beta.1 - 4.0.0-beta.0
* Package usage:
  * `node_modules/v-tooltip`

### vue-loader <a href="#user-content-vue-loader" id="vue-loader">#</a>
* Caused by vulnerable dependency:
  * [@vue/component-compiler-utils](#user-content-\@vue\/component-compiler-utils)
* Affected versions: 15.0.0-beta.1 - 15.11.1
* Package usage:
  * `node_modules/vue-loader`

### vue-resize <a href="#user-content-vue-resize" id="vue-resize">#</a>
* Caused by vulnerable dependency:
  * [vue](#user-content-vue)
* Affected versions: 0.4.0 - 1.0.1
* Package usage:
  * `node_modules/vue-resize`

### vue-template-compiler <a href="#user-content-vue-template-compiler" id="vue-template-compiler">#</a>
* vue-template-compiler vulnerable to client-side Cross-Site Scripting (XSS)
* Severity: **moderate** (CVSS 4.2)
* Reference: [https://github.com/advisories/GHSA-g3ch-rx76-35fx](https://github.com/advisories/GHSA-g3ch-rx76-35fx)
* Affected versions: >=2.0.0
* Package usage:
  * `node_modules/vue-template-compiler`