### PR TITLE
fix: meeting proposal conversion error

### DIFF
--- a/lib/Service/Proposal/ProposalService.php
+++ b/lib/Service/Proposal/ProposalService.php
@@ -362,6 +362,12 @@ class ProposalService {
 			]);
 		}
 
+		// delete any existing calendar blocker event
+		$result = $this->findCalendarBlocker($user, $proposal);
+		if ($result !== null) {
+			$this->deleteCalendarBlockersOrganizer($user, $result['calendarUri'], $result['eventUri'], $proposal);
+		}
+
 		// store the calendar object
 		$userCalendar->createFromString(
 			Uuid::v4()->toRfc4122() . '.ics',


### PR DESCRIPTION
### Summary
- Adjusted proposal logic to delete existing time blocker to prevent duplicate uid error

```
"message": "Calendar object with uid already exists in this calendar collection.",
    "exception": "{\"class\":\"Sabre\\DAV\\Exception\\BadRequest\",\"message\":\"Calendar object with uid already exists in this calendar collection.\",\"code\":0,\"file\":\"/var/www/nextcloud/master/apps/dav/lib/CalDAV/CalDavBackend.php:1370\",\"trace\":\"#0 /var/www/nextcloud/master/lib/public/AppFramework/Db/TTransactional.php(45): OCA\\DAV\\CalDAV\\CalDavBackend->OCA\\DAV\\CalDAV\\{closure}()\\n#1 /var/www/nextcloud/master/apps/dav/lib/CalDAV/CalDavBackend.php(1356): OCA\\DAV\\CalDAV\\CalDavBackend->atomic()\\n#2 /var/www/nextcloud/master/3rdparty/sabre/dav/lib/CalDAV/Calendar.php(199): OCA\\DAV\\CalDAV\\CalDavBackend->createCalendarObject()\\n#3 /var/www/nextcloud/master/3rdparty/sabre/dav/lib/DAV/Server.php(1098): Sabre\\CalDAV\\Calendar->createFile()\\n#4 /var/www/nextcloud/master/apps/dav/lib/CalDAV/CalendarImpl.php(203): Sabre\\DAV\\Server->createFile()\\n#5 /var/www/nextcloud/master/apps/dav/lib/CalDAV/CalendarImpl.php(213): OCA\\DAV\\CalDAV\\CalendarImpl->createFromStringInServer()\\n#6 /var/www/nextcloud/master/apps/calendar/lib/Service/Proposal/ProposalService.php(366): OCA\\DAV\\CalDAV\\CalendarImpl->createFromString()\\n#7 /var/www/nextcloud/master/apps/calendar/lib/Controller/ProposalController.php(194): OCA\\Calendar\\Service\\Proposal\\ProposalService->convertProposal()\\n#8 /var/www/nextcloud/master/lib/private/AppFramework/Http/Dispatcher.php(205): OCA\\Calendar\\Controller\\ProposalController->convert()\\n#9 /var/www/nextcloud/master/lib/private/AppFramework/Http/Dispatcher.php(118): OC\\AppFramework\\Http\\Dispatcher->executeController()\\n#10 /var/www/nextcloud/master/lib/private/AppFramework/App.php(153): OC\\AppFramework\\Http\\Dispatcher->dispatch()\\n#11 /var/www/nextcloud/master/lib/private/Route/Router.php(321): OC\\AppFramework\\App::main()\\n#12 /var/www/nextcloud/master/ocs/v1.php(61): OC\\Route\\Router->match()\\n#13 /var/www/nextcloud/master/ocs/v2.php(8): require_once('...')\\n#14 {main}\"}",
    "CustomMessage": "Calendar object with uid already exists in this calendar collection."
```

### Testing
- Create meeting proposal with at least one attendee and one date (this will create a time blocker in the calendar)
- After proposal is created convert one of the date to a meeting (does not require a vote) the conversion should fail with a error without this PR