### PR TITLE
fix: show calendar name in read-only event editor

### DIFF
--- a/src/views/EditFull.vue
+++ b/src/views/EditFull.vue
@@ -111,7 +111,7 @@
 						@update-end-time="updateEndTime"
 						@update-end-timezone="updateEndTimezone" />
 
-					<div v-if="!isReadOnly" class="app-full__header__details">
+					<div class="app-full__header__details">
 						<div class="app-full__header__details-time">
 							<NcCheckboxRadioSwitch
 								v-if="!isReadOnly && !isViewedByAttendee"


### PR DESCRIPTION
Resolves: https://github.com/nextcloud/calendar/issues/7704

Summary: 
The calendar details section was hidden when `isReadOnly` was true, preventing users from seeing the calendar name and recurrence information.

Before:
<img width="1017" height="570" alt="image" src="https://github.com/user-attachments/assets/f8e90b63-962f-4ea8-8579-e652c41574fb" />

After:
<img width="1063" height="620" alt="image" src="https://github.com/user-attachments/assets/819c17e9-65c1-4507-8b8a-8deb0fbfd21e" />
