### PR TITLE
fix: show time zone selector

### DIFF
--- a/src/components/Editor/Properties/PropertyTitleTimePicker.vue
+++ b/src/components/Editor/Properties/PropertyTitleTimePicker.vue
@@ -14,7 +14,7 @@
 			class="property-title-time-picker__time-pickers">
 			<div :class="{ 'property-title-time-picker__time-pickers--all-day': isAllDay}"
 				class="property-title-time-picker__time-pickers__inner">
-				<NcButton v-if="!showTimezoneSelect && !isAllDay && isMobile"
+				<NcButton v-if="!showTimezoneSelect && (!isAllDay || isMobile)"
 					type="tertiary"
 					@click="showTimezoneSelect = !showTimezoneSelect">
 					<template>


### PR DESCRIPTION
## Issue
When 10 people review a feature and no one thinks of changing the time zone of a new event. 

## Resolution
- Modified logic to make time zone selector show properly when event is NOT all day.

### Before
<img width="512" height="291" alt="image" src="https://github.com/user-attachments/assets/463c330f-da90-4175-93da-13f32317cfb4" />

### After
<img width="525" height="293" alt="image" src="https://github.com/user-attachments/assets/869d8e05-b8e9-4b55-ab05-6b23f4c299d4" />
