### PR TITLE
refactor: migrate AppNavigationHeaderTodayButton to setup script (and drop Hotkey usage)

### DIFF
--- a/src/components/AppNavigation/AppNavigationHeader/AppNavigationHeaderTodayButton.vue
+++ b/src/components/AppNavigation/AppNavigationHeader/AppNavigationHeaderTodayButton.vue
@@ -3,39 +3,36 @@
   - SPDX-License-Identifier: AGPL-3.0-or-later
 -->
 
-<template>
-	<Hotkey :keys="['t']" @hotkey="today">
-		<NcButton class="button today"
-			@click="today">
-			{{ $t('calendar', 'Today') }}
-		</NcButton>
-	</Hotkey>
-</template>
-
-<script>
+<script setup lang="ts">
+import { useRoute, useRouter } from 'vue-router/composables'
 import { NcButton } from '@nextcloud/vue'
-import { Hotkey } from '@simolation/vue-hotkey'
+import { useHotKey } from '@nextcloud/vue/composables/useHotKey'
+import { t } from '@nextcloud/l10n'
 
-export default {
-	name: 'AppNavigationHeaderTodayButton',
-	components: {
-		NcButton,
-		Hotkey,
-	},
-	methods: {
-		today() {
-			const name = this.$route.name
-			const params = Object.assign({}, this.$route.params, {
-				firstDay: 'now',
-			})
+const route = useRoute()
+const router = useRouter()
 
-			// Don't push new route when day didn't change
-			if (this.$route.params.firstDay === 'now') {
-				return
-			}
+async function today(): Promise<void> {
+	// Don't push new route when day didn't change
+	if (route.params.firstDay === 'now') {
+		return
+	}
 
-			this.$router.push({ name, params })
-		},
-	},
+	const name = route.name!
+	const params = {
+		...route.params,
+		firstDay: 'now',
+	}
+
+	await router.push({ name, params })
 }
+
+useHotKey('t', () => today())
 </script>
+
+<template>
+	<NcButton class="button today"
+		@click="today">
+		{{ t('calendar', 'Today') }}
+	</NcButton>
+</template>


### PR DESCRIPTION
For #7466 

I had to migrate the component to the setup script paradigm because it is not possible to access a method via this from the setup function. The method needs to be a inside the setup script too.

## Testing

1. Navigate to another day.
2. Press the today button (top left).
3. Navigate to another day.
4. Press the t key on your keyboard.

Step 2 and 4 should cause you to be back on today.