### PR TITLE
fix(EditSimple): a11y on small screens

### DIFF
--- a/src/fullcalendar/interaction/eventClick.js
+++ b/src/fullcalendar/interaction/eventClick.js
@@ -62,9 +62,11 @@ function handleEventClick(event, router, route, window, isWidget = false) {
 		? 'EditFullView'
 		: 'EditPopoverView'
 
-	// Don't show the popover if the window size is too small (less then its max width of 450 px + a bit)
-	// The mobile breakpoint of the reworked modals is 1024 px / 2 so simply use that.
-	if (window.innerWidth <= 1024 / 2 && desiredRoute === 'EditPopoverView') {
+	// Don't show the popover if the window size is too small (less than its max width of 516 px + a bit)
+	// The sidebar is 300px, so we check 850px (300 + 516 + some margin)
+
+	// The popover also becomes uncomfortable to use on short screens
+	if ((window.innerWidth <= 850 || window.innerHeight <= 400) && desiredRoute === 'EditPopoverView') {
 		desiredRoute = 'EditFullView'
 	}
 

--- a/src/views/EditSimple.vue
+++ b/src/views/EditSimple.vue
@@ -506,7 +506,7 @@ export default {
 .event-popover__inner {
 	width: unset !important;
 	min-width: 500px !important;
-	max-height: 100vh !important;
+	max-height: 90vh !important; // leaving some margin makes scrolling easier and ensures elements aren't cut off
 	overflow-y: auto !important;
 }
 


### PR DESCRIPTION
Prevents situations like these where the buttons get cut off even when having scrolled down to the bottom:

<img width="931" height="446" alt="image" src="https://github.com/user-attachments/assets/7d92b2a2-5098-4fb4-ad9c-5f744cae4bbf" />
