### PR TITLE
fix: trashbin error toast wording when deleting items

### DIFF
--- a/src/components/AppNavigation/CalendarList/Trashbin.vue
+++ b/src/components/AppNavigation/CalendarList/Trashbin.vue
@@ -227,9 +227,9 @@ export default {
 					break
 				}
 			} catch (error) {
-				logger.error('could not restore ' + item.url, { error })
+				logger.error('could not delete ' + item.url, { error })
 
-				showError(t('calendar', 'Could not restore calendar or event'))
+				showError(t('calendar', 'Could not delete calendar or event'))
 			}
 		},
 		async restore(item) {


### PR DESCRIPTION
This seems to be a copy/paste error.

1. Delete an event.
2. Open the trash bin and permanently delete it.
3. Observe the invalid toast message.

**Before:** Could not restore calendar or event
**After:** Could not delete calendar or event