### PR TITLE
feat(appointments): add duplicate button to clone appointment

### DIFF
--- a/src/components/AppNavigation/AppointmentConfigList/AppointmentConfigListItem.vue
+++ b/src/components/AppNavigation/AppointmentConfigList/AppointmentConfigListItem.vue
@@ -31,7 +31,15 @@
 				</ActionButton>
 				<ActionButton
 					:close-after-click="true"
-					@click="showModal = true">
+					@click="duplicate">
+					<template #icon>
+						<ContentDuplicate :size="20" />
+					</template>
+					{{ t('calendar', 'Duplicate') }}
+				</ActionButton>
+				<ActionButton
+					:close-after-click="true"
+					@click="openEditModal">
 					<template #icon>
 						<PencilIcon :size="20" />
 					</template>
@@ -49,7 +57,8 @@
 		</AppNavigationItem>
 		<AppointmentConfigModal
 			v-if="showModal"
-			:is-new="false"
+			:is-new="isDuplicate"
+			:is-duplicate="isDuplicate"
 			:config="config"
 			@close="closeModal" />
 	</div>
@@ -63,6 +72,7 @@ import {
 	NcAppNavigationItem as AppNavigationItem,
 } from '@nextcloud/vue'
 import CalendarCheckIcon from 'vue-material-design-icons/CalendarCheck.vue'
+import ContentDuplicate from 'vue-material-design-icons/ContentDuplicate.vue'
 import LinkVariantIcon from 'vue-material-design-icons/Link.vue'
 import OpenInNewIcon from 'vue-material-design-icons/OpenInNew.vue'
 import PencilIcon from 'vue-material-design-icons/PencilOutline.vue'
@@ -78,6 +88,7 @@ export default {
 		AppNavigationItem,
 		ActionButton,
 		ActionLink,
+		ContentDuplicate,
 		DeleteIcon,
 		OpenInNewIcon,
 		PencilIcon,
@@ -96,6 +107,7 @@ export default {
 		return {
 			showModal: false,
 			loading: false,
+			isDuplicate: false,
 		}
 	},
 
@@ -108,6 +120,17 @@ export default {
 	methods: {
 		closeModal() {
 			this.showModal = false
+			this.isDuplicate = false
+		},
+
+		openEditModal() {
+			this.isDuplicate = false
+			this.showModal = true
+		},
+
+		duplicate() {
+			this.isDuplicate = true
+			this.showModal = true
 		},
 
 		async copyLink() {

--- a/src/components/AppointmentConfigModal.vue
+++ b/src/components/AppointmentConfigModal.vue
@@ -199,6 +199,11 @@ export default {
 			type: Boolean,
 			required: true,
 		},
+
+		isDuplicate: {
+			type: Boolean,
+			default: false,
+		},
 	},
 
 	data() {
@@ -292,6 +297,10 @@ export default {
 	methods: {
 		reset() {
 			this.editing = this.config.clone()
+
+			if (this.isDuplicate) {
+				this.editing.name = `${this.editing.name} ${this.t('calendar', '(copy)')}`
+			}
 
 			this.enablePreparationDuration = !!this.editing.preparationDuration
 			this.enableFollowupDuration = !!this.editing.followupDuration


### PR DESCRIPTION
Resolves: https://github.com/nextcloud/calendar/issues/7712

Summary:
Added "Duplicate" action button in the three-dot menu for each appointment schedule.

Added a new `isCreatingNew` flag in  `AppointmentConfigListItem` to control whether to edit or duplicate the existing config.

Before:
<img width="333" height="277" alt="image" src="https://github.com/user-attachments/assets/2739410d-6745-46a5-b880-6a5fcb195e88" />

After:
<img width="339" height="291" alt="image" src="https://github.com/user-attachments/assets/43025a26-2bd5-4eb1-a246-7555f70df1dd" />
