### PR TITLE
chore: add playwright config and tsconfig to .nextcloudignore

### DIFF
--- a/.nextcloudignore
+++ b/.nextcloudignore
@@ -41,3 +41,6 @@ timezones
 /vendor/bamarni/composer-bin-plugin/e2e
 /vendor-bin
 webpack.*
+playwright.config.js
+tsconfig.json
+tsconfig.json.license


### PR DESCRIPTION
We don't need to ship those files.