### PR TITLE
fix(ui): scope mobile css rules for full editor

### DIFF
--- a/css/app-full.scss
+++ b/css/app-full.scss
@@ -51,20 +51,6 @@
 	}
 }
 
-@media screen and (max-width: 785px) {
-	.app-full__header__top {
-		gap: calc(var(--default-grid-baseline) * 2) !important;
-
-		&-close-icon {
-			visibility: visible;
-		}
-	}
-
-	.modal-container__close {
-		visibility: hidden;
-	}
-}
-
 .app-full__header {
 	display: flex;
 	flex-direction: column;
@@ -96,6 +82,20 @@
 }
 
 .calendar-edit-full {
+	@media screen and (max-width: 785px) {
+		.app-full__header__top {
+			gap: calc(var(--default-grid-baseline) * 2) !important;
+
+			&-close-icon {
+				visibility: visible;
+			}
+		}
+
+		.modal-container__close {
+			visibility: hidden;
+		}
+	}
+
 	.modal-wrapper--full > .modal-container {
 		height: 100% !important;
 		top: 0 !important;


### PR DESCRIPTION
Follow-up to #7185

## How to test
1. Open Talk
2. Create a public conversation
3. Open the conversation in a private tab on a phone or responsive mode on desktop with a screen narrower than 785px

main: no *X* icon at the top right
here: *X* icon at top right

Calendar editor stays identical before/after