### PR TITLE
fix: psalm error for ci

### DIFF
--- a/lib/Service/Proposal/ProposalService.php
+++ b/lib/Service/Proposal/ProposalService.php
@@ -324,7 +324,9 @@ class ProposalService {
 		// timezone option
 		$eventTimezone = null;
 		if (isset($options['timezone']) && is_string($options['timezone']) && in_array($options['timezone'], DateTimeZone::listIdentifiers(), true)) {
-			$eventTimezone = new DateTimeZone($options['timezone']);
+			if (!empty($options['timezone'])) {
+				$eventTimezone = new DateTimeZone($options['timezone']);
+			}
 		}
 		// participant attendance option
 		$eventAttendancePreset = false;


### PR DESCRIPTION
### Summary
- Fixed 
ERROR: ArgumentTypeCoercion - lib/Service/Proposal/ProposalService.php:327:38 - Argument 1 of DateTimeZone::__construct expects non-empty-string, but parent type string provided (see https://psalm.dev/193)
                        $eventTimezone = new DateTimeZone((string)$options['timezone']);
