### PR TITLE
[stable5.5] fix: settings button icon alignment

### DIFF
--- a/src/components/AppNavigation/Settings.vue
+++ b/src/components/AppNavigation/Settings.vue
@@ -502,9 +502,13 @@ export default {
 }
 </script>
 
-<style scoped>
+<style lang="scss" scoped>
 .settings-fieldset-interior-item,
 :deep(.v-select.select) {
 	width: 100%;
+}
+
+:deep(.settings-button__icon > svg) {
+	margin: 7px 5px 7px 9px;
 }
 </style>


### PR DESCRIPTION
This is not an issue on `main` and all other calendar branches below `stable5.5` are EOL.

| Before | After |
| --- | --- |
| <img width="319" height="150" alt="image" src="https://github.com/user-attachments/assets/fe422b5d-f0be-445a-98ce-2dd417e63409" /> | <img width="319" height="150" alt="image" src="https://github.com/user-attachments/assets/91aec8ca-3494-4d17-accf-6016e7da4ac7" /> |

(Tested on Nextcloud `stable31`.)