### PR TITLE
chore: enrich sentry errors

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -17,6 +17,10 @@ import AppointmentConfig from './models/appointmentConfig.js'
 import windowTitleService from './services/windowTitleService.js'
 import { createPinia, PiniaVuePlugin } from 'pinia'
 import useAppointmentConfigsStore from './store/appointmentConfigs.js'
+import { version as appVersion } from '../package.json'
+import logger from './utils/logger'
+
+window.Sentry?.setTag('calendar_version', appVersion)
 
 Vue.use(PiniaVuePlugin)
 const pinia = createPinia()
@@ -38,6 +42,19 @@ Vue.prototype.$n = translatePlural
 // The nextcloud-vue package does currently rely on t and n
 Vue.prototype.t = translate
 Vue.prototype.n = translatePlural
+
+Vue.config.errorHandler = function(error, vm, info) {
+	logger.error(`Unhandled Vue error: ${error}`, {
+		error,
+		info,
+	})
+
+	window.Sentry?.setTag('captured_by', 'Vue.config.errorHandler')
+	window.Sentry?.setExtras({
+		info,
+	})
+	window.Sentry?.captureException(error)
+}
 
 export default new Vue({
 	el: '#content',

--- a/src/utils/sentryError.js
+++ b/src/utils/sentryError.js
@@ -1,0 +1,19 @@
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+/**
+ * Intercept errors to enrich them with data for Sentry.
+ *
+ * @param {Array} args Constructor arguments
+ */
+export default function Error(...args) {
+	const error = new window.Error(...args)
+	window.Sentry?.setTag('captured_by', 'sentryError.js')
+	window.Sentry?.setExtras({
+		args,
+		error,
+	})
+	return error
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -27,6 +27,13 @@ webpackConfig.resolve = {
 	}
 }
 
+webpackConfig.plugins.push(
+	new webpack.ProvidePlugin({
+		// Intercept all errors and enrich them with extra data for Sentry
+		Error: [path.resolve(__dirname, 'src/utils/sentryError.js'), 'default'],
+	})
+)
+
 // Edit JS rule
 webpackRules.RULE_JS.test = /\.m?js$/
 webpackRules.RULE_JS.exclude = BabelLoaderExcludeNodeModulesExcept([


### PR DESCRIPTION
Requires something like https://github.com/ChristophWurst/nextcloud_sentry/pull/749

- Enrich errors before reporting them to sentry
- Also capture unhandled Vue errors (previously uncaptured)

It would be great to simply make use of the Vue integration of Sentry. However, they only support Vue 3.