### PR TITLE
fix: improve confidentiality wording when sharing calendars/events

### DIFF
--- a/src/components/AppNavigation/EditCalendarModal/ShareItem.vue
+++ b/src/components/AppNavigation/EditCalendarModal/ShareItem.vue
@@ -24,7 +24,7 @@
 				type="checkbox"
 				class="checkbox"
 				@change="updatePermission">
-			<label :for="`${id}-can-edit`">{{ $t('calendar', 'can edit') }}</label>
+			<label :for="`${id}-can-edit`">{{ $t('calendar', 'can edit and see confidential events') }}</label>
 		</template>
 
 		<NcActions>

--- a/src/models/rfcProps.js
+++ b/src/models/rfcProps.js
@@ -24,7 +24,7 @@ function getRFCProperties() {
 				{ value: 'PRIVATE', label: t('calendar', 'When shared hide this event') },
 			],
 			multiple: false,
-			info: t('calendar', 'The visibility of this event in shared calendars.'),
+			info: t('calendar', 'The visibility of this event in read-only shared calendars.'),
 			defaultValue: 'PUBLIC',
 		},
 		/**

--- a/tests/javascript/unit/models/rfcProps.test.js
+++ b/tests/javascript/unit/models/rfcProps.test.js
@@ -27,7 +27,7 @@ describe('Test suite: RFC properties (models/rfcProps.js)', () => {
 		expect(rfcProps.accessClass.readableName).toEqual('When shared show')
 		expect(rfcProps.accessClass.icon).toEqual('Eye')
 		expect(rfcProps.accessClass.multiple).toEqual(false)
-		expect(rfcProps.accessClass.info).toEqual('The visibility of this event in shared calendars.')
+		expect(rfcProps.accessClass.info).toEqual('The visibility of this event in read-only shared calendars.')
 		expect(rfcProps.accessClass.defaultValue).toEqual('PUBLIC')
 		expect(rfcProps.accessClass.options).toEqual([
 			{value: 'PUBLIC', label: 'When shared show full event'},
@@ -94,7 +94,7 @@ describe('Test suite: RFC properties (models/rfcProps.js)', () => {
 		expect(translate).toHaveBeenNthCalledWith(2, 'calendar', 'When shared show full event')
 		expect(translate).toHaveBeenNthCalledWith(3, 'calendar', 'When shared show only busy')
 		expect(translate).toHaveBeenNthCalledWith(4, 'calendar', 'When shared hide this event')
-		expect(translate).toHaveBeenNthCalledWith(5, 'calendar', 'The visibility of this event in shared calendars.')
+		expect(translate).toHaveBeenNthCalledWith(5, 'calendar', 'The visibility of this event in read-only shared calendars.')
 
 		expect(translate).toHaveBeenNthCalledWith(6, 'calendar', 'Location')
 		expect(translate).toHaveBeenNthCalledWith(7, 'calendar', 'Add a location')


### PR DESCRIPTION
Fix #7591 

<img width="696" height="260" alt="image" src="https://github.com/user-attachments/assets/df6bdfd9-80a6-471c-97b5-acad376ee90c" />
