### PR TITLE
fix: match main route more strictly to prevent conflicts in the contacts menu

### DIFF
--- a/src/router.js
+++ b/src/router.js
@@ -107,7 +107,7 @@ const router = new Router({
 		 * It has to be last, so that other routes starting with /p/, etc. match first
 		 */
 		{
-			path: '/:view/:firstDay',
+			path: '/:view([a-zA-Z]+)/:firstDay(now|[0-9]+-[0-9]{2}-[0-9]{2})',
 			component: Calendar,
 			name: 'CalendarView',
 			children: [


### PR DESCRIPTION
Fix #7170 

## How to reproduce?

1. Have two users: user-a and user-b
2. Share user-a's calendar with user-b.
3. Open the calendar app as user-b
4. Open the three-dot menu of the incoming shared calendar.
5. click on the avatar of the sharer (three-dot menu should appear on hover).
6. Click on `View profile`.

**Before:** Opens an invalid URL `/apps/calendar/u/user-a`
**After:** Opens the profile at `/u/user-a`