### PR TITLE
refactor: migrate AppNavigationHeaderDatePicker to setup script (and drop Hotkey usage)

### DIFF
--- a/src/components/AppNavigation/AppNavigationHeader/AppNavigationHeaderDatePicker.vue
+++ b/src/components/AppNavigation/AppNavigationHeader/AppNavigationHeaderDatePicker.vue
@@ -3,13 +3,170 @@
   - SPDX-License-Identifier: AGPL-3.0-or-later
 -->
 
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+import {
+	getYYYYMMDDFromDate,
+	getDateFromFirstdayParam,
+	modifyDate,
+} from '../../../utils/date.js'
+import formatDateRange from '../../../filters/dateRangeFormat.js'
+import DatePicker from '../../Shared/DatePickerOld.vue'
+import ChevronLeftIcon from 'vue-material-design-icons/ChevronLeft.vue'
+import ChevronRightIcon from 'vue-material-design-icons/ChevronRight.vue'
+import { NcButton } from '@nextcloud/vue'
+import { useHotKey } from '@nextcloud/vue/composables/useHotKey'
+import useSettingsStore from '../../../store/settings.js'
+import useWidgetStore from '../../../store/widget.js'
+import { isRTL as isRTLFn, t } from '@nextcloud/l10n'
+import { useRoute, useRouter } from 'vue-router/composables'
+
+const props = defineProps<{
+	isWidget?: boolean,
+}>()
+
+const route = useRoute()
+const router = useRouter()
+
+const isDatepickerOpen = ref(false)
+
+const widgetStore = useWidgetStore()
+const settingsStore = useSettingsStore()
+const isRTL = computed(() => isRTLFn())
+
+const selectedDate = computed<Date>(() => {
+	if (props.isWidget) {
+		return getDateFromFirstdayParam(widgetStore.widgetDate)
+	}
+	return getDateFromFirstdayParam(route.params?.firstDay ?? 'now')
+})
+
+const formattedSelectedDate = computed<string>(
+	() => formatDateRange(selectedDate.value, view.value, settingsStore.momentLocale),
+)
+
+const view = computed<string>(() => {
+	if (props.isWidget) {
+		return widgetStore.widgetView
+	}
+	return route.params.view
+})
+
+const previousLabel = computed(() => {
+	switch (view.value) {
+	case 'timeGridDay':
+		return t('calendar', 'Previous day')
+
+	case 'timeGridWeek':
+		return t('calendar', 'Previous week')
+
+	case 'multiMonthYear':
+		return t('calendar', 'Previous year')
+
+	case 'dayGridMonth':
+	default:
+		return t('calendar', 'Previous month')
+	}
+})
+
+const nextLabel = computed(() => {
+	switch (view.value) {
+	case 'timeGridDay':
+		return t('calendar', 'Next day')
+
+	case 'timeGridWeek':
+		return t('calendar', 'Next week')
+
+	case 'multiMonthYear':
+		return t('calendar', 'Next year')
+
+	case 'dayGridMonth':
+	default:
+		return t('calendar', 'Next month')
+	}
+})
+
+function navigateTimeRangeForward(): void {
+	navigateTimeRangeByFactor(1)
+}
+
+function navigateTimeRangeBackward(): void {
+	navigateTimeRangeByFactor(-1)
+}
+
+function navigateTimeRangeByFactor(factor: number): void {
+	let newDate: Date | undefined
+
+	switch (route.params.view) {
+	case 'timeGridDay':
+		newDate = modifyDate(selectedDate.value, {
+			day: factor,
+		})
+		break
+
+	case 'timeGridWeek':
+		newDate = modifyDate(selectedDate.value, {
+			week: factor,
+		})
+		break
+
+	case 'multiMonthYear':
+		newDate = modifyDate(selectedDate.value, {
+			year: factor,
+		})
+		break
+
+	case 'dayGridMonth':
+	case 'listMonth':
+	default: {
+		// modifyDate is just adding one month, so we have to manually
+		// set the date of month to 1. Otherwise if your date is set to
+		// January 30th and you add one month, February 30th doesn't exist
+		// and it automatically changes to March 1st. Same happens on March 31st.
+		const firstDayOfCurrentMonth = new Date(selectedDate.value.getTime())
+		firstDayOfCurrentMonth.setDate(1)
+		newDate = modifyDate(firstDayOfCurrentMonth, {
+			month: factor,
+		})
+		break
+	}
+	}
+
+	// newDate is always set at this point
+	// TODO: migrate modifyDate() to TypeScript to fix typing
+	navigateToDate(newDate!)
+}
+
+async function navigateToDate(date: Date): Promise<void> {
+	if (props.isWidget) {
+		widgetStore.setWidgetDate({ widgetDate: getYYYYMMDDFromDate(date) })
+	} else {
+		// Don't push new route when day didn't change
+		if (route.params.firstDay === getYYYYMMDDFromDate(date)) {
+			return
+		}
+
+		const name = route.name!
+		const params = {
+			...route.params,
+			firstDay: getYYYYMMDDFromDate(date),
+		}
+
+		await router.push({ name, params })
+	}
+}
+
+function toggleDatepicker() {
+	isDatepickerOpen.value = !isDatepickerOpen.value
+}
+
+useHotKey(['n', 'j'], () => navigateTimeRangeForward())
+useHotKey(['p', 'k'], () => navigateTimeRangeBackward())
+</script>
+
 <template>
 	<div class="datepicker-button-section">
-		<Hotkey :keys="['n']" @hotkey="navigateTimeRangeForward" />
-		<Hotkey :keys="['j']" @hotkey="navigateTimeRangeForward" />
-		<Hotkey :keys="['p']" @hotkey="navigateTimeRangeBackward" />
-		<Hotkey :keys="['k']" @hotkey="navigateTimeRangeBackward" />
-		<NcButton v-if="!isWidget"
+		<NcButton v-if="!props.isWidget"
 			:aria-label="isRTL? nextLabel: previousLabel"
 			class="button"
 			:class="{'datepicker-button-section__right': isRTL , 'datepicker-button-section__left': !isRTL}"
@@ -20,22 +177,22 @@
 				<ChevronLeftIcon v-else :size="22" />
 			</template>
 		</NcButton>
-		<NcButton v-if="!isWidget"
+		<NcButton v-if="!props.isWidget"
 			class="datepicker-button-section__datepicker-label button datepicker-label"
 			@click.stop.prevent="toggleDatepicker"
-			@mousedown.stop.prevent="doNothing"
-			@mouseup.stop.prevent="doNothing">
-			{{ selectedDate | formatDateRange(view, locale) }}
+			@mousedown.stop.prevent="() => {}"
+			@mouseup.stop.prevent="() => {}">
+			{{ formattedSelectedDate }}
 		</NcButton>
 		<DatePicker ref="datepicker"
-			:class="isWidget ? 'datepicker-widget':'datepicker-button-section__datepicker'"
-			:append-to-body="isWidget"
+			:class="props.isWidget ? 'datepicker-widget':'datepicker-button-section__datepicker'"
+			:append-to-body="props.isWidget"
 			:date="selectedDate"
 			:is-all-day="true"
 			:open.sync="isDatepickerOpen"
 			:type="view === 'multiMonthYear' ? 'year' : 'date'"
 			@change="navigateToDate" />
-		<NcButton v-if="!isWidget"
+		<NcButton v-if="!props.isWidget"
 			:aria-label="isRTL? previousLabel: nextLabel"
 			class="button"
 			:class="{'datepicker-button-section__right': !isRTL , 'datepicker-button-section__left': isRTL}"
@@ -49,173 +206,6 @@
 	</div>
 </template>
 
-<script>
-import {
-	getYYYYMMDDFromDate,
-	getDateFromFirstdayParam,
-	modifyDate,
-} from '../../../utils/date.js'
-import { mapState, mapStores } from 'pinia'
-import formatDateRange from '../../../filters/dateRangeFormat.js'
-import DatePicker from '../../Shared/DatePickerOld.vue'
-import ChevronLeftIcon from 'vue-material-design-icons/ChevronLeft.vue'
-import ChevronRightIcon from 'vue-material-design-icons/ChevronRight.vue'
-import { NcButton } from '@nextcloud/vue'
-import { Hotkey } from '@simolation/vue-hotkey'
-import useSettingsStore from '../../../store/settings.js'
-import useWidgetStore from '../../../store/widget.js'
-import { isRTL } from '@nextcloud/l10n'
-
-export default {
-	name: 'AppNavigationHeaderDatePicker',
-	components: {
-		DatePicker,
-		ChevronLeftIcon,
-		ChevronRightIcon,
-		NcButton,
-		Hotkey,
-	},
-	filters: {
-		formatDateRange,
-	},
-	props: {
-		isWidget: {
-			type: Boolean,
-			default: false,
-		},
-	},
-	data() {
-		return {
-			isDatepickerOpen: false,
-		}
-	},
-	computed: {
-		...mapStores(useWidgetStore),
-		...mapState(useSettingsStore, {
-			locale: 'momentLocale',
-		}),
-		isRTL() {
-			return isRTL()
-		},
-		selectedDate() {
-			if (this.isWidget) {
-				return getDateFromFirstdayParam(this.widgetStore.widgetDate)
-			}
-			return getDateFromFirstdayParam(this.$route.params?.firstDay ?? 'now')
-		},
-		previousLabel() {
-			switch (this.view) {
-			case 'timeGridDay':
-				return this.$t('calendar', 'Previous day')
-
-			case 'timeGridWeek':
-				return this.$t('calendar', 'Previous week')
-
-			case 'multiMonthYear':
-				return this.$t('calendar', 'Previous year')
-
-			case 'dayGridMonth':
-			default:
-				return this.$t('calendar', 'Previous month')
-			}
-		},
-		nextLabel() {
-			switch (this.view) {
-			case 'timeGridDay':
-				return this.$t('calendar', 'Next day')
-
-			case 'timeGridWeek':
-				return this.$t('calendar', 'Next week')
-
-			case 'multiMonthYear':
-				return this.$t('calendar', 'Next year')
-
-			case 'dayGridMonth':
-			default:
-				return this.$t('calendar', 'Next month')
-			}
-		},
-		view() {
-			if (this.isWidget) {
-				return this.widgetStore.widgetView
-			}
-			return this.$route.params.view
-		},
-	},
-	methods: {
-		navigateTimeRangeForward() {
-			return this.navigateTimeRangeByFactor(1)
-		},
-		navigateTimeRangeBackward() {
-			return this.navigateTimeRangeByFactor(-1)
-		},
-		navigateTimeRangeByFactor(factor) {
-			let newDate
-
-			switch (this.$route.params.view) {
-			case 'timeGridDay':
-				newDate = modifyDate(this.selectedDate, {
-					day: factor,
-				})
-				break
-
-			case 'timeGridWeek':
-				newDate = modifyDate(this.selectedDate, {
-					week: factor,
-				})
-				break
-
-			case 'multiMonthYear':
-				newDate = modifyDate(this.selectedDate, {
-					year: factor,
-				})
-				break
-
-			case 'dayGridMonth':
-			case 'listMonth':
-			default: {
-				// modifyDate is just adding one month, so we have to manually
-				// set the date of month to 1. Otherwise if your date is set to
-				// January 30th and you add one month, February 30th doesn't exist
-				// and it automatically changes to March 1st. Same happens on March 31st.
-				const firstDayOfCurrentMonth = new Date(this.selectedDate.getTime())
-				firstDayOfCurrentMonth.setDate(1)
-				newDate = modifyDate(firstDayOfCurrentMonth, {
-					month: factor,
-				})
-				break
-			}
-			}
-
-			this.navigateToDate(newDate)
-		},
-		navigateToDate(date) {
-			if (this.isWidget) {
-				this.widgetStore.setWidgetDate({ widgetDate: getYYYYMMDDFromDate(date) })
-			} else {
-				const name = this.$route.name
-				const params = Object.assign({}, this.$route.params, {
-					firstDay: getYYYYMMDDFromDate(date),
-				})
-
-				// Don't push new route when day didn't change
-				if (this.$route.params.firstDay === getYYYYMMDDFromDate(date)) {
-					return
-				}
-
-				this.$router.push({ name, params })
-			}
-		},
-		toggleDatepicker() {
-			this.isDatepickerOpen = !this.isDatepickerOpen
-		},
-		doNothing() {
-			// This function does nothing in itself,
-			// it only captures and prevents the mousedown and mouseup of vue2-datepicker
-		},
-	},
-}
-</script>
 <style lang="scss">
 .datepicker-widget{
 	width: 135px;


### PR DESCRIPTION
For #7466 

I had to migrate the component to the setup script paradigm because it is not possible to access a method via this from the setup function. The method needs to be a inside the setup script too.

## Testing

1. Click left and right (previous and next) on the date picker widget on the top left.
2. Use the hotkeys: j, k, n and p (**Note:** n is currently broken as it collides with the sidebar)
3. Observe that the selected time range changes.
4. Also check the text in the middle. It should reflect the current time range in a human readable manner.