### PR TITLE
fix(rtl): calendar grid direction

### DIFF
--- a/src/fullcalendar/localization/localeProvider.js
+++ b/src/fullcalendar/localization/localeProvider.js
@@ -2,7 +2,7 @@
  * SPDX-FileCopyrightText: 2020 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
-import { getFirstDay, getLanguage, translate as t } from '@nextcloud/l10n'
+import { getFirstDay, getLanguage, isRTL, translate as t } from '@nextcloud/l10n'
 
 /**
  * Returns localization settings for the FullCalender package.
@@ -14,6 +14,7 @@ function getFullCalendarLocale() {
 	return {
 		firstDay: getFirstDay(),
 		locale: getLanguage(),
+		direction: isRTL() ? 'rtl' : 'ltr',
 		// TRANSLATORS W is an abbreviation for Week
 		weekText: t('calendar', 'W'),
 		allDayText: t('calendar', 'All day'),


### PR DESCRIPTION
| b | a |
|--------|--------|
|<img width="1602" height="720" alt="image" src="https://github.com/user-attachments/assets/ee92d152-f254-417e-b3d3-d0b4415bde1d" /> |<img width="1602" height="720" alt="image" src="https://github.com/user-attachments/assets/fcd9ac9b-aab4-4035-94c8-e0df2a1439e1" /> | 