### PR TITLE
perf: reduce contacts menu entrypoint bundle size

### DIFF
--- a/src/contactsMenu.js
+++ b/src/contactsMenu.js
@@ -10,7 +10,7 @@ import '../css/calendar.scss'
 import { getRequestToken } from '@nextcloud/auth'
 import { linkTo } from '@nextcloud/router'
 import { translate as t } from '@nextcloud/l10n'
-import { registerContactsMenuAction } from '@nextcloud/vue'
+import { registerContactsMenuAction } from '@nextcloud/vue/dist/Functions/contactsMenu.js'
 import CalendarBlankSvg from '@mdi/svg/svg/calendar-blank.svg'
 
 // CSP config for webpack dynamic chunk loading


### PR DESCRIPTION
## Bundle sizes (js)

| | Before | After |
| --- | --- | --- |
| js/calendar-contacts-menu.js | 3.5M | 333K |
| total | 24M | 21M |