### PR TITLE
Make attendee participation status not ellipse early

### DIFF
--- a/css/app-full.scss
+++ b/css/app-full.scss
@@ -661,3 +661,10 @@ textarea {
 .property-select__input {
 	height: 34px;
 }
+
+.app-full .avatar-participation-status__text {
+	bottom: -1px !important;
+	position: absolute !important;
+	max-width: min(calc(100vw - 130px), 500px) !important;
+	min-width: unset !important;
+}

--- a/src/components/Editor/AvatarParticipationStatus.vue
+++ b/src/components/Editor/AvatarParticipationStatus.vue
@@ -235,7 +235,7 @@ export default {
 	bottom: 21px;
 	white-space: nowrap;
 	position: relative;
-	min-width: 220px;
+	min-width: 420px;
 	text-overflow: ellipsis;
 	overflow: hidden;
 }


### PR DESCRIPTION
| Before | After | 
| - | - | 
| <img width="518" height="379" alt="image" src="https://github.com/user-attachments/assets/77872456-2e32-42eb-b462-e6ea2f334336" /> | <img width="508" height="370" alt="image" src="https://github.com/user-attachments/assets/b7f08772-687b-49de-ae67-d0b6e526a425" /> |
| <img width="623" height="221" alt="image" src="https://github.com/user-attachments/assets/80f68cb7-f872-4a98-8715-72286d0fed83" /> | <img width="623" height="215" alt="image" src="https://github.com/user-attachments/assets/c411cd0c-ae30-405c-82d2-61c78f3d87cd" /> |

I had to change the position style for the full page modal view, seeing as in that case there are two different cases, one in which the columns have their full width (`500px` max width), or in responsive mode when they become compressed (`calc(100vw - 130px)`).

The `position: absolute` is needed to prevent having a wider content than the viewframe. (with relative position, it started pushing other components out).