### PR TITLE
refactor: migrate AppNavigationHeaderViewMenu to setup script (and drop Hotkey usage)

### DIFF
--- a/src/components/AppNavigation/AppNavigationHeader/AppNavigationHeaderViewMenu.vue
+++ b/src/components/AppNavigation/AppNavigationHeader/AppNavigationHeaderViewMenu.vue
@@ -3,43 +3,12 @@
   - SPDX-License-Identifier: AGPL-3.0-or-later
 -->
 
-<template>
-	<div>
-		<Hotkey :keys="['d']" @hotkey="selectView('timeGridDay')" />
-		<Hotkey :keys="['1']" @hotkey="selectView('timeGridDay')" />
-		<Hotkey :keys="['w']" @hotkey="selectView('timeGridWeek')" />
-		<Hotkey :keys="['2']" @hotkey="selectView('timeGridWeek')" />
-		<Hotkey :keys="['m']" @hotkey="selectView('dayGridMonth')" />
-		<Hotkey :keys="['3']" @hotkey="selectView('dayGridMonth')" />
-		<Hotkey :keys="['y']" @hotkey="selectView('multiMonthYear')" />
-		<Hotkey :keys="['4']" @hotkey="selectView('multiMonthYear')" />
-		<Hotkey :keys="['l']" @hotkey="selectView('listMonth')" />
-		<Hotkey :keys="['5']" @hotkey="selectView('listMonth')" />
-
-		<Actions menu-align="right">
-			<template #icon>
-				<component :is="defaultIcon" :size="20" decorative />
-			</template>
-			<ActionButton v-for="view in views"
-				:key="view.id"
-				:icon="view.icon"
-				@click="selectView(view.id)">
-				<template #icon>
-					<component :is="view.icon" :size="20" decorative />
-				</template>
-				{{ view.label }}
-			</ActionButton>
-		</Actions>
-	</div>
-</template>
-
-<script>
-import {
-	NcActions as Actions,
-	NcActionButton as ActionButton,
-} from '@nextcloud/vue'
-import { Hotkey } from '@simolation/vue-hotkey'
-
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useRoute, useRouter } from 'vue-router/composables'
+import { t } from '@nextcloud/l10n'
+import { NcActions, NcActionButton } from '@nextcloud/vue'
+import { useHotKey } from '@nextcloud/vue/composables/useHotKey'
 import ViewDay from 'vue-material-design-icons/ViewDay.vue'
 import ViewGrid from 'vue-material-design-icons/ViewGrid.vue'
 import ViewList from 'vue-material-design-icons/ViewList.vue'
@@ -47,67 +16,78 @@ import ViewModule from 'vue-material-design-icons/ViewModule.vue'
 import ViewWeek from 'vue-material-design-icons/ViewWeek.vue'
 import ViewComfy from 'vue-material-design-icons/ViewComfy.vue'
 
-export default {
-	name: 'AppNavigationHeaderViewMenu',
-	components: {
-		Actions,
-		ActionButton,
-		Hotkey,
-		ViewDay,
-		ViewGrid,
-		ViewComfy,
-		ViewList,
-		ViewModule,
-		ViewWeek,
-	},
-	computed: {
-		views() {
-			return [{
-				id: 'timeGridDay',
-				icon: 'ViewDay',
-				label: this.$t('calendar', 'Day'),
-			}, {
-				id: 'timeGridWeek',
-				icon: 'ViewWeek',
-				label: this.$t('calendar', 'Week'),
-			}, {
-				id: 'dayGridMonth',
-				icon: 'ViewModule',
-				label: this.$t('calendar', 'Month'),
-			}, {
-				id: 'multiMonthYear',
-				icon: 'ViewComfy',
-				label: this.$t('calendar', 'Year'),
-			}, {
-				id: 'listMonth',
-				icon: 'ViewList',
-				label: this.$t('calendar', 'List'),
-			}]
-		},
-		defaultIcon() {
-			for (const view of this.views) {
-				if (view.id === this.$route.params.view) {
-					return view.icon
-				}
-			}
+const route = useRoute()
+const router = useRouter()
 
-			return 'ViewGrid'
-		},
-	},
-	methods: {
-		selectView(viewName) {
-			const name = this.$route.name
-			const params = Object.assign({}, this.$route.params, {
-				view: viewName,
-			})
+const views = [{
+	id: 'timeGridDay',
+	icon: ViewDay,
+	label: t('calendar', 'Day'),
+}, {
+	id: 'timeGridWeek',
+	icon: ViewWeek,
+	label: t('calendar', 'Week'),
+}, {
+	id: 'dayGridMonth',
+	icon: ViewModule,
+	label: t('calendar', 'Month'),
+}, {
+	id: 'multiMonthYear',
+	icon: ViewComfy,
+	label: t('calendar', 'Year'),
+}, {
+	id: 'listMonth',
+	icon: ViewList,
+	label: t('calendar', 'List'),
+}]
 
-			// Don't push new route when view didn't change
-			if (this.$route.params.view === viewName) {
-				return
-			}
+const defaultIcon = computed(() => {
+	for (const view of views) {
+		if (view.id === route.params.view) {
+			return view.icon
+		}
+	}
 
-			this.$router.push({ name, params })
-		},
-	},
+	return ViewGrid
+})
+
+async function selectView(viewName: string): Promise<void> {
+	// Don't push new route when view didn't change
+	if (route.params.view === viewName) {
+		return
+	}
+
+	const name = route.name!
+	const params = {
+		...route.params,
+		view: viewName,
+	}
+
+	await router.push({ name, params })
 }
+
+useHotKey(['d', '1'], () => selectView('timeGridDay'))
+useHotKey(['w', '2'], () => selectView('timeGridWeek'))
+useHotKey(['m', '3'], () => selectView('dayGridMonth'))
+useHotKey(['y', '4'], () => selectView('multiMonthYear'))
+useHotKey(['l', '5'], () => selectView('listMonth'))
 </script>
+
+<template>
+	<div>
+		<NcActions menu-align="right">
+			<template #icon>
+				<component :is="defaultIcon" :size="20" />
+			</template>
+			<NcActionButton v-for="view in views"
+				:key="view.id"
+				:icon="view.icon"
+				@click="selectView(view.id)">
+				<template #icon>
+					<component :is="view.icon" :size="20" />
+				</template>
+				{{ view.label }}
+			</NcActionButton>
+		</NcActions>
+	</div>
+</template>


### PR DESCRIPTION
For https://github.com/nextcloud/calendar/issues/7466

I had to migrate the component to the setup script paradigm because it is not possible to access a method via this from the setup function. The method needs to be a inside the setup script too.

## Testing

1. Press all hotkeys and observe that the view changes: 1, 2, 3, 4, 5, d, w, m, y, l
2. Observe that the view icon changes (top left).