### PR TITLE
fix: fix compiler SCSS warning

### DIFF
--- a/src/components/Editor/FreeBusy/FreeBusy.vue
+++ b/src/components/Editor/FreeBusy/FreeBusy.vue
@@ -741,16 +741,16 @@ export default {
 			}
 		}
 		&__title{
-			&--mobile{
-				width: 100%;
-				margin: 0;
-			}
 			display: flex;
 			justify-content: space-between;
 			align-items: center;
 			margin-bottom: calc(var(--default-grid-baseline) * 4);
 			width: calc(100% - 260px);
 			margin-inline-start: 260px;
+			&--mobile{
+				width: 100%;
+				margin: 0;
+			}
 			h2{
 				font-weight: 500;
 				margin: 0;


### PR DESCRIPTION
Before:

<img width="1920" height="1032" alt="image" src="https://github.com/user-attachments/assets/49a8fdbb-927c-4234-8be6-4c15aa5abf9c" />

After:

<img width="1920" height="1032" alt="image" src="https://github.com/user-attachments/assets/293de07f-f9d5-495d-9bed-44eb878954f5" />
