### PR TITLE
fix: redirect sidebar editor route for activity deep links

### DIFF
--- a/src/router.js
+++ b/src/router.js
@@ -121,6 +121,14 @@ const router = new Router({
 					name: 'EditFullView',
 					component: EditFull,
 				},
+				// Redirect the old sidebar route until Calendar drops support for Nextcloud < 32
+				// Ref https://github.com/nextcloud/server/pull/52410
+				{
+					path: '/:view/:firstDay/edit/sidebar/:object/:recurrenceId',
+					redirect: {
+						name: 'EditFullView',
+					},
+				},
 				{
 					path: '/:view/:firstDay/new/popover/:allDay/:dtstart/:dtend',
 					name: 'NewPopoverView',


### PR DESCRIPTION
## How to reproduce?

1. Checkout Nextcloud `stable30` or `stable31`.
2. Create an event.
3. Open the activity app and click on a event link.

**Before:** Calendar app is not rendered.
**After:** Calendar app is rendered and shows full page editor of that event.