### PR TITLE
ci(appstore-conventional-build-publish): fix wget output flag

### DIFF
--- a/.github/workflows/appstore-conventional-build-publish.yml
+++ b/.github/workflows/appstore-conventional-build-publish.yml
@@ -90,7 +90,7 @@ jobs:
         id: server-checkout
         run: |
           NCVERSION=${{ fromJSON(steps.appinfo.outputs.result).nextcloud.min-version }}
-          wget https://download.nextcloud.com/server/releases/latest-$NCVERSION.zip -o build/nextcloud.zip
+          wget https://download.nextcloud.com/server/releases/latest-$NCVERSION.zip -O build/nextcloud.zip
           unzip build/nextcloud.zip build/nextcloud
 
       - name: Checkout server master fallback


### PR DESCRIPTION
Spotted by @SebastianKrupinski 

Doesn't break the release because we have a server/master fallback but should be fixed.