### PR TITLE
Prevent event date change glitch

### DIFF
--- a/src/components/Editor/Properties/PropertyTitleTimePicker.vue
+++ b/src/components/Editor/Properties/PropertyTitleTimePicker.vue
@@ -128,7 +128,6 @@
 <script>
 import moment from '@nextcloud/moment'
 import { NcButton, NcTimezonePicker } from '@nextcloud/vue'
-import { debounce } from 'lodash'
 import { mapState } from 'pinia'
 import CalendarIcon from 'vue-material-design-icons/CalendarOutline.vue'
 import IconTimezone from 'vue-material-design-icons/Web.vue'
@@ -317,18 +316,18 @@ export default {
 		 *
 		 * @param {Date} value The new start date
 		 */
-		changeStartDate: debounce(function(value) {
+		changeStartDate(value) {
 			this.$emit('update-start-date', value)
-		}, 500),
+		},
 
 		/**
 		 * Update the start time
 		 *
 		 * @param {Date} value The new start time
 		 */
-		changeStartTime: debounce(function(value) {
+		changeStartTime(value) {
 			this.$emit('update-start-time', value)
-		}, 500),
+		},
 
 		/**
 		 * Updates the timezone of the start date
@@ -350,18 +349,18 @@ export default {
 		 *
 		 * @param {Date} value The new end date
 		 */
-		changeEndDate: debounce(function(value) {
+		changeEndDate(value) {
 			this.$emit('update-end-date', value)
-		}, 500),
+		},
 
 		/**
 		 * Update the end time
 		 *
 		 * @param {Date} value The new end time
 		 */
-		changeEndTime: debounce(function(value) {
+		changeEndTime(value) {
 			this.$emit('update-end-time', value)
-		}, 500),
+		},
 
 		/**
 		 * Updates the timezone of the end date

--- a/src/components/Shared/DatePicker.vue
+++ b/src/components/Shared/DatePicker.vue
@@ -12,14 +12,14 @@
 		:type="type"
 		:hide-label="true"
 		class="date-time-picker"
-		@input="change" />
+		@blur="onBlur"
+		@input="onInput" />
 </template>
 
 <script>
 import {
 	NcDateTimePickerNative as DateTimePicker,
 } from '@nextcloud/vue'
-import debounce from 'debounce'
 import { mapStores } from 'pinia'
 import useDavRestrictionsStore from '../../store/davRestrictions.js'
 
@@ -56,6 +56,12 @@ export default {
 		},
 	},
 
+	data() {
+		return {
+			pendingDate: null,
+		}
+	},
+
 	computed: {
 		...mapStores(useDavRestrictionsStore),
 		/**
@@ -83,13 +89,26 @@ export default {
 		 *
 		 * @param {Date} date The new Date object
 		 */
-		change: debounce(async function(date) {
+		onInput(date) {
+			// Buffer the input; only emit when the user leaves the field
 			if (this.disabledDate(date)) {
 				return
 			}
+			this.pendingDate = date
+		},
 
-			this.$emit('change', date)
-		}, 1000),
+		onBlur(event) {
+			// When focus leaves the picker, commit the pending date
+			if (this.pendingDate === undefined || this.pendingDate === null) {
+				return
+			}
+			const pending = this.pendingDate
+			this.pendingDate = null
+			if (this.disabledDate(pending)) {
+				return
+			}
+			this.$emit('change', pending)
+		},
 
 		/**
 		 * Whether or not the date is acceptable


### PR DESCRIPTION
Fixes #7509 by only committing date/time changes when the user leaves the input field. This is similiar e.g. to the behavior of Thunderbird.