### PR TITLE
fix(free-busy): adjust event title color to nextcloud theme

### DIFF
--- a/src/components/Editor/FreeBusy/FreeBusy.vue
+++ b/src/components/Editor/FreeBusy/FreeBusy.vue
@@ -520,7 +520,7 @@ export default {
 			title: 'Selected slot',
 			start: this.currentStart,
 			end: this.currentEnd,
-			textColor: '#fff',
+			textColor: 'var(--color-main-text)',
 			backgroundColor: 'rgba(0, 0, 0, 0)',
 			editable: true,
 			overlap: true,

--- a/src/fullcalendar/eventSources/freeBusyResourceEventSourceFunction.js
+++ b/src/fullcalendar/eventSources/freeBusyResourceEventSourceFunction.js
@@ -60,7 +60,7 @@ export default function(uri, calendarData, success, start, end, timezone, attend
 				isOrganizer && freeBusyProperty.type === 'BUSY-UNAVAILABLE' ? 'free-busy-busy-unavailable--organizer' : '',
 			],
 			title: attendeeName,
-			textColor: '#FFFFFF',
+			textColor: 'var(--color-main-text)',
 		})
 	}
 


### PR DESCRIPTION
| b | a |
|--------|--------|
|<img width="382" height="237" alt="image" src="https://github.com/user-attachments/assets/557227f6-ad72-44f3-933b-879bb12f250a" /> |<img width="394" height="238" alt="image" src="https://github.com/user-attachments/assets/78ffaa52-a9ad-4b0f-a9ec-2bc16aed9b9e" /> | 

Edit : don't mind the event color change from yellow to pink, unrelated 