### PR TITLE
fix: appointment duration selection

### DIFF
--- a/src/components/AppointmentConfigModal/DurationSelect.vue
+++ b/src/components/AppointmentConfigModal/DurationSelect.vue
@@ -63,7 +63,7 @@ export default {
 
 			options.push(...[
 				// Minutes
-				...[5, 10, 15, 30, 45].map((duration) => {
+				...[5, 10, 15, 20, 25, 30, 35, 40, 45, 50, 55].map((duration) => {
 					const label = this.n('calendar', '{duration} minute', '{duration} minutes', duration, {
 						duration,
 					})


### PR DESCRIPTION
### Summary
- Resolves https://github.com/nextcloud/calendar/issues/7711
- Added more minute increments to duration selection

<img width="459" height="473" alt="image" src="https://github.com/user-attachments/assets/97093301-3399-4177-88da-3e29bb5dd918" />
