### PR TITLE
chore(release): v5.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+# [5.5.1](https://github.com/nextcloud/calendar/compare/v5.5.0...v5.5.1) (2025-08-25)
+
+
+### Bug fixes
+
+* Bump version to fix missing app store release
+
+
+
 # [5.5.0](https://github.com/nextcloud/calendar/compare/v5.4.0-rc.5...v5.5.0) (2025-08-24)
 
 

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -23,7 +23,7 @@
 * 📎 **Attachments!** Add, upload and view event attachments
 * 🙈 **We’re not reinventing the wheel!** Based on the great [c-dav library](https://github.com/nextcloud/cdav-library), [ical.js](https://github.com/mozilla-comm/ical.js) and [fullcalendar](https://github.com/fullcalendar/fullcalendar) libraries.
 	]]></description>
-	<version>5.5.0</version>
+	<version>5.5.1</version>
 	<licence>agpl</licence>
 	<author homepage="https://github.com/st3iny">Richard Steinmetz</author>
 	<author homepage="https://github.com/SebastianKrupinski">Sebastian Krupinski </author>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "calendar",
-  "version": "5.5.0",
+  "version": "5.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "calendar",
-      "version": "5.4.0",
+      "version": "5.5.1",
       "license": "agpl",
       "dependencies": {
         "@fullcalendar/core": "6.1.17",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "calendar",
   "description": "A calendar app for Nextcloud. Easily sync events from various devices, share and edit them online.",
-  "version": "5.5.0",
+  "version": "5.5.1",
   "author": "Georg Ehrke <oc.list@georgehrke.com>",
   "contributors": [
     "Georg Ehrke <oc.list@georgehrke.com>",


### PR DESCRIPTION
# [5.5.1](https://github.com/nextcloud/calendar/compare/v5.5.0...v5.5.1) (2025-08-25)


### Bug fixes

* Bump version to fix missing app store release
