### PR TITLE
fix: settings getCurrentUserPrincipal error

### DIFF
--- a/src/components/AppNavigation/Settings.vue
+++ b/src/components/AppNavigation/Settings.vue
@@ -345,7 +345,10 @@ export default {
 		},
 
 		appleCalDAV() {
-			return new URL(getCurrentUserPrincipal().principalUrl, this.primaryCalDAV)
+			if (!this.currentUserPrincipal) {
+				return ''
+			}
+			return new URL(this.currentUserPrincipal.principalUrl, this.primaryCalDAV).toString()
 		},
 	},
 


### PR DESCRIPTION
### Summary
- Fixes Error below. Caused by the dav stack not being initialized on initial render.

<img width="932" height="459" alt="932-459-max" src="https://github.com/user-attachments/assets/c64d478b-afc5-406d-a064-1edd80ef979b" />



[ERROR] calendar: [Vue error]: Error in render: TypeError: can't access property "principalUrl", _services_caldavService_js__WEBPACK_IMPORTED_MODULE_11__.getCurrentUserPrincipal() is null 
Object { app: "calendar", uid: "user1", level: 0, error: TypeError, vm: {…}, info: "render" }
index.mjs:54:1
    log index.mjs:54
    error index.mjs:72
    errorHandler main.js:42
    VueJS 89
    <anonymous> main.js:49
    <anonymous> calendar-main.js:309625
    <anonymous> calendar-main.js:309627
