### PR TITLE
[stable6.0] chore(deps): drop obsolete vue-hotkey dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "calendar",
-      "version": "6.0.0-rc.4",
+      "version": "6.0.0-rc.5",
       "license": "agpl",
       "dependencies": {
         "@fullcalendar/core": "6.1.19",
@@ -33,7 +33,6 @@
         "@nextcloud/router": "^3.0.1",
         "@nextcloud/timezones": "^1.0.0",
         "@nextcloud/vue": "^8.29.1",
-        "@simolation/vue-hotkey": "^2.1.2",
         "autosize": "^6.0.1",
         "color-convert": "^3.1.0",
         "color-string": "^2.0.1",
@@ -4270,50 +4269,6 @@
       },
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/@simolation/vue-hotkey": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@simolation/vue-hotkey/-/vue-hotkey-2.1.2.tgz",
-      "integrity": "sha512-Ps24BNhhFnYGEwB9mobjKg5UJnwm/llluPE7pDpw5gDjmK6T41CiG8odfNTyFSysjIzyn6PVreMJcz2qQtoYrw==",
-      "license": "MIT",
-      "dependencies": {
-        "vue-demi": "^0.14.10"
-      },
-      "peerDependencies": {
-        "@vue/composition-api": "^1.0.0-rc.1",
-        "vue": "^2.0.0 || >=3.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@vue/composition-api": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@simolation/vue-hotkey/node_modules/vue-demi": {
-      "version": "0.14.10",
-      "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.14.10.tgz",
-      "integrity": "sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "bin": {
-        "vue-demi-fix": "bin/vue-demi-fix.js",
-        "vue-demi-switch": "bin/vue-demi-switch.js"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/antfu"
-      },
-      "peerDependencies": {
-        "@vue/composition-api": "^1.0.0-rc.1",
-        "vue": "^3.0.0-0 || ^2.6.0"
-      },
-      "peerDependenciesMeta": {
-        "@vue/composition-api": {
-          "optional": true
-        }
       }
     },
     "node_modules/@sinclair/typebox": {

--- a/package.json
+++ b/package.json
@@ -61,7 +61,6 @@
     "@nextcloud/router": "^3.0.1",
     "@nextcloud/timezones": "^1.0.0",
     "@nextcloud/vue": "^8.29.1",
-    "@simolation/vue-hotkey": "^2.1.2",
     "autosize": "^6.0.1",
     "color-convert": "^3.1.0",
     "color-string": "^2.0.1",


### PR DESCRIPTION
Manual backport of #7476 