### PR TITLE
fix: embedded calendar header not responsive

### DIFF
--- a/css/public.scss
+++ b/css/public.scss
@@ -11,7 +11,8 @@
 	flex-direction: column;
 
 	#embed-header {
-		height: 50px;
+		flex-wrap: wrap;
+		gap: calc(var(--default-grid-baseline) * 2);
 		width: 100%;
 		padding: calc(var(--default-grid-baseline) * 2);
 		box-sizing: border-box;


### PR DESCRIPTION
Fix https://github.com/nextcloud/calendar/issues/3218

| Before | After |
| --- | --- |
| <img width="494" height="523" alt="Bildschirmfoto vom 2025-09-28 17-44-56" src="https://github.com/user-attachments/assets/b5d53bf4-4f75-4e0f-a5ee-fc27d8fda23a" /> | <img width="496" height="616" alt="Bildschirmfoto vom 2025-09-28 17-44-19" src="https://github.com/user-attachments/assets/04b2bb5c-5328-445a-a116-2a7fa2a78b56" /> |
