### PR TITLE
fix: improve title and description word wrapping

### DIFF
--- a/src/components/Editor/Properties/PropertyText.vue
+++ b/src/components/Editor/Properties/PropertyText.vue
@@ -122,7 +122,7 @@ export default {
 
 .property-text__readonly-value {
 	white-space: pre-wrap;
-	word-break: break-all;
+	overflow-wrap: break-word;
 }
 
 .textarea--description {

--- a/src/components/Editor/Properties/PropertyTitle.vue
+++ b/src/components/Editor/Properties/PropertyTitle.vue
@@ -57,3 +57,10 @@ export default {
 	},
 }
 </script>
+
+<style scoped lang="scss">
+.property-title__input--readonly {
+	white-space: pre-wrap;
+	overflow-wrap: break-word;
+}
+</style>


### PR DESCRIPTION
### Summary
- Resolves https://github.com/nextcloud/calendar/issues/7553
- Modified word wrapping on title and description (this should better accommodate really long word and urls but break up normal text better)

<img width="543" height="858" alt="image" src="https://github.com/user-attachments/assets/47ac09ab-b1de-423c-ab0d-8f23e5825317" />
