### PR TITLE
ci(e2e-test): run apt-get update before installing stunnel

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -61,7 +61,7 @@ jobs:
         working-directory: nextcloud/apps/calendar
         run: npm run build
       - name: Install stunnel (tiny https proxy)
-        run: sudo apt-get install -y stunnel
+        run: sudo apt-get update && sudo apt-get install -y stunnel
       - name: Start php server and https proxy
         working-directory: nextcloud
         run: |


### PR DESCRIPTION
CI might fail if it tries to install old/outdated packages.