### PR TITLE
fix(free-busy): use own calendar color for organiser busy blocks

### DIFF
--- a/src/components/Editor/FreeBusy/FreeBusy.vue
+++ b/src/components/Editor/FreeBusy/FreeBusy.vue
@@ -563,6 +563,10 @@ export default {
 			if (e.el.classList.contains('free-busy-busy-unavailable--organizer')) {
 				return
 			}
+			if (e.el.classList.contains('free-busy-organizer')) {
+				eventElement.style.background = `repeating-linear-gradient(45deg, ${this.personalCalendarColor}, ${this.personalCalendarColor} 1px, transparent 1px, transparent 3.5px)`
+				return
+			}
 			const color = uidToHexColor(e.event.title)
 			eventElement.style.background = `repeating-linear-gradient(45deg, ${color}, ${color} 1px, transparent 1px, transparent 3.5px)`
 		},

--- a/src/fullcalendar/eventSources/freeBusyResourceEventSourceFunction.js
+++ b/src/fullcalendar/eventSources/freeBusyResourceEventSourceFunction.js
@@ -55,6 +55,7 @@ export default function(uri, calendarData, success, start, end, timezone, attend
 			display: 'auto',
 			classNames: [
 				'free-busy-block',
+				isOrganizer ? 'free-busy-organizer' : '',
 				'free-busy-' + freeBusyProperty.type.toLowerCase(),
 				isOrganizer && freeBusyProperty.type === 'BUSY-UNAVAILABLE' ? 'free-busy-busy-unavailable--organizer' : '',
 			],


### PR DESCRIPTION
| b | a |
|--------|--------|
|<img width="1373" height="886" alt="image" src="https://github.com/user-attachments/assets/66fad863-dbe1-4edb-8a20-8f7b2dd154fa" /> |<img width="1373" height="886" alt="image" src="https://github.com/user-attachments/assets/3e2f937c-d591-4a28-8092-0bf3d0c22f45" /> | 