### PR TITLE
perf: don't load ContactsMenuScript when not logged in

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -78,7 +78,11 @@ class Application extends App implements IBootstrap {
 		// TODO: drop condition once we only support Nextcloud >= 31
 		if ($serverVersion->getMajorVersion() >= 31) {
 			// The contacts menu/avatar is potentially shown everywhere so an event based loading
-			// mechanism doesn't make sense here
+			// mechanism doesn't make sense here - well, maybe not when not logged in yet :-)
+			$userSession = $this->getContainer()->get(IUserSession::class);
+			if (!$userSession->isLoggedIn()) {
+				return;
+			}
 			Util::addScript(self::APP_ID, 'calendar-contacts-menu');
 		}
 	}


### PR DESCRIPTION
Not sure how this interacts with guests, but I don't think #6502 currently works with guests anyhow.

Cuts at at least ~700 kB from the initial JS assets that are loaded when visiting `/login`