### PR TITLE
feat: meeting proposal conversion timezone and attendance

### DIFF
--- a/lib/Controller/ProposalController.php
+++ b/lib/Controller/ProposalController.php
@@ -182,7 +182,7 @@ class ProposalController extends ApiController {
 	#[ApiRoute(verb: 'POST', url: '/proposal/convert', root: '/calendar')]
 	#[NoAdminRequired]
 	#[UserRateLimit(limit: 10, period: 60)]
-	public function convert(int $proposalId, int $dateId, ?string $user = null): JSONResponse {
+	public function convert(int $proposalId, int $dateId, array $options = [], ?string $user = null): JSONResponse {
 		// authorize request
 		$authorization = $this->authorize($user);
 		if ($authorization instanceof JSONResponse) {
@@ -191,7 +191,7 @@ class ProposalController extends ApiController {
 		$userObject = $authorization;
 		// handle the conversion
 		try {
-			$this->proposalService->convertProposal($userObject, $proposalId, $dateId);
+			$this->proposalService->convertProposal($userObject, $proposalId, $dateId, $options);
 		} catch (\InvalidArgumentException $e) {
 			return new JSONResponse(['error' => $e->getMessage()], Http::STATUS_NOT_FOUND);
 		}

--- a/lib/Objects/Proposal/ProposalDateCollection.php
+++ b/lib/Objects/Proposal/ProposalDateCollection.php
@@ -99,4 +99,13 @@ class ProposalDateCollection extends BaseCollection {
 		];
 	}
 
+	public function findById(?int $id): ?ProposalDateObject {
+		foreach ($this as $date) {
+			if ($date->getId() === $id) {
+				return $date;
+			}
+		}
+		return null;
+	}
+
 }

--- a/lib/Objects/Proposal/ProposalVoteCollection.php
+++ b/lib/Objects/Proposal/ProposalVoteCollection.php
@@ -53,4 +53,13 @@ class ProposalVoteCollection extends BaseCollection {
 		}
 	}
 
+	public function findByDateAndParticipant(?int $dateId, ?int $participantId): ?ProposalVoteObject {
+		foreach ($this as $vote) {
+			if ($vote->getDateId() === $dateId && $vote->getParticipantId() === $participantId) {
+				return $vote;
+			}
+		}
+		return null;
+	}
+
 }

--- a/lib/Service/Proposal/ProposalService.php
+++ b/lib/Service/Proposal/ProposalService.php
@@ -9,12 +9,15 @@ declare(strict_types=1);
 
 namespace OCA\Calendar\Service\Proposal;
 
+use DateTimeZone;
 use Exception;
 use OCA\Calendar\Db\ProposalDateMapper;
 use OCA\Calendar\Db\ProposalMapper;
 use OCA\Calendar\Db\ProposalParticipantMapper;
 use OCA\Calendar\Db\ProposalVoteMapper;
 use OCA\Calendar\Objects\Proposal\ProposalDateCollection;
+use OCA\Calendar\Objects\Proposal\ProposalDateObject;
+use OCA\Calendar\Objects\Proposal\ProposalDateVote;
 use OCA\Calendar\Objects\Proposal\ProposalObject;
 use OCA\Calendar\Objects\Proposal\ProposalParticipantCollection;
 use OCA\Calendar\Objects\Proposal\ProposalParticipantObject;
@@ -282,20 +285,14 @@ class ProposalService {
 	/**
 	 * Convert a selected proposal date into a calendar meeting.
 	 */
-	public function convertProposal(IUser $user, int $proposalId, int $dateId): void {
+	public function convertProposal(IUser $user, int $proposalId, int $dateId, array $options = []): void {
 		// retrieve full proposal with participants, dates, and votes
 		$proposal = $this->fetchProposal($user, $proposalId);
 		if ($proposal === null) {
 			throw new \InvalidArgumentException('Proposal not found');
 		}
 		// locate selected date
-		$selectedDate = null;
-		foreach ($proposal->getDates() as $date) {
-			if ($date->getId() === $dateId) {
-				$selectedDate = $date;
-				break;
-			}
-		}
+		$selectedDate = $proposal->getDates()->findById($dateId);
 		if ($selectedDate === null) {
 			throw new \InvalidArgumentException('Date not found for proposal');
 		}
@@ -323,18 +320,37 @@ class ProposalService {
 			throw new \RuntimeException('Could not find a useable calendar to create a meeting from the selected proposal');
 		}
 
+		// extract options
+		// timezone option
+		$eventTimezone = null;
+		if (isset($options['timezone']) && is_string($options['timezone']) && in_array($options['timezone'], DateTimeZone::listIdentifiers(), true)) {
+			$eventTimezone = new DateTimeZone($options['timezone']);
+		}
+		// participant attendance option
+		$eventAttendancePreset = false;
+		if (isset($options['attendancePreset']) && is_bool($options['attendancePreset'])) {
+			$eventAttendancePreset = $options['attendancePreset'];
+		}
+		// talk room option
+		$talkRoomUri = null;
+		if (isset($options['talkRoomUri']) && is_string($options['talkRoomUri'])) {
+			$talkRoomUri = $options['talkRoomUri'];
+		}
+
 		// build a VCalendar with single definitive event
 		$vObject = new VCalendar();
 		/** @var \Sabre\VObject\Component\VEvent $vEvent */
 		$vEvent = $vObject->add('VEVENT', []);
 		$vEvent->UID->setValue($proposal->getUuid() ?? Uuid::v4()->toRfc4122());
-		$vEvent->add('DTSTART', $selectedDate->getDate());
+		$vEvent->add('DTSTART', $eventTimezone ? $selectedDate->getDate()->setTimezone($eventTimezone) : $selectedDate->getDate());
 		$vEvent->add('DURATION', "PT{$proposal->getDuration()}M");
 		$vEvent->add('STATUS', 'CONFIRMED');
 		$vEvent->add('SEQUENCE', 1);
 		$vEvent->add('SUMMARY', $proposal->getTitle());
 		$vEvent->add('DESCRIPTION', $proposal->getDescription());
-		if (!empty($proposal->getLocation())) {
+		if ($talkRoomUri !== null) {
+			$vEvent->add('LOCATION', $talkRoomUri);
+		} elseif (!empty($proposal->getLocation())) {
 			$vEvent->add('LOCATION', $proposal->getLocation());
 		}
 		$vEvent->add('ORGANIZER', 'mailto:' . $user->getEMailAddress(), ['CN' => $user->getDisplayName()]);
@@ -345,7 +361,7 @@ class ProposalService {
 			$vEvent->add('ATTENDEE', 'mailto:' . $participant->getAddress(), [
 				'CN' => $participant->getName(),
 				'CUTYPE' => 'INDIVIDUAL',
-				'PARTSTAT' => 'NEEDS-ACTION',
+				'PARTSTAT' => $eventAttendancePreset ? $this->convertProposalAttendeeAttendance($selectedDate, $participant, $proposal->getVotes()) : 'NEEDS-ACTION',
 				'ROLE' => 'REQ-PARTICIPANT'
 			]);
 		}
@@ -361,7 +377,21 @@ class ProposalService {
 		$this->proposalParticipantMapper->deleteByProposalId($user->getUID(), $proposal->getId());
 		$this->proposalDateMapper->deleteByProposalId($user->getUID(), $proposal->getId());
 		$this->proposalMapper->deleteById($user->getUID(), $proposal->getId());
+	}
 
+	public function convertProposalAttendeeAttendance(ProposalDateObject $date, ProposalParticipantObject $participant, ProposalVoteCollection $votes): string {
+		// find the vote for the given date and participant
+		$vote = $votes->findByDateAndParticipant($date->getId(), $participant->getId());
+		// convert the vote to an iCal PARTSTAT value
+		if ($vote === null) {
+			return 'NEEDS-ACTION';
+		}
+		return match ($vote->getVote()) {
+			ProposalDateVote::Yes => 'ACCEPTED',
+			ProposalDateVote::No => 'DECLINED',
+			ProposalDateVote::Maybe => 'TENTATIVE',
+			default => 'NEEDS-ACTION',
+		};
 	}
 
 	public function deleteProposalsByUser(string $user): void {

--- a/src/services/proposalService.ts
+++ b/src/services/proposalService.ts
@@ -86,14 +86,14 @@ class ProposalService {
 		}
 	}
 
-	async convertProposal(proposal: ProposalInterface, date: ProposalDateInterface) {
+	async convertProposal(proposal: ProposalInterface, date: ProposalDateInterface, options: Record<string, unknown>) {
 		const response = await fetch('/ocs/v2.php/calendar/proposal/convert', {
 			method: 'POST',
 			headers: {
 				'Content-Type': 'application/json',
 				'OCS-APIRequest': 'true',
 			},
-			body: JSON.stringify({ proposalId: proposal.id, dateId: date.id }),
+			body: JSON.stringify({ proposalId: proposal.id, dateId: date.id, options }),
 		})
 		if (!response.ok) {
 			throw new Error('Failed to convert proposal')

--- a/src/store/proposalStore.ts
+++ b/src/store/proposalStore.ts
@@ -98,9 +98,14 @@ export default defineStore('proposal', () => {
 	 *
 	 * @param proposal - The proposal to convert.
 	 * @param date - The proposed date to convert to a meeting.
+	 * @param timezone - The timezone to use for the meeting.
 	 */
-	async function convertProposal(proposal: ProposalInterface, date: ProposalDateInterface): Promise<void> {
-		await proposalService.convertProposal(proposal, date)
+	async function convertProposal(proposal: ProposalInterface, date: ProposalDateInterface, timezone: string): Promise<void> {
+		const options = {
+			timezone,
+			attendancePreset: true,
+		}
+		await proposalService.convertProposal(proposal, date, options)
 	}
 
 	/**

--- a/src/views/Proposal/ProposalEditor.vue
+++ b/src/views/Proposal/ProposalEditor.vue
@@ -587,7 +587,7 @@ export default {
 
 			try {
 				showSuccess(t('calendar', 'Creating meeting for {date}', { date: dateString }))
-				await this.proposalStore.convertProposal(this.selectedProposal, date)
+				await this.proposalStore.convertProposal(this.selectedProposal, date, this.userTimezone)
 				showSuccess(t('calendar', 'Successfully created meeting for {date}', { date: dateString }))
 				this.onModalClose()
 			} catch (error) {


### PR DESCRIPTION
### Summary
- Added ability to set timezone of the generated calendar event (by default all meeting proposal timezones are UTC)
- Added ability to set the attendance of the generated calendar event based on the participants vote
- Added missing tests for convertProposal

Before
<img width="542" height="456" alt="image" src="https://github.com/user-attachments/assets/f2b8bff8-69a8-40c1-81e0-9630545934b0" />


After
<img width="526" height="437" alt="image" src="https://github.com/user-attachments/assets/7b4a31b0-a50b-442d-84ff-96fca959535d" />
