### PR TITLE
fix: reduce long press event delay to 500 ms

### DIFF
--- a/src/components/CalendarGrid.vue
+++ b/src/components/CalendarGrid.vue
@@ -118,6 +118,7 @@ export default {
 				navLinkWeekClick: this.isWidget ? false : navLinkWeekClick(this.$router, this.$route),
 				select: this.isWidget ? false : select(this.$router, this.$route, window),
 				navLinks: true,
+				selectLongPressDelay: 500,
 				// Localization
 				...getDateFormattingConfig(),
 				...getFullCalendarLocale(),


### PR DESCRIPTION
~Fixes creating events on touch devices. Try to tap or tap-and-drag on the grid to create an event.~

Reduces the duration for long presses on touch devices when creating new events from 1 to 0.5 seconds.

Can be reproduced on phones or on desktop browsers using the developer tools.

Ref https://fullcalendar.io/docs/longPressDelay