### PR TITLE
chore: imporove ts complier configuration

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,11 +6,10 @@
 		"target": "ESNext",
 		"strictNullChecks": true,
 		"sourceMap": true,
-		"allowSyntheticDefaultImports": true,
 		"declaration": false,
-		"baseUrl": ".",
+		"allowSyntheticDefaultImports": true,
 		"paths": {
-			"@/*": ["src/*"]
+			"@/*": ["./src/*"]
 		}
 	},
 	"vueCompilerOptions": {


### PR DESCRIPTION
### Summary
- baseUrl is deprecate
- modified @ root alias to due to above deprecation
