### PR TITLE
fix(Repeat): change all day is visually disabled when recurrence is set

### DIFF
--- a/src/components/Editor/Repeat/Repeat.vue
+++ b/src/components/Editor/Repeat/Repeat.vue
@@ -447,6 +447,8 @@ export default {
 			if (!this.isEditingMasterItem) {
 				this.$emit('force-this-and-all-future')
 			}
+
+			this.calendarObjectInstanceStore.calendarObjectInstance.canModifyAllDay = this.calendarObjectInstanceStore.calendarObjectInstance.eventComponent.canModifyAllDay()
 		},
 		/**
 		 * Toggle visibility of the options


### PR DESCRIPTION
Steps to reproduce causing bug:

1. Set recurrence on a new event
2. Try to modify "all day", this should result impossible, without any warning

Now:

1. Set recurrence on a new event
2. All day checkbox becomes disabled