### PR TITLE
Adjust CI after branching-off `stable5.4`

### DIFF
--- a/.github/workflows/npm-audit-fix.yml
+++ b/.github/workflows/npm-audit-fix.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        branches: ['main', 'stable5.3', 'stable4.7']
+        branches: ['main', 'stable5.4', 'stable5.3', 'stable4.7']
 
     name: npm-audit-fix-${{ matrix.branches }}
 

--- a/.tx/backport
+++ b/.tx/backport
@@ -1,1 +1,2 @@
 stable5.3
+stable5.4


### PR DESCRIPTION
Follow-up to the recent branch-off. We forgot about those two changes.