### PR TITLE
fix: use system button sytles for top navigation buttons

### DIFF
--- a/css/app-navigation.scss
+++ b/css/app-navigation.scss
@@ -17,43 +17,13 @@
 	.today-button-section,
 	.view-button-section {
 		display: flex;
-
-		.button {
-			// this border-radius affects the button in the middle of the group
-			// for the rounded corner buttons on the sides, see further below
-			border-radius: 0;
-			font-weight: normal;
-			margin: 0 0 var(--default-grid-baseline) 0;
-			flex-grow: 1;
-		}
-
-		.button:first-child:not(:only-of-type) {
-			border-radius: var(--border-radius-element) 0 0 var(--border-radius-element);
-		}
-
-		.button:last-child:not(:only-of-type) {
-			border-radius: 0 var(--border-radius-element) var(--border-radius-element) 0;
-		}
-
-		.button:not(:only-of-type):not(:first-child):not(:last-child) {
-			border-radius: 0;
-		}
-
-		.button:only-child {
-			border-radius: var(--border-radius-element);
-		}
-
-		.button:hover,
-		.button:focus,
-		.button.active {
-			z-index: 50;
-		}
 	}
 
 	.datepicker-button-section {
 		&__datepicker-label {
 			flex-grow: 4 !important;
 			text-align: center;
+			border-radius: 0 !important;
 		}
 
 		&__datepicker {
@@ -92,6 +62,8 @@
 
 	.new-event-today-view-section {
 		display: flex;
+		gap: var(--default-grid-baseline);
+		margin-top: var(--default-grid-baseline);
 
 		// Fix margins from core
 		.button {

--- a/src/components/AppNavigation/AppNavigationHeader/AppNavigationHeaderDatePicker.vue
+++ b/src/components/AppNavigation/AppNavigationHeader/AppNavigationHeaderDatePicker.vue
@@ -167,7 +167,6 @@ useHotKey(['p', 'k'], () => navigateTimeRangeBackward())
 		<NcButton
 			v-if="!props.isWidget"
 			:aria-label="isRTL ? nextLabel : previousLabel"
-			class="button"
 			:class="{ 'datepicker-button-section__right': isRTL, 'datepicker-button-section__left': !isRTL }"
 			:name="isRTL ? nextLabel : previousLabel"
 			@click="navigateTimeRangeBackward">
@@ -178,14 +177,13 @@ useHotKey(['p', 'k'], () => navigateTimeRangeBackward())
 		</NcButton>
 		<NcButton
 			v-if="!props.isWidget"
-			class="datepicker-button-section__datepicker-label button datepicker-label"
+			class="datepicker-button-section__datepicker-label datepicker-label"
 			@click.stop.prevent="toggleDatepicker"
 			@mousedown.stop.prevent="() => {}"
 			@mouseup.stop.prevent="() => {}">
 			{{ formattedSelectedDate }}
 		</NcButton>
 		<DatePicker
-			ref="datepicker"
 			:class="props.isWidget ? 'datepicker-widget' : 'datepicker-button-section__datepicker'"
 			:append-to-body="props.isWidget"
 			:date="selectedDate"
@@ -196,7 +194,6 @@ useHotKey(['p', 'k'], () => navigateTimeRangeBackward())
 		<NcButton
 			v-if="!props.isWidget"
 			:aria-label="isRTL ? previousLabel : nextLabel"
-			class="button"
 			:class="{ 'datepicker-button-section__right': !isRTL, 'datepicker-button-section__left': isRTL }"
 			:name="isRTL ? previousLabel : nextLabel"
 			@click="navigateTimeRangeForward">

--- a/src/components/AppNavigation/AppNavigationHeader/AppNavigationHeaderNewEvent.vue
+++ b/src/components/AppNavigation/AppNavigationHeader/AppNavigationHeaderNewEvent.vue
@@ -5,7 +5,7 @@
 
 <template>
 	<NcButton
-		class="button new-event"
+		class="new-event"
 		variant="primary"
 		:aria-label="newEventButtonAriaLabel"
 		@click="newEvent">
@@ -54,10 +54,3 @@ export default {
 	},
 }
 </script>
-
-<style scoped>
-.button.primary.new-event {
-	display: flex;
-	align-items: center;
-}
-</style>

--- a/src/components/AppNavigation/AppNavigationHeader/AppNavigationHeaderTodayButton.vue
+++ b/src/components/AppNavigation/AppNavigationHeader/AppNavigationHeaderTodayButton.vue
@@ -32,7 +32,7 @@ useHotKey('t', () => today())
 
 <template>
 	<NcButton
-		class="button today"
+		class="today"
 		@click="today">
 		{{ t('calendar', 'Today') }}
 	</NcButton>


### PR DESCRIPTION
### Summary
- Resolves https://github.com/nextcloud/calendar/issues/7714
- Removed custom button styling from top navigation buttons

#### Before
- see linked issue

#### After

https://github.com/user-attachments/assets/6a6cf2a7-4786-465c-a56d-89619d1266dd

