### PR TITLE
chore(composer): rename test script to test:unit

### DIFF
--- a/.github/workflows/php-test.yml
+++ b/.github/workflows/php-test.yml
@@ -37,7 +37,7 @@ jobs:
       run: composer install
     - name: Run tests
       working-directory: nextcloud/apps/calendar
-      run: composer run test
+      run: composer run test:unit
     - name: Upload coverage to Codecov
       if: ${{ matrix.nextcloud-versions == 'master' }}
       uses: codecov/codecov-action@fdcc8476540edceab3de004e990f80d881c6cc00 # v5

--- a/composer.json
+++ b/composer.json
@@ -24,8 +24,8 @@
         "cs:check": "php-cs-fixer fix --dry-run --diff",
         "lint": "find . -name \\*.php -not -path './vendor/*' -not -path './tests/*' -print0 | xargs -0 -n1 php -l",
         "psalm": "psalm",
-        "test": "phpunit --configuration phpunit.unit.xml --fail-on-warning",
-        "test:dev": "phpunit --configuration phpunit.unit.xml --fail-on-warning --stop-on-error --stop-on-failure",
+        "test:unit": "phpunit --configuration phpunit.unit.xml --fail-on-warning",
+        "test:unit:dev": "phpunit --configuration phpunit.unit.xml --fail-on-warning --stop-on-error --stop-on-failure",
         "test:integration": "phpunit -c phpunit.integration.xml --fail-on-warning",
         "test:integration:dev": "phpunit -c phpunit.integration.xml --no-coverage --order-by=defects --stop-on-defect --fail-on-warning --stop-on-error --stop-on-failure",
         "post-install-cmd": [


### PR DESCRIPTION
We use `test:unit` and `test:unit:dev` everywhere else.