### PR TITLE
[stable5.3] Fix npm audit

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "calendar",
-      "version": "5.3.0",
+      "version": "5.3.1",
       "license": "agpl",
       "dependencies": {
         "@fullcalendar/core": "6.1.17",
@@ -11023,24 +11023,6 @@
         "node": ">=12"
       }
     },
-    "node_modules/html-entities": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.5.2.tgz",
-      "integrity": "sha512-K//PSRMQk4FZ78Kyau+mZurHn3FH0Vwr+H36eE0rPbeYkRRi9YxceYPhuN60UwWorxyKHhqoAJl2OFKa4BVtaA==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/mdevils"
-        },
-        {
-          "type": "patreon",
-          "url": "https://patreon.com/mdevils"
-        }
-      ],
-      "license": "MIT",
-      "peer": true
-    },
     "node_modules/html-escaper": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
@@ -20661,9 +20643,9 @@
       }
     },
     "node_modules/webpack-dev-server": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-5.1.0.tgz",
-      "integrity": "sha512-aQpaN81X6tXie1FoOB7xlMfCsN19pSvRAeYUHOdFWOlhpQ/LlbfTqYwwmEDFV0h8GGuqmCmKmT+pxcUV/Nt2gQ==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-5.2.2.tgz",
+      "integrity": "sha512-QcQ72gh8a+7JO63TAx/6XZf/CWhgMzu5m0QirvPfGvptOusAxG12w2+aua1Jkjr7hzaWDnJ2n6JFeexMHI+Zjg==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -20671,6 +20653,7 @@
         "@types/bonjour": "^3.5.13",
         "@types/connect-history-api-fallback": "^1.5.4",
         "@types/express": "^4.17.21",
+        "@types/express-serve-static-core": "^4.17.21",
         "@types/serve-index": "^1.9.4",
         "@types/serve-static": "^1.15.5",
         "@types/sockjs": "^0.3.36",
@@ -20681,10 +20664,9 @@
         "colorette": "^2.0.10",
         "compression": "^1.7.4",
         "connect-history-api-fallback": "^2.0.0",
-        "express": "^4.19.2",
+        "express": "^4.21.2",
         "graceful-fs": "^4.2.6",
-        "html-entities": "^2.4.0",
-        "http-proxy-middleware": "^2.0.3",
+        "http-proxy-middleware": "^2.0.9",
         "ipaddr.js": "^2.1.0",
         "launch-editor": "^2.6.1",
         "open": "^10.0.3",
@@ -20717,6 +20699,20 @@
         "webpack-cli": {
           "optional": true
         }
+      }
+    },
+    "node_modules/webpack-dev-server/node_modules/@types/express-serve-static-core": {
+      "version": "4.19.6",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.19.6.tgz",
+      "integrity": "sha512-N4LZ2xG7DatVqhCZzOGb1Yi5lMbXSZcmdLDe9EzSndPV2HpWYWzRbaerl2n27irrm94EPpprqa8KpskPT085+A==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/node": "*",
+        "@types/qs": "*",
+        "@types/range-parser": "*",
+        "@types/send": "*"
       }
     },
     "node_modules/webpack-dev-server/node_modules/chokidar": {


### PR DESCRIPTION
# Audit report

This audit fix resolves 9 of the total 19 vulnerabilities found in your project.

## Updated dependencies
* [@nextcloud/dialogs](#user-content-\@nextcloud\/dialogs)
* [@nextcloud/webpack-vue-config](#user-content-\@nextcloud\/webpack-vue-config)
* [@vue/component-compiler-utils](#user-content-\@vue\/component-compiler-utils)
* [postcss](#user-content-postcss)
* [v-tooltip](#user-content-v-tooltip)
* [vue-loader](#user-content-vue-loader)
* [vue-resize](#user-content-vue-resize)
* [vue-template-compiler](#user-content-vue-template-compiler)
* [webpack-dev-server](#user-content-webpack-dev-server)
## Fixed vulnerabilities

### @nextcloud/dialogs <a href="#user-content-\@nextcloud\/dialogs" id="\@nextcloud\/dialogs">#</a>
* Caused by vulnerable dependency:
  * [@nextcloud/vue](#user-content-\@nextcloud\/vue)
  * [vue](#user-content-vue)
  * [vue-frag](#user-content-vue-frag)
* Affected versions: 4.2.0-beta.1 - 6.3.0
* Package usage:
  * `node_modules/@nextcloud/dialogs`

### @nextcloud/webpack-vue-config <a href="#user-content-\@nextcloud\/webpack-vue-config" id="\@nextcloud\/webpack-vue-config">#</a>
* Caused by vulnerable dependency:
  * [vue](#user-content-vue)
  * [vue-loader](#user-content-vue-loader)
  * [vue-template-compiler](#user-content-vue-template-compiler)
* Affected versions: <=6.2.0
* Package usage:
  * `node_modules/@nextcloud/webpack-vue-config`

### @vue/component-compiler-utils <a href="#user-content-\@vue\/component-compiler-utils" id="\@vue\/component-compiler-utils">#</a>
* Caused by vulnerable dependency:
  * [postcss](#user-content-postcss)
* Affected versions: *
* Package usage:
  * `node_modules/@vue/component-compiler-utils`

### postcss <a href="#user-content-postcss" id="postcss">#</a>
* PostCSS line return parsing error
* Severity: **moderate** (CVSS 5.3)
* Reference: [https://github.com/advisories/GHSA-7fh5-64p2-3v2j](https://github.com/advisories/GHSA-7fh5-64p2-3v2j)
* Affected versions: <8.4.31
* Package usage:
  * `node_modules/@vue/component-compiler-utils/node_modules/postcss`

### v-tooltip <a href="#user-content-v-tooltip" id="v-tooltip">#</a>
* Caused by vulnerable dependency:
  * [vue-resize](#user-content-vue-resize)
* Affected versions: 2.0.0-beta.1 - 4.0.0-beta.0
* Package usage:
  * `node_modules/v-tooltip`

### vue-loader <a href="#user-content-vue-loader" id="vue-loader">#</a>
* Caused by vulnerable dependency:
  * [@vue/component-compiler-utils](#user-content-\@vue\/component-compiler-utils)
* Affected versions: 15.0.0-beta.1 - 15.11.1
* Package usage:
  * `node_modules/vue-loader`

### vue-resize <a href="#user-content-vue-resize" id="vue-resize">#</a>
* Caused by vulnerable dependency:
  * [vue](#user-content-vue)
* Affected versions: 0.4.0 - 1.0.1
* Package usage:
  * `node_modules/vue-resize`

### vue-template-compiler <a href="#user-content-vue-template-compiler" id="vue-template-compiler">#</a>
* vue-template-compiler vulnerable to client-side Cross-Site Scripting (XSS)
* Severity: **moderate** (CVSS 4.2)
* Reference: [https://github.com/advisories/GHSA-g3ch-rx76-35fx](https://github.com/advisories/GHSA-g3ch-rx76-35fx)
* Affected versions: >=2.0.0
* Package usage:
  * `node_modules/vue-template-compiler`

### webpack-dev-server <a href="#user-content-webpack-dev-server" id="webpack-dev-server">#</a>
* webpack-dev-server users' source code may be stolen when they access a malicious web site with non-Chromium based browser
* Severity: **moderate** (CVSS 6.5)
* Reference: [https://github.com/advisories/GHSA-9jgg-88mc-972h](https://github.com/advisories/GHSA-9jgg-88mc-972h)
* Affected versions: <=5.2.0
* Package usage:
  * `node_modules/webpack-dev-server`