### PR TITLE
refactor: drop Hotkey usage in AppNavigationHeaderNewEvent

### DIFF
--- a/src/components/AppNavigation/AppNavigationHeader/AppNavigationHeaderNewEvent.vue
+++ b/src/components/AppNavigation/AppNavigationHeader/AppNavigationHeaderNewEvent.vue
@@ -4,42 +4,49 @@
 -->
 
 <template>
-	<Hotkey :keys="['c']" @hotkey="newEvent">
-		<NcButton class="button new-event"
-			type="primary"
-			:aria-label="newEventButtonAriaLabel"
-			@click="newEvent">
-			<template #icon>
-				<Plus :size="20" />
-			</template>
-			{{ $t('calendar', 'Event') }}
-		</NcButton>
-	</Hotkey>
+	<NcButton class="button new-event"
+		type="primary"
+		:aria-label="newEventButtonAriaLabel"
+		@click="newEvent">
+		<template #icon>
+			<Plus :size="20" />
+		</template>
+		{{ $t('calendar', 'Event') }}
+	</NcButton>
 </template>
 
 <script>
 import Plus from 'vue-material-design-icons/Plus.vue'
 import { NcButton } from '@nextcloud/vue'
-import { Hotkey } from '@simolation/vue-hotkey'
+import { useHotKey } from '@nextcloud/vue/composables/useHotKey'
+import { useRoute, useRouter } from 'vue-router/composables'
 
 export default {
 	name: 'AppNavigationHeaderNewEvent',
+	setup() {
+		const route = useRoute()
+		const router = useRouter()
+
+		/**
+		 * Opens the new event dialog
+		 */
+		async function newEvent() {
+			router.push(`/new/${route.params.view}`)
+		}
+
+		useHotKey('c', () => newEvent())
+
+		return {
+			newEvent,
+		}
+	},
 	components: {
 		Plus,
 		NcButton,
-		Hotkey,
 	},
 	computed: {
 		newEventButtonAriaLabel() {
 			return this.$t('calendar', 'Create new event')
-		},
-	},
-	methods: {
-		/**
-		 * Opens the new event dialog
-		 */
-		newEvent() {
-			this.$router.push(`/new/${this.$route.params.view}`)
 		},
 	},
 }


### PR DESCRIPTION
For #7466 

## Testing

1. Press the c key on your keyboard.
2. Observe the event creation dialog (editor) to show up.