### PR TITLE
fix(appointments): unify IDs

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -21,8 +21,8 @@ return [
 		// Appointments
 		['name' => 'appointment#index', 'url' => '/appointments/{userId}', 'verb' => 'GET'],
 		['name' => 'appointment#show', 'url' => '/appointment/{token}', 'verb' => 'GET'],
-		['name' => 'booking#getBookableSlots', 'url' => '/appointment/{appointmentConfigId}/slots', 'verb' => 'GET'],
-		['name' => 'booking#bookSlot', 'url' => '/appointment/{appointmentConfigId}/book', 'verb' => 'POST'],
+		['name' => 'booking#getBookableSlots', 'url' => '/appointment/{appointmentConfigToken}/slots', 'verb' => 'GET'],
+		['name' => 'booking#bookSlot', 'url' => '/appointment/{appointmentConfigToken}/book', 'verb' => 'POST'],
 		['name' => 'booking#confirmBooking', 'url' => '/appointment/confirm/{token}', 'verb' => 'GET'],
 		// Public views
 		['name' => 'publicView#public_index_with_branding', 'url' => '/p/{token}', 'verb' => 'GET'],

--- a/src/services/appointmentService.js
+++ b/src/services/appointmentService.js
@@ -12,8 +12,8 @@ import { generateUrl } from '@nextcloud/router'
  * @param timeZone {String} target time zone for the time stamps
  */
 export async function findSlots(config, date, timeZone) {
-	const url = generateUrl('/apps/calendar/appointment/{id}/slots?dateSelected={date}&timeZone={timeZone}', {
-		id: config.id,
+	const url = generateUrl('/apps/calendar/appointment/{token}/slots?dateSelected={date}&timeZone={timeZone}', {
+		token: config.token,
 		date,
 		timeZone,
 	})
@@ -32,8 +32,8 @@ export async function findSlots(config, date, timeZone) {
  * @param timeZone
  */
 export async function bookSlot(config, slot, displayName, email, description, timeZone) {
-	const url = generateUrl('/apps/calendar/appointment/{id}/book', {
-		id: config.id,
+	const url = generateUrl('/apps/calendar/appointment/{token}/book', {
+		token: config.token,
 	})
 
 	const response = await axios.post(url, {

--- a/tests/php/unit/Controller/BookingControllerTest.php
+++ b/tests/php/unit/Controller/BookingControllerTest.php
@@ -114,18 +114,19 @@ class BookingControllerTest extends TestCase {
 
 		$apptConfg = new AppointmentConfig();
 		$apptConfg->setId(1);
+		$apptConfg->setToken('abc123');
 		$this->time->expects(self::once())
 			->method('getTime')
 			->willReturn($currentDate);
 		$this->apptService->expects(self::once())
-			->method('findById')
-			->with(1)
+			->method('findByToken')
+			->with($apptConfg->getToken())
 			->willReturn($apptConfg);
 		$this->bookingService->expects(self::once())
 			->method('getAvailableSlots')
 			->with($apptConfg, $sDT, $eDT);
 
-		$this->controller->getBookableSlots($apptConfg->getId(), $selectedDate, $selectedTz);
+		$this->controller->getBookableSlots($apptConfg->getToken(), $selectedDate, $selectedTz);
 	}
 
 	public function testGetBookableSlotsDatesInPast(): void {
@@ -133,34 +134,36 @@ class BookingControllerTest extends TestCase {
 		$selectedDate = '2024-7-1';
 		$apptConfg = new AppointmentConfig();
 		$apptConfg->setId(1);
+		$apptConfg->setToken('abc123');
 		$this->time->expects(self::once())
 			->method('getTime')
 			->willReturn($currentDate);
 		$this->apptService->expects(self::never())
-			->method('findById')
-			->with(1);
+			->method('findByToken')
+			->with($apptConfg->getToken());
 		$this->bookingService->expects(self::never())
 			->method('getAvailableSlots');
 		$this->logger->expects(self::once())
 			->method('warning');
 
-		$this->controller->getBookableSlots($apptConfg->getId(), $selectedDate, 'Europe/Berlin');
+		$this->controller->getBookableSlots($apptConfg->getToken(), $selectedDate, 'Europe/Berlin');
 	}
 
 	public function testGetBookableSlotsInvalidTimezone(): void {
 		$selectedDate = '2024-7-1';
 		$apptConfg = new AppointmentConfig();
 		$apptConfg->setId(1);
+		$apptConfg->setToken('abc123');
 		$this->time->expects(self::never())
 			->method('getTime');
 		$this->apptService->expects(self::never())
-			->method('findById')
-			->with(1);
+			->method('findByToken')
+			->with($apptConfg->getToken());
 		$this->bookingService->expects(self::never())
 			->method('getAvailableSlots');
 		$this->expectException(Exception::class);
 
-		$this->controller->getBookableSlots($apptConfg->getId(), $selectedDate, 'Hook/Neverland');
+		$this->controller->getBookableSlots($apptConfg->getToken(), $selectedDate, 'Hook/Neverland');
 	}
 
 	public function testGetBookableSlotsTimezoneIdentical(): void {
@@ -173,18 +176,19 @@ class BookingControllerTest extends TestCase {
 
 		$apptConfg = new AppointmentConfig();
 		$apptConfg->setId(1);
+		$apptConfg->setToken('abc123');
 		$this->time->expects(self::once())
 			->method('getTime')
 			->willReturn($currentDate);
 		$this->apptService->expects(self::once())
-			->method('findById')
-			->with(1)
+			->method('findByToken')
+			->with($apptConfg->getToken())
 			->willReturn($apptConfg);
 		$this->bookingService->expects(self::once())
 			->method('getAvailableSlots')
 			->with($apptConfg, $sDT, $eDT);
 
-		$this->controller->getBookableSlots($apptConfg->getId(), $selectedDate, $selectedTz);
+		$this->controller->getBookableSlots($apptConfg->getToken(), $selectedDate, $selectedTz);
 	}
 
 	public function testGetBookableSlotsTimezoneMinus10(): void {
@@ -197,18 +201,19 @@ class BookingControllerTest extends TestCase {
 
 		$apptConfg = new AppointmentConfig();
 		$apptConfg->setId(1);
+		$apptConfg->setToken('abc123');
 		$this->time->expects(self::once())
 			->method('getTime')
 			->willReturn($currentDate);
 		$this->apptService->expects(self::once())
-			->method('findById')
-			->with(1)
+			->method('findByToken')
+			->with($apptConfg->getToken())
 			->willReturn($apptConfg);
 		$this->bookingService->expects(self::once())
 			->method('getAvailableSlots')
 			->with($apptConfg, $sDT, $eDT);
 
-		$this->controller->getBookableSlots($apptConfg->getId(), $selectedDate, $timezone);
+		$this->controller->getBookableSlots($apptConfg->getToken(), $selectedDate, $timezone);
 	}
 
 	public function testGetBookableSlotsTimezonePlus10(): void {
@@ -221,18 +226,19 @@ class BookingControllerTest extends TestCase {
 
 		$apptConfg = new AppointmentConfig();
 		$apptConfg->setId(1);
+		$apptConfg->setToken('abc123');
 		$this->time->expects(self::once())
 			->method('getTime')
 			->willReturn($currentDate);
 		$this->apptService->expects(self::once())
-			->method('findById')
-			->with(1)
+			->method('findByToken')
+			->with($apptConfg->getToken())
 			->willReturn($apptConfg);
 		$this->bookingService->expects(self::once())
 			->method('getAvailableSlots')
 			->with($apptConfg, $sDT, $eDT);
 
-		$this->controller->getBookableSlots($apptConfg->getId(), $selectedDate, $timezone);
+		$this->controller->getBookableSlots($apptConfg->getToken(), $selectedDate, $timezone);
 	}
 
 	public function testGetBookableSlotsTimezonePlus14(): void {
@@ -245,18 +251,19 @@ class BookingControllerTest extends TestCase {
 
 		$apptConfg = new AppointmentConfig();
 		$apptConfg->setId(1);
+		$apptConfg->setToken('abc123');
 		$this->time->expects(self::once())
 			->method('getTime')
 			->willReturn($currentDate);
 		$this->apptService->expects(self::once())
-			->method('findById')
-			->with(1)
+			->method('findByToken')
+			->with($apptConfg->getToken())
 			->willReturn($apptConfg);
 		$this->bookingService->expects(self::once())
 			->method('getAvailableSlots')
 			->with($apptConfg, $sDT, $eDT);
 
-		$this->controller->getBookableSlots($apptConfg->getId(), $selectedDate, $timezone);
+		$this->controller->getBookableSlots($apptConfg->getToken(), $selectedDate, $timezone);
 	}
 
 	public function testBook(): void {
@@ -268,14 +275,14 @@ class BookingControllerTest extends TestCase {
 			->with($email)
 			->willReturn(true);
 		$this->apptService->expects(self::once())
-			->method('findById')
+			->method('findByToken')
 			->willReturn($config);
 		$this->bookingService->expects(self::once())
 			->method('book')
 			->with($config, 1, 1, 'Hook/Neverland', 'Test', $email, 'Test')
 			->willReturn(new Booking());
 
-		$this->controller->bookSlot(1, 1, 1, 'Test', $email, 'Test', 'Hook/Neverland');
+		$this->controller->bookSlot('abc123', 1, 1, 'Test', $email, 'Test', 'Hook/Neverland');
 	}
 
 
@@ -288,14 +295,14 @@ class BookingControllerTest extends TestCase {
 			->with($email)
 			->willReturn(true);
 		$this->apptService->expects(self::once())
-			->method('findById')
+			->method('findByToken')
 			->willReturn($config);
 		$this->bookingService->expects(self::once())
 			->method('book')
 			->with($config, 1, 1, 'Hook/Neverland', 'Test', $email, 'Test')
 			->willThrowException(new InvalidArgumentException());
 
-		$this->controller->bookSlot(1, 1, 1, 'Test', $email, 'Test', 'Hook/Neverland');
+		$this->controller->bookSlot('abc123', 1, 1, 'Test', $email, 'Test', 'Hook/Neverland');
 	}
 
 	public function testBookInvalidSlot(): void {
@@ -307,14 +314,14 @@ class BookingControllerTest extends TestCase {
 			->with($email)
 			->willReturn(true);
 		$this->apptService->expects(self::once())
-			->method('findById')
+			->method('findByToken')
 			->willReturn($config);
 		$this->bookingService->expects(self::once())
 			->method('book')
 			->with($config, 1, 1, 'Europe/Berlin', 'Test', $email, 'Test')
 			->willThrowException(new NoSlotFoundException());
 
-		$this->controller->bookSlot(1, 1, 1, 'Test', $email, 'Test', 'Europe/Berlin');
+		$this->controller->bookSlot('abc123', 1, 1, 'Test', $email, 'Test', 'Europe/Berlin');
 	}
 
 	public function testBookInvalidBooking(): void {
@@ -326,7 +333,7 @@ class BookingControllerTest extends TestCase {
 			->with($email)
 			->willReturn(true);
 		$this->apptService->expects(self::once())
-			->method('findById')
+			->method('findByToken')
 			->willReturn($config);
 		$this->bookingService->expects(self::once())
 			->method('book')
@@ -337,7 +344,7 @@ class BookingControllerTest extends TestCase {
 			->with('debug')
 			->willReturn(false);
 
-		$this->controller->bookSlot(1, 1, 1, 'Test', $email, 'Test', 'Europe/Berlin');
+		$this->controller->bookSlot('abc123', 1, 1, 'Test', $email, 'Test', 'Europe/Berlin');
 	}
 
 	public function testBookInvalidId(): void {
@@ -347,12 +354,12 @@ class BookingControllerTest extends TestCase {
 			->with($email)
 			->willReturn(true);
 		$this->apptService->expects(self::once())
-			->method('findById')
+			->method('findByToken')
 			->willThrowException(new ServiceException());
 		$this->bookingService->expects(self::never())
 			->method('book');
 
-		$this->controller->bookSlot(1, 1, 1, 'Test', $email, 'Test', 'Europe/Berlin');
+		$this->controller->bookSlot('abc123', 1, 1, 'Test', $email, 'Test', 'Europe/Berlin');
 	}
 
 
@@ -364,10 +371,10 @@ class BookingControllerTest extends TestCase {
 			->with($email)
 			->willReturn(false);
 		$this->apptService->expects(self::never())
-			->method('findById');
+			->method('findByToken');
 		$this->bookingService->expects(self::never())
 			->method('book');
 
-		$this->controller->bookSlot(1, 1, 1, 'Test', $email, 'Test', 'Europe/Berlin');
+		$this->controller->bookSlot('abc123', 1, 1, 'Test', $email, 'Test', 'Europe/Berlin');
 	}
 }


### PR DESCRIPTION
Mixing two IDs makes reading logs more complex than necessary. Let's be consistent.