### PR TITLE
fix: make absolute URL generation more robust

### DIFF
--- a/__mocks__/@nextcloud/calendar-availability-vue/index.js
+++ b/__mocks__/@nextcloud/calendar-availability-vue/index.js
@@ -1,0 +1,7 @@
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+export {
+}

--- a/src/fullcalendar/interaction/eventClick.js
+++ b/src/fullcalendar/interaction/eventClick.js
@@ -110,5 +110,5 @@ function handleToDoClick(event, route, window, isWidget = false) {
 		return
 	}
 	const url = `apps/tasks/calendars/${calendarId}/tasks/${taskId}`
-	window.location = window.location.protocol + '//' + window.location.host + generateUrl(url)
+	window.location.href = generateUrl(url)
 }

--- a/src/models/appointmentConfig.js
+++ b/src/models/appointmentConfig.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-import { generateUrl } from '@nextcloud/router'
+import { generateUrl, getBaseUrl } from '@nextcloud/router'
 import {
 	getEmptySlots,
 	vavailabilityToSlots,
@@ -175,11 +175,11 @@ export default class AppointmentConfig {
 	 * @return {string} Absolute URL
 	 */
 	get bookingUrl() {
-		const baseUrl = `${window.location.protocol}//${window.location.hostname}`
-		const relativeUrl = generateUrl('/apps/calendar/appointment/{token}', {
+		return generateUrl('/apps/calendar/appointment/{token}', {
 			token: this.token,
+		}, {
+			baseURL: getBaseUrl(),
 		})
-		return baseUrl + relativeUrl
 	}
 
 }

--- a/src/services/talkService.js
+++ b/src/services/talkService.js
@@ -4,7 +4,7 @@
  */
 import HTTPClient from '@nextcloud/axios'
 import { translate as t } from '@nextcloud/l10n'
-import { generateUrl, generateOcsUrl } from '@nextcloud/router'
+import { generateUrl, generateOcsUrl, getBaseUrl } from '@nextcloud/router'
 import { loadState } from '@nextcloud/initial-state'
 import { getCurrentUser } from '@nextcloud/auth'
 import logger from '../utils/logger.js'
@@ -144,7 +144,9 @@ export function doesContainTalkLink(text) {
  * @return {string}
  */
 export function generateURLForToken(token = '') {
-	return window.location.protocol + '//' + window.location.host + generateUrl('/call/' + token)
+	return generateUrl('/call/' + token, {}, {
+		baseURL: getBaseUrl(),
+	})
 }
 
 /**

--- a/tests/javascript/unit/fullcalendar/interaction/eventClick.test.js
+++ b/tests/javascript/unit/fullcalendar/interaction/eventClick.test.js
@@ -325,7 +325,7 @@ describe('fullcalendar/eventClick test suite', () => {
 		expect(generateUrl).toHaveBeenCalledTimes(1)
 		expect(generateUrl).toHaveBeenNthCalledWith(1, 'apps/tasks/calendars/reminders/tasks/EAFB112A-4556-404A-B807-B1E040D0F7A0.ics')
 
-		expect(window.location).toEqual('http://nextcloud.testing/generated-url')
+		expect(window.location.href).toEqual('/generated-url')
 	})
 
 	it('should do nothing when tasks is disabled and route is public', () => {

--- a/tests/javascript/unit/models/appointmentConfig.test.js
+++ b/tests/javascript/unit/models/appointmentConfig.test.js
@@ -1,0 +1,46 @@
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import AppointmentConfig from '../../../../src/models/appointmentConfig.js'
+
+describe('models/appointmentConfig test suite', () => {
+	let windowSpy
+
+	beforeEach(() => {
+		windowSpy = jest.spyOn(window, 'window', 'get')
+	})
+
+	afterEach(() => {
+		windowSpy.mockRestore()
+	})
+
+	test.each([
+		[
+			{ protocol: 'https:', host: 'nextcloud.testing' },
+			'https://nextcloud.testing/nextcloud/index.php/apps/calendar/appointment/foobar'
+		],
+		[
+			{ protocol: 'http:', host: 'nextcloud.testing' },
+			'http://nextcloud.testing/nextcloud/index.php/apps/calendar/appointment/foobar',
+		],
+		[
+			{ protocol: 'https:', host: 'nextcloud.testing:8443' },
+			'https://nextcloud.testing:8443/nextcloud/index.php/apps/calendar/appointment/foobar',
+		],
+		[
+			{ protocol: 'http:', host: 'nextcloud.testing:8080' },
+			'http://nextcloud.testing:8080/nextcloud/index.php/apps/calendar/appointment/foobar',
+		],
+	])('should generate absolute URLs', (location, expected) => {
+		windowSpy.mockImplementation(() => ({
+			location,
+			_oc_webroot: '/nextcloud',
+		}))
+		const config = new AppointmentConfig({
+			token: 'foobar',
+		})
+		expect(config.bookingUrl).toBe(expected)
+	})
+})


### PR DESCRIPTION
Leverage getBaseUrl() of `@nextcloud/router`.

Problems: Instances with a custom port, for example, HTTPS on 8443.