### PR TITLE
fix(PropertyTitleTimePicker): improve styling for local time subtitle

### DIFF
--- a/src/components/Editor/Properties/PropertyTitleTimePicker.vue
+++ b/src/components/Editor/Properties/PropertyTitleTimePicker.vue
@@ -94,16 +94,18 @@
 			v-if="isReadOnly"
 			class="property-title-time-picker__time-pickers property-title-time-picker__time-pickers--readonly">
 			<div class="property-title-time-picker-read-only-wrapper property-title-time-picker-read-only-wrapper--start-date">
-				<div class="property-title-time-picker-read-only-wrapper__label">
-					{{ formattedStart }}
-				</div>
-				<IconTimezone
-					v-if="!isAllDay"
-					:title="startTimezone"
-					:class="{ 'highlighted-timezone-icon': highlightTimezones }"
-					:size="20" />
-				<div v-if="highlightTimezones && startTimezone !== 'floating'" class="property-title-time-picker-read-only-wrapper__timezone" :title="startTimezone">
-					{{ startTimezone }}
+				<div class="property-title-time-picker-read-only-wrapper__main-info">
+					<div class="property-title-time-picker-read-only-wrapper__label">
+						{{ formattedStart }}
+					</div>
+					<IconTimezone
+						v-if="!isAllDay"
+						:title="startTimezone"
+						:class="{ 'highlighted-timezone-icon': highlightTimezones }"
+						:size="20" />
+					<div v-if="highlightTimezones && startTimezone !== 'floating'" class="property-title-time-picker-read-only-wrapper__timezone" :title="startTimezone">
+						{{ startTimezone }}
+					</div>
 				</div>
 				<div v-if="subtitleStart" class="property-title-time-picker-read-only-wrapper__subtitle">
 					{{ subtitleStart }} {{ t('calendar', 'Your Time') }}
@@ -111,16 +113,18 @@
 			</div>
 			<template v-if="!isAllDayOneDayEvent">
 				<div class="property-title-time-picker-read-only-wrapper property-title-time-picker-read-only-wrapper--end-date">
-					<div class="property-title-time-picker-read-only-wrapper__label">
-						{{ formattedEnd }}
-					</div>
-					<IconTimezone
-						v-if="!isAllDay"
-						:title="endTimezone"
-						:class="{ 'highlighted-timezone-icon': highlightTimezones }"
-						:size="20" />
-					<div v-if="highlightTimezones && endTimezone !== 'floating'" class="property-title-time-picker-read-only-wrapper__timezone" :title="endTimezone">
-						{{ endTimezone }}
+					<div class="property-title-time-picker-read-only-wrapper__main-info">
+						<div class="property-title-time-picker-read-only-wrapper__label">
+							{{ formattedEnd }}
+						</div>
+						<IconTimezone
+							v-if="!isAllDay"
+							:title="endTimezone"
+							:class="{ 'highlighted-timezone-icon': highlightTimezones }"
+							:size="20" />
+						<div v-if="highlightTimezones && endTimezone !== 'floating'" class="property-title-time-picker-read-only-wrapper__timezone" :title="endTimezone">
+							{{ endTimezone }}
+						</div>
 					</div>
 					<div v-if="subtitleEnd" class="property-title-time-picker-read-only-wrapper__subtitle">
 						{{ subtitleEnd }} {{ t('calendar', 'Your Time') }}
@@ -615,6 +619,7 @@ export default {
 
 	.property-title-time-picker-read-only-wrapper {
 		display: flex;
+		flex-direction: column;
 		gap: calc(var(--default-grid-baseline) * 2);
 		max-width: calc(var(--sidebar-max-width) - var(--default-clickable-area) - var(--default-grid-baseline));
 
@@ -636,7 +641,19 @@ export default {
 	}
 }
 
+.property-title-time-picker-read-only-wrapper__main-info {
+	display: flex;
+	gap: calc(var(--default-grid-baseline) * 2);
+}
+
 .property-title-time-picker-read-only-wrapper__subtitle {
     opacity: 0.8;
 }
+
+.app-full {
+	.property-title-time-picker--readonly {
+		margin-inline-start: calc(var(--default-grid-baseline) * 9);
+	}
+}
+
 </style>


### PR DESCRIPTION
| Before | After |
| - | - |
| <img width="544" height="555" alt="swappy-20251125_170550" src="https://github.com/user-attachments/assets/aa08b6ac-a444-44c5-862b-2009330a5c17" /> | <img width="549" height="569" alt="swappy-20251125_170300" src="https://github.com/user-attachments/assets/6c3702ea-69f8-4b11-a1fd-5371c9f76136" /> |
| <img width="1018" height="318" alt="swappy-20251125_170538" src="https://github.com/user-attachments/assets/1d5b1e78-fc55-43e6-abc0-0f2a48dafb92" /> | <img width="951" height="265" alt="swappy-20251125_170446" src="https://github.com/user-attachments/assets/194eb914-6a45-4bdd-aad1-c4688c45d690" /> |
