### PR TITLE
fix: reduce background sync interval a bit

### DIFF
--- a/src/views/Calendar.vue
+++ b/src/views/Calendar.vue
@@ -297,7 +297,7 @@ export default {
 				for (const calendar of calendars) {
 					this.calendarsStore.syncCalendar({ calendar, skipIfUnchangedSyncToken: true })
 				}
-			}, 1000 * 30)
+			}, 1000 * 60)
 		}
 
 		this.timeFrameCacheExpiryJob = setInterval(() => {


### PR DESCRIPTION
There is a real-time sync based on notify_push now. So we don't need to poll the server as often. Admins which would like to make use of near instant sync should set up and enable notify_push.

As suggested by @tcitworld here: https://github.com/nextcloud/calendar/pull/6364#pullrequestreview-3335483585