### PR TITLE
fix: use outlined checkbox for disabled/hidden calendars

### DIFF
--- a/src/components/AppNavigation/CalendarList/CalendarListItem.vue
+++ b/src/components/AppNavigation/CalendarList/CalendarListItem.vue
@@ -84,7 +84,7 @@ import {
 } from '@nextcloud/vue'
 import { showError } from '@nextcloud/dialogs'
 import CheckboxMarked from 'vue-material-design-icons/CheckboxMarked.vue'
-import CheckboxBlank from 'vue-material-design-icons/CheckboxBlank.vue'
+import CheckboxBlank from 'vue-material-design-icons/CheckboxBlankOutline.vue'
 import Pencil from 'vue-material-design-icons/PencilOutline.vue'
 import Undo from 'vue-material-design-icons/Undo.vue'
 import LinkVariant from 'vue-material-design-icons/Link.vue'


### PR DESCRIPTION
Fix #7425

Designers already approved this (see chat on c.nc.c).

| Before | After |
| --- | --- |
| <img width="413" height="293" alt="Screenshot_20250915_144537" src="https://github.com/user-attachments/assets/984dc487-2027-44e2-ab43-d3a223048058" /> | <img width="413" height="293" alt="Screenshot_20250915_144935" src="https://github.com/user-attachments/assets/435bee57-5784-4077-9f31-eb74b3bead77" /> |
