### PR TITLE
fix(circles): just skip invalid users in circles instead of throwing an exception

### DIFF
--- a/lib/Controller/ContactController.php
+++ b/lib/Controller/ContactController.php
@@ -219,7 +219,7 @@ class ContactController extends Controller {
 				$user = $this->userManager->get($circleMemberUserId);
 
 				if ($user === null) {
-					throw new ServiceException('Could not find organizer');
+					continue;
 				}
 
 				$contacts[] = [


### PR DESCRIPTION
Another fix is needed on the front-end side as it seems it creates team attendees instead of actual ones.