### PR TITLE
fix: adjust populating of Talk room

### DIFF
--- a/src/services/talkService.js
+++ b/src/services/talkService.js
@@ -91,9 +91,12 @@ export async function updateTalkParticipants(eventComponent) {
 			const participantId = removeMailtoPrefix(attendee.email)
 			try {
 				// Map attendee email to Nextcloud user uid
-				const searchResult = await HTTPClient.get(generateOcsUrl('core/autocomplete/', 2) + 'get?search=' + encodeURIComponent(participantId) + '&itemType=&itemId=%20&shareTypes[]=0&limit=2')
+				const searchResult = await HTTPClient.get(generateOcsUrl('core/autocomplete/', 2) + 'get?search=' + encodeURIComponent(attendee.commonName ?? participantId) + '&itemType=&itemId=%20&shareTypes[]=0&limit=2')
 				// Only map if there is exactly one result
-				if (searchResult.data.ocs.data.length === 1 && searchResult.data.ocs.data[0].id !== getCurrentUser().uid) {
+				if (searchResult.data.ocs.data.length === 1
+					&& searchResult.data.ocs.data[0].id !== getCurrentUser().uid
+					&& searchResult.data.ocs.data[0].shareWithDisplayNameUnique === participantId
+				) {
 					await HTTPClient.post(generateOcsUrl('apps/spreed/api/' + apiVersion + '/', 2) + 'room/' + token + '/participants', {
 						newParticipant: searchResult.data.ocs.data[0].id,
 						source: 'users',


### PR DESCRIPTION
Fix adding of attendees into Talk event rooms by displayed name (`commonName`) instead of email

GET request `/core/autocomplete` does not handle emails, but user ids and display name, so could be a better substitution
Also search result contains email in 'shareWithDisplayNameUnique' field, so can be compared with event attendee to match before saving
In worst case search result will be ignored and function falls back to email attendee (as in Before)

Before | After
-- | --
<img width="210" alt="2025-05-16_14h45_01" src="https://github.com/user-attachments/assets/15116710-3ea3-4d91-a010-54f457f50a2d" /> | <img width="209" alt="2025-05-16_14h45_08" src="https://github.com/user-attachments/assets/5552eede-78ec-4827-98f9-689f6abe761b" />
