### PR TITLE
fix(appointments): mobile booking view not being responsive

### DIFF
--- a/src/views/Appointments/Booking.vue
+++ b/src/views/Appointments/Booking.vue
@@ -4,7 +4,7 @@
 -->
 
 <template>
-	<NcGuestContent>
+	<NcGuestContent class="booking-wrapper">
 		<div v-if="!selectedSlot && !bookingConfirmed" class="booking">
 			<div class="booking__config-user-info">
 				<Avatar :user="userInfo.uid"
@@ -251,8 +251,13 @@ export default {
 </script>
 
 <style lang="scss" scoped>
+.booking-wrapper {
+	display: flex;
+}
+
 .booking {
 	display: flex;
+	flex: 1 auto;
 	flex-direction: row;
 	flex-wrap: wrap;
 	width: 900px;


### PR DESCRIPTION
Closes https://github.com/nextcloud/calendar/pull/6948 (alternative to)
Resolves https://github.com/nextcloud/calendar/issues/6771

## How to test?

1. Create an appointment config.
2. Click on "Preview".
3. Switch to a mobile layout.
4. Observe that the layout is broken and unusable.

## Screenshots

| Before | After |
| --- | --- |
| ![image](https://github.com/user-attachments/assets/ac126259-8cf7-40ed-aba1-aaa507ccccdf) | ![image](https://github.com/user-attachments/assets/1857d093-a772-4115-94fd-177eb13a4e42) |