### PR TITLE
Update styling for "no email" warning while inviting attendees

### DIFF
--- a/src/components/Editor/OrganizerNoEmailError.vue
+++ b/src/components/Editor/OrganizerNoEmailError.vue
@@ -6,7 +6,7 @@
 <template>
 	<div class="editor-invitee-list-no-email-configured-message">
 		<div class="editor-invitee-list-no-email-configured-message__icon">
-			@
+			<EmailAlertOutline :size="20" />
 		</div>
 		<!-- Using v-html won't cause any XSS here, -->
 		<!-- because: -->
@@ -19,9 +19,13 @@
 
 <script>
 import { generateUrl } from '@nextcloud/router'
+import EmailAlertOutline from 'vue-material-design-icons/EmailAlertOutline.vue'
 
 export default {
 	name: 'OrganizerNoEmailError',
+	components: {
+		EmailAlertOutline,
+	},
 	computed: {
 		/**
 		 * This returns the caption of the warning message, including a link to the personal settings
@@ -36,3 +40,10 @@ export default {
 	},
 }
 </script>
+
+<style lang="scss" scoped>
+.editor-invitee-list-no-email-configured-message {
+	display: flex;
+	gap: calc(var(--default-grid-baseline) * 4);
+}
+</style>

--- a/src/components/Editor/Resources/ResourceList.vue
+++ b/src/components/Editor/Resources/ResourceList.vue
@@ -12,8 +12,6 @@
 			:calendar-object-instance="calendarObjectInstance"
 			@add-resource="addResource" />
 
-		<OrganizerNoEmailError v-if="!isReadOnly && isListEmpty && !hasUserEmailAddress" />
-
 		<div class="resource-list">
 			<ResourceListItem v-for="resource in resources"
 				:key="resource.email"
@@ -41,7 +39,6 @@ import { checkResourceAvailability } from '../../../services/freeBusyService.js'
 import logger from '../../../utils/logger.js'
 import ResourceListSearch from './ResourceListSearch.vue'
 import ResourceListItem from './ResourceListItem.vue'
-import OrganizerNoEmailError from '../OrganizerNoEmailError.vue'
 import { organizerDisplayName, removeMailtoPrefix } from '../../../utils/attendee.js'
 import usePrincipalsStore from '../../../store/principals.js'
 import useCalendarObjectInstanceStore from '../../../store/calendarObjectInstance.js'
@@ -53,7 +50,6 @@ export default {
 	components: {
 		ResourceListItem,
 		ResourceListSearch,
-		OrganizerNoEmailError,
 		MapMarker,
 	},
 	props: {


### PR DESCRIPTION
Fix https://github.com/nextcloud/calendar/issues/7215

| Before | After |
| - | - |
| <img width="1008" height="240" alt="image" src="https://github.com/user-attachments/assets/11ad493d-ab6c-45ed-a437-ce113f9ec512" /> | <img width="975" height="202" alt="image" src="https://github.com/user-attachments/assets/7fa2848e-1698-4f80-a70a-53567848fbb8" /> |
