### PR TITLE
chore(jest): do not collect coverage from *.d.ts files

### DIFF
--- a/package.json
+++ b/package.json
@@ -140,6 +140,7 @@
     "collectCoverage": true,
     "collectCoverageFrom": [
       "<rootDir>/src/**/*.{js,ts,vue}",
+      "!<rootDir>/src/**/*.d.ts",
       "!**/node_modules/**"
     ],
     "coverageReporters": [


### PR DESCRIPTION
This is not broken or anything but prevents annoying errors like:

```
Running coverage on untested files...Failed to collect coverage from /home/richard/src/nextcloud/master/dev_apps/calendar/src/env.d.ts
ERROR: /home/richard/src/nextcloud/master/dev_apps/calendar/src/env.d.ts: Unexpected token, expected "from" (6:12)
```

Jest is not able to parse `*.d.ts` files when collecting coverage.

Follow-up to #7077 