### PR TITLE
feat: Reusable duration selector

### DIFF
--- a/src/components/Editor/DurationSelector.vue
+++ b/src/components/Editor/DurationSelector.vue
@@ -1,0 +1,468 @@
+<!--
+  - SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+  - SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
+<!--
+    DurationSelector - A reusable duration selection component
+-->
+<script setup lang="ts">
+import { n, t } from '@nextcloud/l10n'
+import { computed, ref, watch } from 'vue'
+import NcSelect from '@nextcloud/vue/components/NcSelect'
+
+interface DurationOption {
+	value: number | 'custom'
+	label: string
+}
+
+interface SelectOption {
+	id: number | string
+	label: string
+}
+
+type SelectPayload = SelectOption | number | string | null
+
+interface Props {
+	/** Duration value - can be minutes (number) or ISO 8601 duration string (e.g., "PT1H30M") */
+	modelValue?: number | string
+	/** Output format: 'minutes' (default) or 'iso8601' */
+	format?: 'minutes' | 'iso8601'
+	/** Label for the duration selector */
+	label?: string
+	/** Whether to show the label */
+	labelOutside?: boolean
+	/** Predefined duration options in minutes */
+	predefinedOptions?: DurationOption[]
+	/** Whether to include custom option */
+	showCustom?: boolean
+	/** Show days selector in custom mode */
+	showDays?: boolean
+	/** Show hours selector in custom mode */
+	showHours?: boolean
+	/** Show minutes selector in custom mode */
+	showMinutes?: boolean
+	/** Maximum days for custom duration */
+	maxDays?: number
+	/** Maximum hours for custom duration */
+	maxHours?: number
+	/** Step for minutes selector */
+	minuteStep?: number
+}
+
+const props = withDefaults(defineProps<Props>(), {
+	modelValue: 0,
+	format: 'minutes',
+	label: () => t('calendar', 'Duration'),
+	labelOutside: false,
+	predefinedOptions: () => [
+		{ value: 15, label: t('calendar', '15 minutes') },
+		{ value: 30, label: t('calendar', '30 minutes') },
+		{ value: 45, label: t('calendar', '45 minutes') },
+		{ value: 60, label: t('calendar', '1 hour') },
+		{ value: 90, label: t('calendar', '1 hour 30 minutes') },
+		{ value: 120, label: t('calendar', '2 hours') },
+	],
+	showCustom: true,
+	showDays: true,
+	showHours: true,
+	showMinutes: true,
+	maxDays: 30,
+	maxHours: 23,
+	minuteStep: 5,
+})
+
+const emit = defineEmits<{
+	'update:modelValue': [value: number | string]
+}>()
+const predefinedSelected = ref<SelectOption | null>(null)
+const customSelected = ref(false)
+const customDays = ref<SelectOption | null>(null)
+const customHours = ref<SelectOption | null>(null)
+const customMinutes = ref<SelectOption | null>(null)
+
+// Computed
+
+// Normalize modelValue to minutes
+const internalMinutes = computed<number>(() => {
+	if (typeof props.modelValue === 'string') {
+		return iso8601ToMinutes(props.modelValue)
+	}
+	return props.modelValue || 0
+})
+
+const allOptions = computed<SelectOption[]>(() => {
+	const options = props.predefinedOptions.map((opt: DurationOption) => ({
+		id: opt.value,
+		label: opt.label,
+	}))
+
+	if (props.showCustom) {
+		options.push({
+			id: 'custom',
+			label: t('calendar', 'Custom'),
+		})
+	}
+
+	return options
+})
+
+const selectedOption = computed<SelectOption | null>({
+	get() {
+		// If we have an internal selection, use it
+		if (predefinedSelected.value) {
+			return predefinedSelected.value
+		}
+
+		// Otherwise, calculate from modelValue
+		const predefined = props.predefinedOptions.find((opt: DurationOption) => opt.value === internalMinutes.value)
+		if (predefined) {
+			const option = {
+				id: predefined.value,
+				label: predefined.label,
+			}
+			return option
+		}
+
+		// Only select custom if we have a non-zero duration that doesn't match predefined options
+		if (props.showCustom && internalMinutes.value > 0) {
+			const customOption = {
+				id: 'custom',
+				label: t('calendar', 'Custom'),
+			}
+			return customOption
+		}
+
+		return null
+	},
+	set(value: SelectOption | null) {
+		predefinedSelected.value = value
+	},
+})
+
+const isCustomSelected = computed<boolean>(() => {
+	return selectedOption.value?.id === 'custom'
+})
+
+const daysOptions = computed<SelectOption[]>(() => {
+	const options: SelectOption[] = []
+	for (let i = 0; i <= props.maxDays; i++) {
+		options.push({
+			id: i,
+			label: n('calendar', '{i} day', '{i} days', i, { i }),
+		})
+	}
+	return options
+})
+
+const hoursOptions = computed<SelectOption[]>(() => {
+	const options: SelectOption[] = []
+	for (let i = 0; i <= props.maxHours; i++) {
+		options.push({
+			id: i,
+			label: n('calendar', '{i} hour', '{i} hours', i, { i }),
+		})
+	}
+	return options
+})
+
+const minutesOptions = computed<SelectOption[]>(() => {
+	const options: SelectOption[] = []
+	for (let i = 0; i < 60; i += props.minuteStep) {
+		options.push({
+			id: i,
+			label: n('calendar', '{i} minute', '{i} minutes', i, { i }),
+		})
+	}
+	return options
+})
+
+// Watchers
+watch(() => props.modelValue, (newValue: number | string) => {
+	const minutes = typeof newValue === 'string' ? iso8601ToMinutes(newValue) : newValue || 0
+
+	// Calculate which option should be selected
+	const predefined = props.predefinedOptions.find((opt: DurationOption) => opt.value === minutes)
+	if (predefined && !customSelected.value) {
+		predefinedSelected.value = {
+			id: predefined.value,
+			label: predefined.label,
+		}
+	} else if (props.showCustom && minutes > 0) {
+		predefinedSelected.value = {
+			id: 'custom',
+			label: t('calendar', 'Custom'),
+		}
+		// Also update custom fields
+		updateCustomFields(minutes)
+	} else {
+		predefinedSelected.value = null
+	}
+}, { immediate: true })
+
+// Methods
+function onOptionChange(option: SelectPayload): void {
+	const optionId = getPayloadId(option)
+	if (optionId === null) {
+		return
+	}
+
+	predefinedSelected.value = toSelectOption(option)
+
+	if (optionId === 'custom') {
+		customSelected.value = true
+		const initialMinutes = internalMinutes.value || 60
+		updateCustomFields(initialMinutes)
+		emitDuration(initialMinutes)
+	} else {
+		customSelected.value = false
+		emitDuration(Number(optionId))
+	}
+}
+
+function onCustomDaysChange(option: SelectPayload): void {
+	const optionId = getPayloadId(option)
+	if (optionId === null) {
+		return
+	}
+	customDays.value = toSelectOption(option)
+	emitCustomDuration()
+}
+
+function onCustomHoursChange(option: SelectPayload): void {
+	const optionId = getPayloadId(option)
+	if (optionId === null) {
+		return
+	}
+	customHours.value = toSelectOption(option)
+	emitCustomDuration()
+}
+
+function onCustomMinutesChange(option: SelectPayload): void {
+	const optionId = getPayloadId(option)
+	if (optionId === null) {
+		return
+	}
+	customMinutes.value = toSelectOption(option)
+	emitCustomDuration()
+}
+
+function getPayloadId(option: SelectPayload): number | string | null {
+	if (option === null) {
+		return null
+	}
+	if (typeof option === 'object') {
+		return option.id
+	}
+	return option
+}
+
+function toSelectOption(option: SelectPayload): SelectOption | null {
+	if (option === null) {
+		return null
+	}
+	if (typeof option === 'object') {
+		return option
+	}
+	const match = allOptions.value.find((entry) => entry.id === option)
+	if (match) {
+		return match
+	}
+	return {
+		id: option,
+		label: String(option),
+	}
+}
+
+function emitDuration(minutes: number): void {
+	if (props.format === 'iso8601') {
+		emit('update:modelValue', minutesToISO8601(minutes))
+	} else {
+		emit('update:modelValue', minutes)
+	}
+}
+
+function emitCustomDuration(): void {
+	const days = (customDays.value?.id as number) || 0
+	const hours = (customHours.value?.id as number) || 0
+	const minutes = (customMinutes.value?.id as number) || 0
+	const totalMinutes = (days * 24 * 60) + (hours * 60) + minutes
+
+	if (totalMinutes > 0) {
+		emitDuration(totalMinutes)
+	}
+}
+
+function updateCustomFields(totalMinutes: number): void {
+	const days = Math.floor(totalMinutes / (24 * 60))
+	const remainingAfterDays = totalMinutes % (24 * 60)
+	const hours = Math.floor(remainingAfterDays / 60)
+	const minutes = remainingAfterDays % 60
+
+	customDays.value = daysOptions.value.find((opt) => opt.id === days) || daysOptions.value[0]
+	customHours.value = hoursOptions.value.find((opt) => opt.id === hours) || hoursOptions.value[0]
+
+	const closestMinute = Math.round(minutes / props.minuteStep) * props.minuteStep
+	customMinutes.value = minutesOptions.value.find((opt) => opt.id === closestMinute) || minutesOptions.value[0]
+}
+
+/**
+ * convert ISO 8601 duration string to minutes
+ * Supports formats like: PT1H30M, PT30M, PT1H, P1DT2H30M
+ *
+ * @param iso8601 - ISO 8601 duration string
+ * @return Total minutes
+ */
+function iso8601ToMinutes(iso8601: string): number {
+	if (!iso8601 || typeof iso8601 !== 'string') {
+		return 0
+	}
+
+	// deconstruct the ISO 8601 duration string
+	const pattern = /^P(?:(\d+)D)?(?:T(?:(\d+)H)?(?:(\d+)M)?(?:(\d+)S)?)?$/
+	const matches = iso8601.match(pattern)
+	if (!matches) {
+		console.warn('Invalid ISO 8601 duration format:', iso8601)
+		return 0
+	}
+	const days = parseInt(matches[1] || '0', 10)
+	const hours = parseInt(matches[2] || '0', 10)
+	const minutes = parseInt(matches[3] || '0', 10)
+	const seconds = parseInt(matches[4] || '0', 10)
+
+	// Convert everything to minutes (seconds are rounded up)
+	return (days * 24 * 60) + (hours * 60) + minutes + Math.ceil(seconds / 60)
+}
+
+/**
+ * Convert minutes to ISO 8601 duration string
+ *
+ * @param totalMinutes - Total duration in minutes
+ * @return ISO 8601 duration string (e.g., "PT1H30M", "P1DT2H")
+ */
+function minutesToISO8601(totalMinutes: number): string {
+	if (!totalMinutes || totalMinutes < 0) {
+		return 'PT0M'
+	}
+
+	const days = Math.floor(totalMinutes / (24 * 60))
+	const remainingAfterDays = totalMinutes % (24 * 60)
+	const hours = Math.floor(remainingAfterDays / 60)
+	const minutes = remainingAfterDays % 60
+
+	// construct ISO 8601 string
+	let duration = 'P'
+	if (days > 0) {
+		duration += `${days}D`
+	}
+	if (hours > 0 || minutes > 0) {
+		duration += 'T'
+		if (hours > 0) {
+			duration += `${hours}H`
+		}
+		if (minutes > 0) {
+			duration += `${minutes}M`
+		}
+	}
+
+	// If only days (no time component), just return PnD
+	// If no duration at all, return PT0M
+	return duration === 'P' ? 'PT0M' : duration
+}
+</script>
+
+<template>
+	<div class="duration-selector">
+		<NcSelect
+			:modelValue="selectedOption"
+			:options="allOptions"
+			:labelOutside="labelOutside"
+			:placeholder="label"
+			:clearable="false"
+			@update:modelValue="onOptionChange">
+			<template #selected-option="option">
+				{{ option.label }}
+			</template>
+		</NcSelect>
+
+		<!-- Custom duration controls (shown when "Custom" is selected) -->
+		<div v-if="isCustomSelected" class="duration-selector__custom-controls">
+			<NcSelect
+				v-if="showDays"
+				:modelValue="customDays"
+				:options="daysOptions"
+				:labelOutside="true"
+				:placeholder="t('calendar', 'Days')"
+				:clearable="false"
+				class="duration-selector__custom-select"
+				@update:modelValue="onCustomDaysChange">
+				<template #selected-option="option">
+					{{ option.label }}
+				</template>
+			</NcSelect>
+
+			<NcSelect
+				v-if="showHours"
+				:modelValue="customHours"
+				:options="hoursOptions"
+				:labelOutside="true"
+				:placeholder="t('calendar', 'Hours')"
+				:clearable="false"
+				class="duration-selector__custom-select"
+				@update:modelValue="onCustomHoursChange">
+				<template #selected-option="option">
+					{{ option.label }}
+				</template>
+			</NcSelect>
+
+			<NcSelect
+				v-if="showMinutes"
+				:modelValue="customMinutes"
+				:options="minutesOptions"
+				:labelOutside="true"
+				:placeholder="t('calendar', 'Minutes')"
+				:clearable="false"
+				class="duration-selector__custom-select"
+				@update:modelValue="onCustomMinutesChange">
+				<template #selected-option="option">
+					{{ option.label }}
+				</template>
+			</NcSelect>
+		</div>
+	</div>
+</template>
+
+<style lang="scss" scoped>
+.duration-selector {
+	display: flex;
+	flex-direction: column;
+	gap: calc(var(--default-grid-baseline) * 2);
+	width: 100%;
+	max-width: 100%;
+	overflow: hidden;
+}
+
+.duration-selector__custom-controls {
+	display: flex;
+	gap: calc(var(--default-grid-baseline) * 2);
+	flex-wrap: nowrap;
+	width: 100%;
+	max-width: 100%;
+	overflow: hidden;
+}
+
+.duration-selector__custom-select {
+	flex: 1 1 0;
+	min-width: 0 !important;
+	max-width: 100%;
+	margin: 0;
+	width: 100%;
+
+	:deep(.vs__selected) {
+		white-space: nowrap;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		max-width: 100%;
+	}
+}
+</style>

--- a/src/views/Proposal/ProposalEditor.vue
+++ b/src/views/Proposal/ProposalEditor.vue
@@ -93,28 +93,10 @@
 								{{ t('calendar', 'Add Talk conversation') }}
 							</NcCheckboxRadioSwitch>
 						</div>
-						<div class="proposal-editor__proposal-duration-container">
-							<NcTextField
-								v-model="selectedProposal.duration"
-								class="proposal-editor__proposal-duration"
-								:label="t('calendar', 'Duration')"
-								type="number"
-								min="1"
-								step="1"
-								@input="onProposalDurationChange($event)" />
-							<NcRadioGroup
-								v-model="selectedProposal.duration"
-								class="proposal-editor__proposal-duration-helpers"
-								:label="t('calendar', 'Duration suggestions')"
-								hideLabel
-								@update:modelValue="onProposalDurationSuggestionChange">
-								<NcRadioGroupButton
-									v-for="duration in [15, 30, 60, 90]"
-									:key="duration"
-									:label="t('calendar', '{duration} min', { duration })"
-									:value="duration" />
-							</NcRadioGroup>
-						</div>
+						<DurationSelector
+							class="proposal-editor__proposal-duration"
+							:modelValue="selectedProposal.duration"
+							@update:modelValue="changeDuration" />
 						<InviteesListSearch
 							class="proposal-editor__proposal-participants-selector"
 							:alreadyInvitedEmails="existingParticipantAddressess"
@@ -243,10 +225,9 @@ import NcButton from '@nextcloud/vue/components/NcButton'
 import NcCheckboxRadioSwitch from '@nextcloud/vue/components/NcCheckboxRadioSwitch'
 import NcDialog from '@nextcloud/vue/components/NcDialog'
 import NcModal from '@nextcloud/vue/components/NcModal'
-import NcRadioGroup from '@nextcloud/vue/components/NcRadioGroup'
-import NcRadioGroupButton from '@nextcloud/vue/components/NcRadioGroupButton'
 import NcTextArea from '@nextcloud/vue/components/NcTextArea'
 import NcTextField from '@nextcloud/vue/components/NcTextField'
+import DurationSelector from '@/components/Editor/DurationSelector.vue'
 import InviteesListSearch from '@/components/Editor/Invitees/InviteesListSearch.vue'
 import ProposalDateItem from '@/components/Proposal/ProposalDateItem.vue'
 import ProposalParticipantItem from '@/components/Proposal/ProposalParticipantItem.vue'
@@ -286,10 +267,9 @@ export default {
 		NcCheckboxRadioSwitch,
 		NcDialog,
 		NcModal,
-		NcRadioGroup,
-		NcRadioGroupButton,
 		NcTextField,
 		NcTextArea,
+		DurationSelector,
 		FullCalendar,
 		InviteesListSearch,
 		ProposalParticipantItem,
@@ -653,12 +633,6 @@ export default {
 			this.showConvertDialog = true
 		},
 
-		onProposalDurationChange(event: Event) {
-			const value = (event.target as HTMLInputElement).value
-			const duration = parseInt(value, 10)
-			this.changeDuration(duration)
-		},
-
 		onProposalLocationTypeToggle(): void {
 			if (!this.selectedProposal) {
 				return
@@ -833,11 +807,6 @@ export default {
 			this.selectedProposal.duration = duration
 			// Refresh calendar view
 			this.renderParticipantAvailability()
-		},
-
-		onProposalDurationSuggestionChange(value: string): void {
-			const duration = parseInt(value, 10)
-			this.changeDuration(duration)
 		},
 
 		addParticipant(participant: ParticipantSearchInterface): void {
@@ -1231,27 +1200,6 @@ export default {
 
 .proposal-editor__proposal-location {
 	flex: 1;
-}
-
-.proposal-editor__proposal-duration-container {
-	display: flex;
-	align-items: stretch;
-	gap: calc(var(--default-grid-baseline) * 2);
-	flex-wrap: nowrap;
-}
-
-.proposal-editor__proposal-duration {
-	flex: 0 0 20%;
-	max-width: 20%;
-}
-
-.proposal-editor__proposal-duration-helpers {
-	flex: 1 1 80%;
-	max-width: 80%;
-
-	:deep(.nc-form-box) {
-		width: 100%;
-	}
 }
 
 :deep([class*="participant-busy-"]) {


### PR DESCRIPTION
### Summary
- Added reusable duration selector with predefined duration and custom duration, supports minute and iso8601 duration format input and output

Predefined options
<img width="430" height="696" alt="image" src="https://github.com/user-attachments/assets/e4e62f10-933c-4bd0-ba4b-1688872b7ba1" />

Custom options
<img width="450" height="860" alt="image" src="https://github.com/user-attachments/assets/8bb53c5f-b877-46ac-951b-09d7280729c6" />
