### PR TITLE
fix(fullcalendar.scss): calendar grid headers overlapping

### DIFF
--- a/css/fullcalendar.scss
+++ b/css/fullcalendar.scss
@@ -268,6 +268,12 @@
 // Fix week button overlapping with the toggle
 .fc-col-header-cell {
 	padding-top: 10px !important;
+
+	&-cushion {
+		text-overflow: ellipsis;
+		overflow: clip;
+		max-width: 100%;
+	}
 }
 
 .fc-timegrid-axis-cushion {


### PR DESCRIPTION
| Before | After |
| - | - |
| <img width="587" height="154" alt="image" src="https://github.com/user-attachments/assets/b0108b24-6659-4424-aa5e-7b46863f3b95" /> | <img width="586" height="153" alt="image" src="https://github.com/user-attachments/assets/3efd4d15-8af5-4ba3-823c-d76539d4ece3" /> |