### PR TITLE
chore(i18n): Aligned spelling

### DIFF
--- a/lib/Service/Proposal/ProposalService.php
+++ b/lib/Service/Proposal/ProposalService.php
@@ -472,7 +472,7 @@ class ProposalService {
 				$this->l10n->t('Dear %s, a proposed meeting has been updated', [$recipientName])
 			),
 			'D' => $template->addHeading(
-				$this->l10n->t('Dear %s, a proposed meeting has been canceled', [$recipientName])
+				$this->l10n->t('Dear %s, a proposed meeting has been cancelled', [$recipientName])
 			)
 		};
 		// description


### PR DESCRIPTION
Reported at Transifex.

https://app.transifex.com/nextcloud/nextcloud/translate/#en_GB/$/505333903?q=text%3Acancelled