### PR TITLE
perf(appointments): reduce bundle size bloat by @nextcloud/vue

### DIFF
--- a/src/components/Appointments/AppointmentBookingConfirmation.vue
+++ b/src/components/Appointments/AppointmentBookingConfirmation.vue
@@ -14,7 +14,7 @@
 </template>
 
 <script>
-import { NcEmptyContent as EmptyContent } from '@nextcloud/vue'
+import NcEmptyContent from '@nextcloud/vue/components/NcEmptyContent'
 import EmailIcon from 'vue-material-design-icons/EmailOutline.vue'
 
 export default {

--- a/src/components/Appointments/AppointmentDetails.vue
+++ b/src/components/Appointments/AppointmentDetails.vue
@@ -104,12 +104,10 @@
 </template>
 
 <script>
-import {
-	NcAvatar as Avatar,
-	NcButton,
-	NcLoadingIcon,
-	NcNoteCard,
-} from '@nextcloud/vue'
+import Avatar from '@nextcloud/vue/components/NcAvatar'
+import NcButton from '@nextcloud/vue/components/NcButton'
+import NcLoadingIcon from '@nextcloud/vue/components/NcLoadingIcon'
+import NcNoteCard from '@nextcloud/vue/components/NcNoteCard'
 import IconBack from 'vue-material-design-icons/ArrowLeft.vue'
 import IconCalendar from 'vue-material-design-icons/CalendarOutline.vue'
 import IconCheck from 'vue-material-design-icons/CheckOutline.vue'

--- a/src/components/Appointments/AppointmentSlot.vue
+++ b/src/components/Appointments/AppointmentSlot.vue
@@ -10,7 +10,7 @@
 </template>
 
 <script>
-import { NcButton } from '@nextcloud/vue'
+import NcButton from '@nextcloud/vue/components/NcButton'
 import { timeStampToLocaleTime } from '../../utils/localeTime.js'
 
 export default {

--- a/src/views/Appointments/Booking.vue
+++ b/src/views/Appointments/Booking.vue
@@ -84,13 +84,12 @@
 
 <script>
 import { showError } from '@nextcloud/dialogs'
-import {
-	NcAvatar as Avatar,
-	NcDateTimePicker as DateTimePicker,
-	NcEmptyContent,
-	NcGuestContent,
-	NcTimezonePicker as TimezonePicker,
-} from '@nextcloud/vue'
+import NcButton from '@nextcloud/vue/components/NcButton'
+import Avatar from '@nextcloud/vue/components/NcAvatar'
+import DateTimePicker from '@nextcloud/vue/components/NcDateTimePicker'
+import NcEmptyContent from '@nextcloud/vue/components/NcEmptyContent'
+import NcGuestContent from '@nextcloud/vue/components/NcGuestContent'
+import TimezonePicker from '@nextcloud/vue/components/NcDateTimePicker'
 import MDILoading from 'vue-material-design-icons/Loading.vue'
 import AppointmentBookingConfirmation from '../../components/Appointments/AppointmentBookingConfirmation.vue'
 import AppointmentDetails from '../../components/Appointments/AppointmentDetails.vue'


### PR DESCRIPTION
## Details

From https://stable8--nextcloud-vue-components.netlify.app/

> Import from a single root is available as well. Use with caution: this might lead to slower build time and larger bundles in some cases.

The appointments scripts are small and standalone. They use a few nextcloud/vue components. On main we include the full nextcloud/vue. It will not be tree shaken.

## Comparison

### Before

```
Entrypoints:
  main (5.64 MiB)
      calendar-main.js?v=a7305326cd103dfb1881
  contacts-menu (333 KiB)
      calendar-contacts-menu.js?v=9003c166b073eb6859e5
  appointments-booking (3.48 MiB)
      calendar-appointments-booking.js?v=30b2a188baa1c9f0c8e3
  appointments-confirmation (403 KiB)
      calendar-appointments-confirmation.js?v=09c94c3f873574961d8d
  appointments-conflict (403 KiB)
      calendar-appointments-conflict.js?v=5b98e8588590912beb50
  appointments-overview (3.17 MiB)
      calendar-appointments-overview.js?v=601d743edc8ea917e84b
  proposal-public (1.99 MiB)
      calendar-proposal-public.js?v=6bae3689fb176fc337c9
```

### After

```
Entrypoints:
  main (5.64 MiB)
      calendar-main.js?v=c69cd9e13409ea3714ea
  contacts-menu (333 KiB)
      calendar-contacts-menu.js?v=7ef629f700fce7391355
  appointments-booking (1.35 MiB)
      calendar-appointments-booking.js?v=a8191000967f91886fdf
  appointments-confirmation (403 KiB)
      calendar-appointments-confirmation.js?v=09c94c3f873574961d8d
  appointments-conflict (403 KiB)
      calendar-appointments-conflict.js?v=5b98e8588590912beb50
  appointments-overview (3.17 MiB)
      calendar-appointments-overview.js?v=601d743edc8ea917e84b
  proposal-public (1.99 MiB)
      calendar-proposal-public.js?v=22fba3be8899be9df924
```