### PR TITLE
[stable5.5] Fix npm audit

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3406,9 +3406,9 @@
       }
     },
     "node_modules/@nextcloud/calendar-availability-vue": {
-      "version": "2.2.8",
-      "resolved": "https://registry.npmjs.org/@nextcloud/calendar-availability-vue/-/calendar-availability-vue-2.2.8.tgz",
-      "integrity": "sha512-smjCY915UpIthknoO/zlSzcxpisv6bt4TXPc/q+gSWpOayMRoS7hG82KOXIL44tk1O+KuwwXFLmr24MN6EIRBA==",
+      "version": "2.2.10",
+      "resolved": "https://registry.npmjs.org/@nextcloud/calendar-availability-vue/-/calendar-availability-vue-2.2.10.tgz",
+      "integrity": "sha512-om6DkxKockjBipMqPMB+zNQzZwY5vDI0VQN82IRwQz/cx75C+4wEnHWexSx776kTixU6JJLACLFMExrF+tp9QA==",
       "license": "MIT",
       "dependencies": {
         "@nextcloud/logger": "^3.0.2",
@@ -3830,9 +3830,9 @@
       }
     },
     "node_modules/@nextcloud/vue": {
-      "version": "8.29.1",
-      "resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-8.29.1.tgz",
-      "integrity": "sha512-fJtKBmO1Al4SWZDsb2s+wmS1k+TkMQ+2Basx/M3VQsrczTpWqXOabsYdJR0ZoZgkL0suDPgK3p5OOEomWvLewA==",
+      "version": "8.29.2",
+      "resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-8.29.2.tgz",
+      "integrity": "sha512-kxi5KEF5K0JiYo3P/JvorbZ7u1/g7kkbcba1IEAR1hliAOS9Mwqdr+5BdJGUdIB2AIH/bj8YTg85P4g4gGZnXA==",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@floating-ui/dom": "^1.1.0",


### PR DESCRIPTION
# Audit report

This audit fix resolves 16 of the total 18 vulnerabilities found in your project.

## Updated dependencies
* [@linusborg/vue-simple-portal](#user-content-\@linusborg\/vue-simple-portal)
* [@nextcloud/calendar-availability-vue](#user-content-\@nextcloud\/calendar-availability-vue)
* [@nextcloud/dialogs](#user-content-\@nextcloud\/dialogs)
* [@nextcloud/vue](#user-content-\@nextcloud\/vue)
* [@nextcloud/vue-select](#user-content-\@nextcloud\/vue-select)
* [@nextcloud/webpack-vue-config](#user-content-\@nextcloud\/webpack-vue-config)
* [@vue/component-compiler-utils](#user-content-\@vue\/component-compiler-utils)
* [floating-vue](#user-content-floating-vue)
* [postcss](#user-content-postcss)
* [v-tooltip](#user-content-v-tooltip)
* [vue](#user-content-vue)
* [vue-frag](#user-content-vue-frag)
* [vue-loader](#user-content-vue-loader)
* [vue-resize](#user-content-vue-resize)
* [vue-template-compiler](#user-content-vue-template-compiler)
* [vue2-datepicker](#user-content-vue2-datepicker)
## Fixed vulnerabilities

### @linusborg/vue-simple-portal <a href="#user-content-\@linusborg\/vue-simple-portal" id="\@linusborg\/vue-simple-portal">#</a>
* Caused by vulnerable dependency:
  * [vue](#user-content-vue)
* Affected versions: *
* Package usage:
  * `node_modules/@linusborg/vue-simple-portal`

### @nextcloud/calendar-availability-vue <a href="#user-content-\@nextcloud\/calendar-availability-vue" id="\@nextcloud\/calendar-availability-vue">#</a>
* Caused by vulnerable dependency:
  * [@nextcloud/vue](#user-content-\@nextcloud\/vue)
  * [vue](#user-content-vue)
* Affected versions: *
* Package usage:
  * `node_modules/@nextcloud/calendar-availability-vue`

### @nextcloud/dialogs <a href="#user-content-\@nextcloud\/dialogs" id="\@nextcloud\/dialogs">#</a>
* Caused by vulnerable dependency:
  * [@nextcloud/vue](#user-content-\@nextcloud\/vue)
  * [vue](#user-content-vue)
  * [vue-frag](#user-content-vue-frag)
* Affected versions: 4.2.0-beta.1 - 6.3.1
* Package usage:
  * `node_modules/@nextcloud/dialogs`

### @nextcloud/vue <a href="#user-content-\@nextcloud\/vue" id="\@nextcloud\/vue">#</a>
* Caused by vulnerable dependency:
  * [@linusborg/vue-simple-portal](#user-content-\@linusborg\/vue-simple-portal)
  * [@nextcloud/vue-select](#user-content-\@nextcloud\/vue-select)
  * [floating-vue](#user-content-floating-vue)
  * [vue](#user-content-vue)
  * [vue-frag](#user-content-vue-frag)
  * [vue2-datepicker](#user-content-vue2-datepicker)
* Affected versions: <=8.29.2
* Package usage:
  * `node_modules/@nextcloud/vue`

### @nextcloud/vue-select <a href="#user-content-\@nextcloud\/vue-select" id="\@nextcloud\/vue-select">#</a>
* Caused by vulnerable dependency:
  * [vue](#user-content-vue)
* Affected versions: *
* Package usage:
  * `node_modules/@nextcloud/vue-select`

### @nextcloud/webpack-vue-config <a href="#user-content-\@nextcloud\/webpack-vue-config" id="\@nextcloud\/webpack-vue-config">#</a>
* Caused by vulnerable dependency:
  * [vue](#user-content-vue)
  * [vue-loader](#user-content-vue-loader)
  * [vue-template-compiler](#user-content-vue-template-compiler)
* Affected versions: <=6.2.0
* Package usage:
  * `node_modules/@nextcloud/webpack-vue-config`

### @vue/component-compiler-utils <a href="#user-content-\@vue\/component-compiler-utils" id="\@vue\/component-compiler-utils">#</a>
* Caused by vulnerable dependency:
  * [postcss](#user-content-postcss)
* Affected versions: *
* Package usage:
  * `node_modules/@vue/component-compiler-utils`

### floating-vue <a href="#user-content-floating-vue" id="floating-vue">#</a>
* Caused by vulnerable dependency:
  * [vue](#user-content-vue)
  * [vue-resize](#user-content-vue-resize)
* Affected versions: <=1.0.0-beta.19
* Package usage:
  * `node_modules/floating-vue`

### postcss <a href="#user-content-postcss" id="postcss">#</a>
* PostCSS line return parsing error
* Severity: **moderate** (CVSS 5.3)
* Reference: [https://github.com/advisories/GHSA-7fh5-64p2-3v2j](https://github.com/advisories/GHSA-7fh5-64p2-3v2j)
* Affected versions: <8.4.31
* Package usage:
  * `node_modules/@vue/component-compiler-utils/node_modules/postcss`

### v-tooltip <a href="#user-content-v-tooltip" id="v-tooltip">#</a>
* Caused by vulnerable dependency:
  * [vue-resize](#user-content-vue-resize)
* Affected versions: 2.0.0-beta.1 - 4.0.0-beta.0
* Package usage:
  * `node_modules/v-tooltip`

### vue <a href="#user-content-vue" id="vue">#</a>
* ReDoS vulnerability in vue package that is exploitable through inefficient regex evaluation in the parseHTML function
* Severity: **low** (CVSS 3.7)
* Reference: [https://github.com/advisories/GHSA-5j4c-8p2g-v4jx](https://github.com/advisories/GHSA-5j4c-8p2g-v4jx)
* Affected versions: 2.0.0-alpha.1 - 2.7.16
* Package usage:
  * `node_modules/vue`

### vue-frag <a href="#user-content-vue-frag" id="vue-frag">#</a>
* Caused by vulnerable dependency:
  * [vue](#user-content-vue)
* Affected versions: >=1.3.1
* Package usage:
  * `node_modules/vue-frag`

### vue-loader <a href="#user-content-vue-loader" id="vue-loader">#</a>
* Caused by vulnerable dependency:
  * [@vue/component-compiler-utils](#user-content-\@vue\/component-compiler-utils)
* Affected versions: 15.0.0-beta.1 - 15.11.1
* Package usage:
  * `node_modules/vue-loader`

### vue-resize <a href="#user-content-vue-resize" id="vue-resize">#</a>
* Caused by vulnerable dependency:
  * [vue](#user-content-vue)
* Affected versions: 0.4.0 - 1.0.1
* Package usage:
  * `node_modules/vue-resize`

### vue-template-compiler <a href="#user-content-vue-template-compiler" id="vue-template-compiler">#</a>
* vue-template-compiler vulnerable to client-side Cross-Site Scripting (XSS)
* Severity: **moderate** (CVSS 4.2)
* Reference: [https://github.com/advisories/GHSA-g3ch-rx76-35fx](https://github.com/advisories/GHSA-g3ch-rx76-35fx)
* Affected versions: >=2.0.0
* Package usage:
  * `node_modules/vue-template-compiler`

### vue2-datepicker <a href="#user-content-vue2-datepicker" id="vue2-datepicker">#</a>
* Caused by vulnerable dependency:
  * [vue](#user-content-vue)
* Affected versions: <=1.9.8 || 3.0.2 - 3.11.1
* Package usage:
  * `node_modules/vue2-datepicker`