### PR TITLE
feat(invitees): add export attendees to CSV button

### DIFF
--- a/src/components/Editor/Invitees/InviteesList.vue
+++ b/src/components/Editor/Invitees/InviteesList.vue
@@ -10,6 +10,16 @@
 				<AccountMultipleIcon :size="20" />
 				<span class="invitees-list__header__title__text">{{ t('calendar', 'Attendees') }}</span>
 				<NcCounterBubble :count="invitees.length + 1" />
+				<NcButton
+					variant="tertiary"
+					:disabled="invitees.length === 0"
+					:aria-label="t('calendar', 'Copy attendees to clipboard')"
+					:title="t('calendar', 'Copy attendees to clipboard')"
+					@click="copyAttendeesToClipboard">
+					<template #icon>
+						<ContentCopy :size="20" />
+					</template>
+				</NcButton>
 			</div>
 
 			<div v-if="!hideButtons" class="invitees-list-button-group">
@@ -81,6 +91,7 @@ import {
 import { NcButton, NcCounterBubble } from '@nextcloud/vue'
 import { mapState, mapStores } from 'pinia'
 import AccountMultipleIcon from 'vue-material-design-icons/AccountMultipleOutline.vue'
+import ContentCopy from 'vue-material-design-icons/ContentCopy.vue'
 import FreeBusy from '../FreeBusy/FreeBusy.vue'
 import OrganizerNoEmailError from '../OrganizerNoEmailError.vue'
 import InviteesListItem from './InviteesListItem.vue'
@@ -104,6 +115,7 @@ export default {
 		OrganizerListItem,
 		AccountMultipleIcon,
 		NcCounterBubble,
+		ContentCopy,
 	},
 
 	props: {
@@ -445,6 +457,37 @@ export default {
 		saveNewDate(dates) {
 			this.$emit('updateDates', dates)
 			this.showFreeBusyModel = false
+		},
+
+		async copyAttendeesToClipboard() {
+			const headers = `${this.t('calendar', 'Name')}\t${this.t('calendar', 'Email')}\t${this.t('calendar', 'Status')}\t${this.t('calendar', 'Role')}`
+			const statusLabels = {
+				ACCEPTED: this.t('calendar', 'Accepted'),
+				DECLINED: this.t('calendar', 'Declined'),
+				TENTATIVE: this.t('calendar', 'Tentative'),
+				'NEEDS-ACTION': this.t('calendar', 'Awaiting response'),
+				DELEGATED: this.t('calendar', 'Delegated'),
+			}
+			const roleLabels = {
+				CHAIR: this.t('calendar', 'Chairperson'),
+				'REQ-PARTICIPANT': this.t('calendar', 'Required participant'),
+				'OPT-PARTICIPANT': this.t('calendar', 'Optional participant'),
+				'NON-PARTICIPANT': this.t('calendar', 'Non-participant'),
+			}
+			const rows = this.inviteesWithoutOrganizer.map((attendee) => {
+				const name = attendee.commonName || ''
+				const email = removeMailtoPrefix(attendee.uri) || ''
+				const status = statusLabels[attendee.participationStatus] || attendee.participationStatus
+				const role = roleLabels[attendee.role] || attendee.role
+				return `${name}\t${email}\t${status}\t${role}`
+			})
+			const tsvContent = [headers, ...rows].join('\n')
+			try {
+				await navigator.clipboard.writeText(tsvContent)
+				showSuccess(this.t('calendar', 'Attendees copied to clipboard'))
+			} catch (e) {
+				showError(this.t('calendar', 'Failed to copy attendees to clipboard'))
+			}
 		},
 	},
 }


### PR DESCRIPTION
Resolves: https://github.com/nextcloud/calendar/issues/7696

Summary:
Add a button to export invitees information as csv.

Before:
<img width="525" height="510" alt="image" src="https://github.com/user-attachments/assets/e81c7e27-15ba-4890-9b5f-603d2084372d" />

After:
<img width="515" height="464" alt="image" src="https://github.com/user-attachments/assets/5f08a8be-4e51-40e4-9d18-206a37a9c80f" />

Sample csv:
[test-2026-01-17 (1).csv](https://github.com/user-attachments/files/24688827/test-2026-01-17.1.csv)

