### PR TITLE
fix: handle missing organizer gracefully when fetching room suggestions

### DIFF
--- a/src/components/Editor/Resources/ResourceList.vue
+++ b/src/components/Editor/Resources/ResourceList.vue
@@ -108,6 +108,10 @@ export default {
 			return !!emailAddress
 		},
 		isViewedByOrganizer() {
+			if (!this.calendarObjectInstance.organizer) {
+				return true
+			}
+
 			const organizerEmail = removeMailtoPrefix(this.calendarObjectInstance.organizer.uri)
 			return organizerEmail === this.principalsStore.getCurrentUserPrincipalEmail
 		},


### PR DESCRIPTION
Removes a console warning like `[Vue warn]: Error in render: "TypeError: can't access property "uri", this.calendarObjectInstance.organizer is null"` whenever the last attendee is removed from an event.