### PR TITLE
Make the wording "Selected slot" translatable

### DIFF
--- a/src/components/Editor/FreeBusy/FreeBusy.vue
+++ b/src/components/Editor/FreeBusy/FreeBusy.vue
@@ -569,7 +569,7 @@ export default {
 		}
 		calendar.addEvent({
 			id: 'selected-event-slot',
-			title: 'Selected slot',
+			title: t('calendar', 'Selected slot'),
 			start: this.currentStart,
 			end: this.currentEnd,
 			textColor: 'var(--color-main-text)',


### PR DESCRIPTION
In the following screenshot, French UI is used, but "Selected slot" remains in English. 

If I'm not mistaking, this PR should fix this.

Testing from reviewers needed.

<img width="1187" height="936" alt="2025-10-23_16-23" src="https://github.com/user-attachments/assets/921c9dcd-3ab5-47d3-b6c3-28ccd98852ea" />