### PR TITLE
fix: meeting proposal system mailer from address

### DIFF
--- a/lib/Service/Proposal/ProposalService.php
+++ b/lib/Service/Proposal/ProposalService.php
@@ -563,9 +563,10 @@ class ProposalService {
 				// send message
 				$mailService->sendMessage($message);
 			} else {
+				$fromAddress = \OCP\Util::getDefaultEmailAddress('proposal-noreply');
 				// construct symfony mailer message and set required parameters
 				$message = $this->systemMailManager->createMessage();
-				$message->setFrom([$senderAddress => $senderName ?? '']);
+				$message->setFrom([$fromAddress => $senderName ?? '']);
 				$message->setTo(
 					$recipientName !== null ? [$recipientAddress => $recipientName] : [$recipientAddress]
 				);


### PR DESCRIPTION
### Issue
When the flag to use the system email account is enabled, mail messages are silently reject by the SMTP server if FROM enforcement is enabled.

Example:
System mailer account is system@domain.com
Emails message are sent with the users email address user1@domain.com

### Resolution
Force messages being sent from a system account to use the system account email address in the FROM.
