### PR TITLE
Fix timepicker not adjusting end date

### DIFF
--- a/src/mixins/EditorMixin.js
+++ b/src/mixins/EditorMixin.js
@@ -627,7 +627,7 @@ export default {
 				calendarObjectInstance: this.calendarObjectInstance,
 				startDate,
 				onlyTime: true,
-				changeEndDate: false,
+				changeEndDate: true,
 			})
 		},
 		/**


### PR DESCRIPTION
Regression after https://github.com/nextcloud/calendar/pull/6888

To test: have an event with different start and end times, change start time, end time should also change to be the same interval as before