### PR TITLE
feat: restrict calendar invitation participants

### DIFF
--- a/lib/Controller/ContactController.php
+++ b/lib/Controller/ContactController.php
@@ -18,6 +18,7 @@ use OCP\AppFramework\Http\Attribute\NoAdminRequired;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\AppFramework\QueryException;
 use OCP\Contacts\IManager;
+use OCP\IAppConfig;
 use OCP\IRequest;
 use OCP\IUserManager;
 use Psr\Log\LoggerInterface;
@@ -41,6 +42,7 @@ class ContactController extends Controller {
 		private IAppManager $appManager,
 		private IUserManager $userManager,
 		private ContactsService $contactsService,
+		private IAppConfig $appConfig,
 		private LoggerInterface $logger,
 	) {
 		parent::__construct($appName, $request);
@@ -100,11 +102,16 @@ class ContactController extends Controller {
 			return new JSONResponse();
 		}
 
-		$result = $this->contactsManager->search($search, ['FN', 'EMAIL'], ['enumeration' => false]);
+		$externalAttendeesDisabled = $this->appConfig->getValueBool('dav', 'caldav_external_attendees_disabled', false);
+		$result = $this->contactsManager->search($search, ['FN', 'EMAIL'], ['enumeration' => true]);
 
 		$contacts = [];
 		foreach ($result as $r) {
-			if ($this->contactsService->isSystemBook($r) || !$this->contactsService->hasEmail($r)) {
+			if (!$this->contactsService->hasEmail($r)) {
+				continue;
+			}
+			// When external attendees are disabled, only include system book contacts
+			if ($externalAttendeesDisabled && !$this->contactsService->isSystemBook($r)) {
 				continue;
 			}
 			$name = $this->contactsService->getNameFromContact($r);
@@ -122,24 +129,27 @@ class ContactController extends Controller {
 			];
 		}
 
-		$groups = $this->contactsManager->search($search, ['CATEGORIES']);
-		$groups = array_filter($groups, function ($group) {
-			return $this->contactsService->hasEmail($group);
-		});
-		$filtered = $this->contactsService->filterGroupsWithCount($groups, $search);
-		foreach ($filtered as $groupName => $count) {
-			if ($count === 0) {
-				continue;
+		// Skip contact groups when external attendees are disabled
+		if (!$externalAttendeesDisabled) {
+			$groups = $this->contactsManager->search($search, ['CATEGORIES']);
+			$groups = array_filter($groups, function ($group) {
+				return $this->contactsService->hasEmail($group);
+			});
+			$filtered = $this->contactsService->filterGroupsWithCount($groups, $search);
+			foreach ($filtered as $groupName => $count) {
+				if ($count === 0) {
+					continue;
+				}
+				$contacts[] = [
+					'name' => $groupName,
+					'emails' => ['mailto:' . urlencode($groupName) . '@group'],
+					'lang' => '',
+					'tzid' => '',
+					'photo' => '',
+					'type' => 'contactsgroup',
+					'members' => $count,
+				];
 			}
-			$contacts[] = [
-				'name' => $groupName,
-				'emails' => ['mailto:' . urlencode($groupName) . '@group'],
-				'lang' => '',
-				'tzid' => '',
-				'photo' => '',
-				'type' => 'contactsgroup',
-				'members' => $count,
-			];
 		}
 
 		return new JSONResponse($contacts);

--- a/tests/php/unit/Controller/ContactControllerTest.php
+++ b/tests/php/unit/Controller/ContactControllerTest.php
@@ -12,6 +12,7 @@ use OCA\Calendar\Service\ContactsService;
 use OCP\App\IAppManager;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\Contacts\IManager;
+use OCP\IAppConfig;
 use OCP\IRequest;
 use OCP\IUserManager;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -34,6 +35,7 @@ class ContactControllerTest extends TestCase {
 	/** @var IUserManager|MockObject */
 	private $userManager;
 	private ContactsService|MockObject $service;
+	private IAppConfig|MockObject $appConfig;
 
 	/** @var ContactController */
 	protected $controller;
@@ -49,6 +51,7 @@ class ContactControllerTest extends TestCase {
 		$this->appManager = $this->createMock(IAppManager::class);
 		$this->userManager = $this->createMock(IUserManager::class);
 		$this->service = $this->createMock(ContactsService::class);
+		$this->appConfig = $this->createMock(IAppConfig::class);
 		$this->logger = $this->createMock(NullLogger::class);
 		$this->controller = new ContactController($this->appName,
 			$this->request,
@@ -56,6 +59,7 @@ class ContactControllerTest extends TestCase {
 			$this->appManager,
 			$this->userManager,
 			$this->service,
+			$this->appConfig,
 			$this->logger,
 		);
 	}
@@ -338,6 +342,10 @@ class ContactControllerTest extends TestCase {
 		$this->manager->expects(self::once())
 			->method('isEnabled')
 			->willReturn(true);
+		$this->appConfig->expects(self::once())
+			->method('getValueBool')
+			->with('dav', 'caldav_external_attendees_disabled', false)
+			->willReturn(false);
 		$this->service
 			->method('hasEmail')
 			->willReturnMap([
@@ -360,20 +368,23 @@ class ContactControllerTest extends TestCase {
 				[$user1, 'Person 1'],
 				[$user2, 'Person 2'],
 				[$user3, ''],
+				[$user4, 'Person 3'],
 			]);
-		$this->service->expects(self::exactly(2))
+		$this->service->expects(self::exactly(3))
 			->method('getLanguageId')
 			->willReturnMap([
 				[$user1, 'de'],
-				[$user3, 'en_us'],
+				[$user2, null],
+				[$user4, 'en_us'],
 			]);
-		$this->service->expects(self::exactly(2))
+		$this->service->expects(self::exactly(3))
 			->method('getTimezoneId')
 			->willReturnMap([
 				[$user1, 'Europe/Berlin'],
-				[$user3, 'Australia/Adelaide'],
+				[$user2, null],
+				[$user4, 'Australia/Adelaide'],
 			]);
-		$this->service->expects(self::exactly(2))
+		$this->service->expects(self::exactly(3))
 			->method('getEmail')
 			->willReturnMap([
 				[$user1, [
@@ -382,7 +393,7 @@ class ContactControllerTest extends TestCase {
 				]
 				],
 				[$user2, ['foo3@example.com']],
-				[$user3, ['foo5@example.com']],
+				[$user4, ['foo4@example.com']],
 			]);
 		$this->service->method('getPhotoUri')
 			->willReturnMap([
@@ -394,7 +405,7 @@ class ContactControllerTest extends TestCase {
 		$this->manager->expects(self::exactly(2))
 			->method('search')
 			->willReturnMap([
-				['search 123', ['FN', 'EMAIL'], ['enumeration' => false], [$user1, $user2, $user3, $user4]],
+				['search 123', ['FN', 'EMAIL'], ['enumeration' => true], [$user1, $user2, $user3, $user4]],
 				['search 123', ['CATEGORIES'], [], [$user4]]
 			]);
 
@@ -419,6 +430,101 @@ class ContactControllerTest extends TestCase {
 				],
 				'lang' => null,
 				'tzid' => null,
+				'photo' => null,
+				'type' => 'individual'
+			], [
+				'name' => 'Person 3',
+				'emails' => [
+					'foo4@example.com'
+				],
+				'lang' => 'en_us',
+				'tzid' => 'Australia/Adelaide',
+				'photo' => null,
+				'type' => 'individual'
+			]
+		], $response->getData());
+		$this->assertEquals(200, $response->getStatus());
+	}
+
+	public function testSearchAttendeeExternalAttendeesDisabled():void {
+		$user1 = [
+			'FN' => 'Person 1',
+			'EMAIL' => [
+				'foo1@example.com',
+				'foo2@example.com',
+			],
+			'LANG' => 'de',
+			'TZ' => 'Europe/Berlin',
+			'PHOTO' => 'VALUE=uri:http://foo.bar'
+		];
+		$user2 = [
+			'FN' => 'Person 2',
+			'EMAIL' => 'foo3@example.com',
+		];
+		$user3 = [
+			'isLocalSystemBook' => true,
+			'FN' => 'System User',
+			'EMAIL' => 'system@example.com',
+			'LANG' => 'en',
+			'TZ' => 'UTC',
+		];
+
+		$this->manager->expects(self::once())
+			->method('isEnabled')
+			->willReturn(true);
+		$this->appConfig->expects(self::once())
+			->method('getValueBool')
+			->with('dav', 'caldav_external_attendees_disabled', false)
+			->willReturn(true);
+		$this->service
+			->method('hasEmail')
+			->willReturnMap([
+				[$user1, true],
+				[$user2, true],
+				[$user3, true],
+			]);
+		$this->service
+			->method('isSystemBook')
+			->willReturnMap([
+				[$user1, false],
+				[$user2, false],
+				[$user3, true],
+			]);
+		$this->service
+			->method('getNameFromContact')
+			->willReturnMap([
+				[$user3, 'System User'],
+			]);
+		$this->service->expects(self::once())
+			->method('getLanguageId')
+			->with($user3)
+			->willReturn('en');
+		$this->service->expects(self::once())
+			->method('getTimezoneId')
+			->with($user3)
+			->willReturn('UTC');
+		$this->service->expects(self::once())
+			->method('getEmail')
+			->with($user3)
+			->willReturn(['system@example.com']);
+		$this->service->expects(self::once())
+			->method('getPhotoUri')
+			->with($user3)
+			->willReturn(null);
+		$this->manager->expects(self::once())
+			->method('search')
+			->with('search 123', ['FN', 'EMAIL'], ['enumeration' => true])
+			->willReturn([$user1, $user2, $user3]);
+
+		$response = $this->controller->searchAttendee('search 123');
+
+		$this->assertInstanceOf(JSONResponse::class, $response);
+		$this->assertEquals([
+			[
+				'name' => 'System User',
+				'emails' => ['system@example.com'],
+				'lang' => 'en',
+				'tzid' => 'UTC',
 				'photo' => null,
 				'type' => 'individual'
 			]


### PR DESCRIPTION
### Summary
- Added functionality to restrict inviting only system users
- Removed calls to the DAV backend the contacts controller already checks all available dav address books