### PR TITLE
[stable6.0][Manual backport] fix(fullcalendar.scss): calendar grid headers overlapping

### DIFF
--- a/css/fullcalendar.scss
+++ b/css/fullcalendar.scss
@@ -268,6 +268,12 @@
 // Fix week button overlapping with the toggle
 .fc-col-header-cell {
 	padding-top: 10px !important;
+
+	&-cushion {
+		text-overflow: ellipsis;
+		overflow: clip;
+		max-width: 100%;
+	}
 }
 
 .fc-timegrid-axis-cushion {


### PR DESCRIPTION
OG PR https://github.com/nextcloud/calendar/pull/7609