### PR TITLE
test: migrate withConsecutive() to willReturnMap()

### DIFF
--- a/tests/php/unit/Controller/EmailControllerTest.php
+++ b/tests/php/unit/Controller/EmailControllerTest.php
@@ -21,6 +21,7 @@ use OCP\Mail\IEMailTemplate;
 use OCP\Mail\IMailer;
 use OCP\Mail\IMessage;
 use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\MockObject\Stub\ReturnSelf;
 
 class EmailControllerTest extends TestCase {
 	/** @var string */
@@ -173,12 +174,11 @@ class EmailControllerTest extends TestCase {
 			->willReturn($template);
 		$template->expects(self::exactly(3))
 			->method('addBodyText')
-			->withConsecutive(
-				['TRANSLATED: Hello,'],
-				['TRANSLATED: We wanted to inform you that User Displayname 123 has published the calendar »calendar name 456«.'],
-				['TRANSLATED: Cheers!']
-			)
-			->willReturnSelf();
+			->willReturnMap([
+				['TRANSLATED: Hello,', new ReturnSelf()],
+				['TRANSLATED: We wanted to inform you that User Displayname 123 has published the calendar »calendar name 456«.', new ReturnSelf()],
+				['TRANSLATED: Cheers!', new ReturnSelf()],
+			]);
 		$template->expects(self::once())
 			->method('addBodyButton')
 			->with('TRANSLATED: Open »calendar name 456«', 'http://publicURL123')

--- a/tests/php/unit/Controller/PublicViewControllerTest.php
+++ b/tests/php/unit/Controller/PublicViewControllerTest.php
@@ -88,7 +88,7 @@ class PublicViewControllerTest extends TestCase {
 
 		$this->initialStateService->expects(self::exactly(18))
 			->method('provideInitialState')
-			->withConsecutive(
+			->willReturnMap([
 				['calendar', 'app_version', '1.0.0'],
 				['calendar', 'event_limit', false],
 				['calendar', 'first_run', false],
@@ -107,7 +107,7 @@ class PublicViewControllerTest extends TestCase {
 				['calendar', 'hide_event_export', false],
 				['calendar', 'can_subscribe_link', 'defaultCanSubscribeLink'],
 				['calendar', 'show_resources', false],
-			);
+			]);
 
 		$response = $this->controller->publicIndexWithBranding('');
 

--- a/tests/php/unit/Service/CalendarInitialStateServiceTest.php
+++ b/tests/php/unit/Service/CalendarInitialStateServiceTest.php
@@ -118,7 +118,7 @@ class CalendarInitialStateServiceTest extends TestCase {
 			->willReturn([new AppointmentConfig()]);
 		$this->initialStateService->expects(self::exactly(24))
 			->method('provideInitialState')
-			->withConsecutive(
+			->willReturnMap([
 				['app_version', '1.0.0'],
 				['event_limit', true],
 				['first_run', true],
@@ -143,7 +143,7 @@ class CalendarInitialStateServiceTest extends TestCase {
 				['show_resources', true],
 				['isCirclesEnabled', false],
 				['publicCalendars', null],
-			);
+			]);
 
 		$this->service->run();
 	}
@@ -210,7 +210,7 @@ class CalendarInitialStateServiceTest extends TestCase {
 			]);
 		$this->initialStateService->expects(self::exactly(23))
 			->method('provideInitialState')
-			->withConsecutive(
+			->willReturnMap([
 				['app_version', '1.0.0'],
 				['event_limit', true],
 				['first_run', true],
@@ -234,7 +234,7 @@ class CalendarInitialStateServiceTest extends TestCase {
 				['show_resources', true],
 				['isCirclesEnabled', false],
 				['publicCalendars', null],
-			);
+			]);
 
 		$this->service->run();
 	}
@@ -311,7 +311,7 @@ class CalendarInitialStateServiceTest extends TestCase {
 			->willReturn([new AppointmentConfig()]);
 		$this->initialStateService->expects(self::exactly(24))
 			->method('provideInitialState')
-			->withConsecutive(
+			->willReturnMap([
 				['app_version', '1.0.0'],
 				['event_limit', true],
 				['first_run', true],
@@ -336,7 +336,7 @@ class CalendarInitialStateServiceTest extends TestCase {
 				['show_resources', true],
 				['isCirclesEnabled', false],
 				['publicCalendars', null],
-			);
+			]);
 
 		$this->service->run();
 


### PR DESCRIPTION
The method `withConsecutive()` is deprecated and was removed from more recent versions of PHPUnit.