### PR TITLE
fix: harden group attendee search

### DIFF
--- a/lib/Service/ContactsService.php
+++ b/lib/Service/ContactsService.php
@@ -120,6 +120,11 @@ class ContactsService {
 		//filter to be unique
 		$categories = [];
 		foreach ($groups as $group) {
+			// CATEGORIES is sometimes missing (despite being searched for via the backend)
+			if (!isset($group['CATEGORIES'])) {
+				continue;
+			}
+
 			$categories[] = array_filter(explode(',', $group['CATEGORIES']), static function ($cat) use ($search) {
 				return str_contains(strtolower($cat), strtolower($search));
 			});

--- a/tests/php/unit/Service/ContactsServiceTest.php
+++ b/tests/php/unit/Service/ContactsServiceTest.php
@@ -63,6 +63,8 @@ class ContactsServiceTest extends TestCase {
 		$contact = [
 			['CATEGORIES' => 'The Proclaimers,I\'m gonna be,When I go out,I would walk 500 Miles,I would walk 500 more'],
 			['CATEGORIES' => 'The Proclaimers,When I\'m lonely,I would walk 500 Miles,I would walk 500 more'],
+			['CATEGORIES' => ''],
+			[],
 		];
 
 		$searchterm = 'walk';


### PR DESCRIPTION
Sometimes, the backend returns contacts without `CATEGORIES` despite being searched by the property.

```php
$groups = $this->contactsManager->search($search, ['CATEGORIES']);
```