### PR TITLE
fix: order all-day events by name

### DIFF
--- a/src/components/CalendarGrid.vue
+++ b/src/components/CalendarGrid.vue
@@ -39,7 +39,11 @@ import momentPlugin from '../fullcalendar/localization/momentPlugin.js'
 // Import rendering handlers
 import dayHeaderDidMount from '../fullcalendar/rendering/dayHeaderDidMount.js'
 import eventDidMount from '../fullcalendar/rendering/eventDidMount.js'
-import eventOrder from '../fullcalendar/rendering/eventOrder.js'
+import {
+	eventOrder,
+	eventDurationOrderDesc,
+	eventStartOrder,
+} from '../fullcalendar/rendering/eventOrder.js'
 import noEventsDidMount from '../fullcalendar/rendering/noEventsDidMount.js'
 
 // Import timezone plugins
@@ -134,7 +138,7 @@ export default {
 				dayHeaderDidMount,
 				eventDidMount,
 				noEventsDidMount,
-				eventOrder: ['start', '-duration', 'allDay', eventOrder],
+				eventOrder: [eventStartOrder, eventDurationOrderDesc, 'allDay', eventOrder],
 				forceEventDuration: false,
 				headerToolbar: false,
 				height: '100%',

--- a/src/fullcalendar/rendering/eventOrder.js
+++ b/src/fullcalendar/rendering/eventOrder.js
@@ -4,6 +4,36 @@
  */
 
 /**
+ * This sorts events by their start date and time and skips all-day events.
+ *
+ * @param {EventApi} first The first full-calendar event
+ * @param {EventApi} second The second full-calendar event
+ * @return {number}
+ */
+export function eventStartOrder(first, second) {
+	if (first.allDay && second.allDay) {
+		return 0
+	}
+
+	return first.start - second.start
+}
+
+/**
+ * This sorts events by their duration in descending order and skips all-day events.
+ *
+ * @param {EventApi} first The first full-calendar event
+ * @param {EventApi} second The second full-calendar event
+ * @return {number}
+ */
+export function eventDurationOrderDesc(first, second) {
+	if (first.allDay && second.allDay) {
+		return 0
+	}
+
+	return second.duration - first.duration
+}
+
+/**
  * This sorts events when they occur at the same time, have the same duration
  * and the same all-day property
  *
@@ -11,7 +41,7 @@
  * @param {EventApi} secondEvent The second full-calendar event
  * @return {number}
  */
-export default function(firstEvent, secondEvent) {
+export function eventOrder(firstEvent, secondEvent) {
 	if (firstEvent.extendedProps.calendarOrder !== secondEvent.extendedProps.calendarOrder) {
 		return (firstEvent.extendedProps.calendarOrder - secondEvent.extendedProps.calendarOrder) < 0 ? -1 : 1
 	}

--- a/tests/javascript/unit/fullcalendar/rendering/eventOrder.test.js
+++ b/tests/javascript/unit/fullcalendar/rendering/eventOrder.test.js
@@ -2,7 +2,11 @@
  * SPDX-FileCopyrightText: 2019 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
-import eventOrder from '../../../../../src/fullcalendar/rendering/eventOrder.js'
+import {
+	eventOrder,
+	eventStartOrder,
+	eventDurationOrderDesc,
+} from '../../../../../src/fullcalendar/rendering/eventOrder.js'
 
 describe('fullcalendar/eventOrder test suite', () => {
 
@@ -116,4 +120,65 @@ describe('fullcalendar/eventOrder test suite', () => {
 		expect(eventOrder(secondEvent, firstEvent)).toEqual(0)
 	})
 
+	it('should sort events by start (ascending)', () => {
+		const firstEvent = {
+			title: 'Title 123',
+			start: 1000,
+		}
+		const secondEvent = {
+			title: 'Title 123',
+			start: 1001,
+		}
+
+		expect(eventStartOrder(firstEvent, secondEvent)).toBeLessThan(0)
+		expect(eventStartOrder(secondEvent, firstEvent)).toBeGreaterThan(0)
+		expect(eventStartOrder(firstEvent, firstEvent)).toBe(0)
+	})
+
+	it('should sort events by start - skip all-day', () => {
+		const firstEvent = {
+			title: 'Title 123',
+			start: 1000,
+			allDay: 1,
+		}
+		const secondEvent = {
+			title: 'Title 123',
+			start: 1001,
+			allDay: 1,
+		}
+
+		expect(eventStartOrder(firstEvent, secondEvent)).toBe(0)
+		expect(eventStartOrder(secondEvent, firstEvent)).toBe(0)
+	})
+
+	it('should sort events by duration (descending)', () => {
+		const firstEvent = {
+			title: 'Title 123',
+			duration: 1000,
+		}
+		const secondEvent = {
+			title: 'Title 123',
+			duration: 1001,
+		}
+
+		expect(eventDurationOrderDesc(firstEvent, secondEvent)).toBeGreaterThan(0)
+		expect(eventDurationOrderDesc(secondEvent, firstEvent)).toBeLessThan(0)
+		expect(eventDurationOrderDesc(firstEvent, firstEvent)).toBe(0)
+	})
+
+	it('should sort events by duration - skip all-day', () => {
+		const firstEvent = {
+			title: 'Title 123',
+			duration: 1000,
+			allDay: 1,
+		}
+		const secondEvent = {
+			title: 'Title 123',
+			duration: 1001,
+			allDay: 1,
+		}
+
+		expect(eventDurationOrderDesc(firstEvent, secondEvent)).toBe(0)
+		expect(eventDurationOrderDesc(secondEvent, firstEvent)).toBe(0)
+	})
 })


### PR DESCRIPTION
## Before
<img width="1340" height="229" alt="Screenshot_20250924_115356" src="https://github.com/user-attachments/assets/cd56c115-6a03-4c37-a9b3-db3c55a7c4bf" />

## After
<img width="1339" height="228" alt="Screenshot_20250924_115340" src="https://github.com/user-attachments/assets/fd0bf931-7288-48ec-b42b-942ba369c6ea" />

