### PR TITLE
fix(talkService): make attendees be synced with talk room members

### DIFF
--- a/src/services/talkService.ts
+++ b/src/services/talkService.ts
@@ -336,7 +336,7 @@ export async function updateRoomParticipantsFromEvent(eventComponent: object): P
  */
 async function transceiveGet<TRequest extends object | undefined, TResponse>(path: string, params?: TRequest): Promise<TResponse> {
 	const apiVersion = loadState('calendar', 'talk_api_version')
-	const url = generateOcsUrl('/apps/spreed/api/{apiVersion}/{path}', { apiVersion, path })
+	const url = generateOcsUrl('/apps/spreed/api/{apiVersion}', { apiVersion }) + `/${path}`
 
 	let response: AxiosResponse<TResponse>
 	try {
@@ -397,7 +397,7 @@ async function transceiveGet<TRequest extends object | undefined, TResponse>(pat
  */
 async function transceivePost<TRequest extends object, TResponse>(path: string, data: TRequest): Promise<TResponse> {
 	const apiVersion = loadState('calendar', 'talk_api_version')
-	const url = generateOcsUrl('/apps/spreed/api/{apiVersion}/{path}', { apiVersion, path })
+	const url = generateOcsUrl('/apps/spreed/api/{apiVersion}', { apiVersion }) + `/${path}`
 
 	let response: AxiosResponse<TResponse>
 	try {


### PR DESCRIPTION
Fixes the following bug:
- have a talk room
- add this talk room to an event, and also an internal user that is not in the room yet, user confirms event participation
- expected: user gets automatically added to the room
- what happened: user not in the room, had to add him by hand

The issue was the `/` becoming encoded as a `%2F`