### PR TITLE
fix(free-busy): make backgound solid for attendees' slots

### DIFF
--- a/src/components/Editor/FreeBusy/FreeBusy.vue
+++ b/src/components/Editor/FreeBusy/FreeBusy.vue
@@ -571,8 +571,7 @@ export default {
 				eventElement.style.background = `repeating-linear-gradient(45deg, ${this.personalCalendarColor}, ${this.personalCalendarColor} 1px, transparent 1px, transparent 3.5px)`
 				return
 			}
-			const color = uidToHexColor(e.event.title)
-			eventElement.style.background = `repeating-linear-gradient(45deg, ${color}, ${color} 1px, transparent 1px, transparent 3.5px)`
+			eventElement.style.background = uidToHexColor(e.event.title)
 		},
 		save() {
 			this.$emit('update-dates', { start: this.currentStart, end: this.currentEnd })


### PR DESCRIPTION
<img width="1512" height="935" alt="image" src="https://github.com/user-attachments/assets/a355e406-dfa6-4367-88a7-762a563b0887" />
