### PR TITLE
feat: show attachments only in view mode for simple editor

### DIFF
--- a/src/components/Editor/Attachments/AttachmentsList.vue
+++ b/src/components/Editor/Attachments/AttachmentsList.vue
@@ -11,7 +11,7 @@
 			multiple
 			:aria-label="t('calendar', 'Upload files as attachments')"
 			@change="onLocalAttachmentSelected">
-		<div class="attachments-summary">
+		<div v-if="showSummary" class="attachments-summary">
 			<div class="attachments-summary-inner">
 				<Paperclip :size="20" />
 				<div v-if="attachments.length > 0" class="attachments-summary-inner-label">
@@ -40,7 +40,7 @@
 				</NcActionButton>
 			</NcActions>
 		</div>
-		<div v-if="attachments.length > 0">
+		<div v-if="showList">
 			<ul class="attachments-list">
 				<NcListItem
 					v-for="attachment in attachments"
@@ -123,6 +123,11 @@ export default {
 			type: Boolean,
 			default: true,
 		},
+
+		compact: {
+			type: Boolean,
+			default: false,
+		},
 	},
 
 	data() {
@@ -143,6 +148,14 @@ export default {
 
 		attachments() {
 			return this.calendarObjectInstance.attachments
+		},
+
+		showSummary() {
+			return !this.compact || this.attachments.length > 1
+		},
+
+		showList() {
+			return this.attachments.length > 0 && (!this.compact || this.attachments.length === 1)
 		},
 	},
 

--- a/src/views/EditSimple.vue
+++ b/src/views/EditSimple.vue
@@ -222,6 +222,10 @@
 							<AlarmList
 								:isReadOnly="isReadOnlyOrViewing" />
 						</div>
+						<AttachmentsList
+							v-if="!isLoading && isViewing"
+							:isReadOnly="true"
+							compact />
 					</div>
 
 					<!-- Footer -->
@@ -290,6 +294,7 @@ import Download from 'vue-material-design-icons/TrayArrowDown.vue'
 import IconVideo from 'vue-material-design-icons/VideoOutline.vue'
 import AddTalkModal from '@/components/Editor/AddTalkModal.vue'
 import AlarmList from '@/components/Editor/Alarm/AlarmList.vue'
+import AttachmentsList from '@/components/Editor/Attachments/AttachmentsList.vue'
 import CalendarPickerHeader from '@/components/Editor/CalendarPickerHeader.vue'
 import InvitationResponseButtons
 	from '@/components/Editor/InvitationResponseButtons.vue'
@@ -321,6 +326,7 @@ export default {
 		NcActionSeparator,
 		AlarmList,
 		Bell,
+		AttachmentsList,
 		EmptyContent,
 		CalendarBlank,
 		Close,

--- a/src/views/EditSimple.vue
+++ b/src/views/EditSimple.vue
@@ -166,7 +166,7 @@
 								{{ $t('calendar', 'All day') }}
 							</NcCheckboxRadioSwitch>
 						</div>
-						<div class="event-popover__location-row">
+						<div v-if="!isViewing || hasLocation" class="event-popover__location-row">
 							<PropertyText
 								:isReadOnly="isReadOnlyOrViewing || isViewedByOrganizer === false"
 								:propModel="rfcProps.location"


### PR DESCRIPTION
Resolves: https://github.com/nextcloud/calendar/issues/7816
Summary:
This PR aims to show attachment list in the simple editor in viewing mode.

Before:
<img width="498" height="417" alt="image" src="https://github.com/user-attachments/assets/4aee5934-5b35-4974-b922-32331276238a" />

After:
<img width="496" height="553" alt="image" src="https://github.com/user-attachments/assets/6d0ed6fb-d237-4d50-844f-382986dca793" />
