### PR TITLE
(fix) system addressbook enumeration disabled in contacts search

### DIFF
--- a/lib/Controller/ContactController.php
+++ b/lib/Controller/ContactController.php
@@ -100,7 +100,7 @@ class ContactController extends Controller {
 			return new JSONResponse();
 		}
 
-		$result = $this->contactsManager->search($search, ['FN', 'EMAIL']);
+		$result = $this->contactsManager->search($search, ['FN', 'EMAIL'], ['enumeration' => false]);
 
 		$contacts = [];
 		foreach ($result as $r) {


### PR DESCRIPTION
- For big instances, inviting attendees is strangely slow
- After doing some logging, I figured out that the query to search on system address book was the culprit
- It turns out that system address book results are skipped anyways at https://github.com/nextcloud/calendar/blob/4c3dd765011ef8329610e6b2920bf9f46780000a/lib/Controller/ContactController.php#L107
- So why not just avoid the search query at system address book and get faster searches by setting `enumeration` to false as per https://github.com/nextcloud/server/blob/d785bcdc6ea27a8d84173813e75c459299ebdbe8/lib/private/ContactsManager.php#L28
- Searches have been much faster after this change for me