### PR TITLE
refactor: do not rebundle moment locales

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -68,4 +68,12 @@ webpackRules.RULE_SCSS.use = [
 	},
 ]
 
+// Reduce moment.js bundle size by ignoring all locales these are bundled in nextcloud/moment
+webpackConfig.plugins.push(
+	new webpack.IgnorePlugin({
+		resourceRegExp: /^\.\/locale$/,
+		contextRegExp: /moment$/,
+	})
+)
+
 module.exports = webpackConfig


### PR DESCRIPTION
### Summary
- Modified compile config to not re-bundle moment locales, they are already bundled in nextcloud/moment 