### PR TITLE
feat(importing): show all writable calendars in picker

### DIFF
--- a/css/import.scss
+++ b/css/import.scss
@@ -21,7 +21,8 @@
 
 		.import-modal-file-item {
 			display: flex;
-			padding-top: 10px;
+			margin-top: calc(var(--default-grid-baseline) * 2);
+			margin-bottom: calc(var(--default-grid-baseline) * 2);
 
 			&--header {
 				font-weight: bold;
@@ -33,6 +34,10 @@
 
 			&__calendar-select {
 				flex: 1 1 0;
+			}
+			
+			&__calendar-disabled-hint {
+				color: var(--color-text-maxcontrast);
 			}
 		}
 	}

--- a/src/components/AppNavigation/Settings/ImportScreenRow.vue
+++ b/src/components/AppNavigation/Settings/ImportScreenRow.vue
@@ -6,17 +6,24 @@
 <template>
 	<li class="import-modal-file-item">
 		<div class="import-modal-file-item__filename">
-			{{ file.name }}
+			<div>{{ file.name }}</div>
+			<div
+				v-if="disabledHint"
+				class="import-modal-file-item__calendar-disabled-hint">
+				{{ disabledHint }}
+			</div>
 		</div>
 		<CalendarPicker
 			class="import-modal-file-item__calendar-select"
 			:value="calendar"
 			:calendars="calendars"
+			:isCalendarSelectable="isCalendarSelectable"
 			@selectCalendar="selectCalendar" />
 	</li>
 </template>
 
 <script>
+import { getLanguage } from '@nextcloud/l10n'
 import { mapStores } from 'pinia'
 import CalendarPicker from '../../Shared/CalendarPicker.vue'
 import useCalendarsStore from '../../../store/calendars.js'
@@ -39,59 +46,90 @@ export default {
 
 	computed: {
 		...mapStores(usePrincipalsStore, useImportFilesStore, useCalendarsStore),
-		calendar() {
-			let calendarId = this.importFilesStore.importCalendarRelation[this.file.id]
-			if (!calendarId) {
-				this.setDefaultCalendarId()
-				calendarId = this.importFilesStore.importCalendarRelation[this.file.id]
-			}
-
-			if (calendarId === 'new') {
-				return {
-					id: 'new',
-					displayName: this.$t('calendar', 'New calendar'),
-					isSharedWithMe: false,
-					color: uidToHexColor(this.$t('calendar', 'New calendar')),
-					owner: this.principalsStore.getCurrentUserPrincipal.url,
-				}
-			}
-
-			return this.calendarsStore.getCalendarById(calendarId)
-		},
-
-		calendars() {
-			// TODO: remove once the false positive is fixed upstream
-
-			const calendars = this.calendarsStore.sortedCalendarFilteredByComponents(
-				this.file.parser.containsVEvents(),
-				this.file.parser.containsVJournals(),
-				this.file.parser.containsVTodos(),
-			)
-
-			calendars.push({
+		newCalendar() {
+			return {
 				id: 'new',
 				displayName: this.$t('calendar', 'New calendar'),
 				isSharedWithMe: false,
 				color: uidToHexColor(this.$t('calendar', 'New calendar')),
 				owner: this.principalsStore.getCurrentUserPrincipal.url,
-			})
+			}
+		},
 
-			return calendars
+		calendar() {
+			const calendarId = this.importFilesStore.importCalendarRelation[this.file.id]
+			if (calendarId === this.newCalendar.id) {
+				return this.newCalendar
+			}
+			return this.calendarsStore.getCalendarById(calendarId)
+		},
+
+		calendars() {
+			const existingCalendars = this.calendarsStore.sortedWritableCalendarsEvenWithoutSupportForEvents
+			return [...existingCalendars, this.newCalendar]
+		},
+
+		/**
+		 * Returns a hint explaining why some calendars cannot be selected.
+		 *
+		 * @return {string|undefined} A message, or undefined if all calendars can be selected.
+		 */
+		disabledHint() {
+			const disalbedBecauseOfEvents = this.file.parser.containsVEvents() && this.calendars.some((calendar) => !calendar.supportsEvents)
+			const disalbedBecauseOfTasks = this.file.parser.containsVTodos() && this.calendars.some((calendar) => !calendar.supportsTasks)
+			const disalbedBecauseOfJournalEntries = this.file.parser.containsVJournals() && this.calendars.some((calendar) => !calendar.supportsJournals)
+
+			const disablingTypes = []
+			if (disalbedBecauseOfEvents) {
+				disablingTypes.push(this.$t('calendar', 'events'))
+			}
+			if (disalbedBecauseOfTasks) {
+				disablingTypes.push(this.$t('calendar', 'tasks'))
+			}
+			if (disalbedBecauseOfJournalEntries) {
+				disablingTypes.push(this.$t('calendar', 'journal entries'))
+			}
+
+			if (disablingTypes.lenght === 0) {
+				return undefined
+			}
+
+			const formatter = new Intl.ListFormat(getLanguage(), { type: 'conjunction' })
+			const localizedTypes = formatter.format(disablingTypes)
+			return this.$t('calendar', 'Some calendars are disabled because this file contains {types}.', { types: localizedTypes })
 		},
 	},
 
+	created() {
+		const preselectedCalendar = this.calendars.find((calendar) => this.isCalendarSelectable(calendar))
+		if (!preselectedCalendar) {
+			// If no other calendar is selectable, at least `this.newCalendar` should be selectable and be preselected.
+			throw new Error('Encountered illegal state. At least one calendar that can be selected should exist.')
+		}
+		this.selectCalendar(preselectedCalendar)
+	},
+
 	methods: {
+		isCalendarSelectable(calendar) {
+			if (calendar.id === this.newCalendar.id) {
+				return true
+			}
+			if (this.file.parser.containsVEvents() && !calendar.supportsEvents) {
+				return false
+			}
+			if (this.file.parser.containsVTodos() && !calendar.supportsTasks) {
+				return false
+			}
+			if (this.file.parser.containsVJournals() && !calendar.supportsJournals) {
+				return false
+			}
+			return true
+		},
+
 		selectCalendar(newCalendar) {
 			this.importFilesStore.setCalendarForFileId({
 				fileId: this.file.id,
 				calendarId: newCalendar.id,
-			})
-		},
-
-		setDefaultCalendarId() {
-			this.importFilesStore.setCalendarForFileId({
-				fileId: this.file.id,
-				calendarId: this.calendars[0].id,
 			})
 		},
 	},

--- a/src/components/Shared/CalendarPicker.vue
+++ b/src/components/Shared/CalendarPicker.vue
@@ -15,6 +15,7 @@
 		:filterBy="selectFilterBy"
 		:inputLabel="inputLabel"
 		:labelOutside="inputLabel === ''"
+		:selectable="selectable"
 		@update:modelValue="handleSelectionUpdate">
 		<template #option="{ id }">
 			<CalendarPickerOption
@@ -90,6 +91,18 @@ export default {
 		inputLabel: {
 			type: String,
 			default: '',
+		},
+
+		/**
+		 * Decides whether a calendar is selectable or not.
+		 * Non-selectable calendars are displayed but cannot be selected.
+		 *
+		 * @param {object} calendar
+		 * @return {boolean}
+		 */
+		isCalendarSelectable: {
+			type: Function,
+			default: (calendar) => true,
 		},
 	},
 
@@ -180,6 +193,17 @@ export default {
 		 */
 		selectFilterBy(option, label, search) {
 			return option.displayName.toLowerCase().indexOf(search) !== -1
+		},
+
+		/**
+		 * Decide whether the given option can be selected
+		 *
+		 * @param {object} option The calendar option
+		 * @return {boolean} True if the option can be selected
+		 */
+		selectable(option) {
+			const calendar = this.getCalendarById(option.id)
+			return this.isCalendarSelectable(calendar)
 		},
 	},
 }

--- a/src/store/calendars.js
+++ b/src/store/calendars.js
@@ -91,6 +91,21 @@ export default defineStore('calendars', {
 		},
 
 		/**
+		 * List of sorted writable calendars.
+		 *
+		 * Even including ones without support for events.
+		 * Those are usually excluded by all other getters.
+		 *
+		 * @param {object} state the store data
+		 * @return {Array}
+		 */
+		sortedWritableCalendarsEvenWithoutSupportForEvents(state) {
+			return state.calendars
+				.filter((calendar) => !calendar.readOnly)
+				.sort((a, b) => a.order - b.order)
+		},
+
+		/**
 		 * List of sorted calendars owned by the principal
 		 *
 		 * @param {object} state the store data
@@ -242,29 +257,6 @@ export default defineStore('calendars', {
 			}
 
 			return null
-		},
-
-		/**
-		 * @return {function({Boolean}, {Boolean}, {Boolean}): {Object}[]}
-		 */
-		sortedCalendarFilteredByComponents() {
-			return (vevent, vjournal, vtodo) => {
-				return this.sortedCalendars.filter((calendar) => {
-					if (vevent && !calendar.supportsEvents) {
-						return false
-					}
-
-					if (vjournal && !calendar.supportsJournals) {
-						return false
-					}
-
-					if (vtodo && !calendar.supportsTasks) {
-						return false
-					}
-
-					return true
-				})
-			}
 		},
 
 		/**

--- a/tests/javascript/unit/store/calendars.test.js
+++ b/tests/javascript/unit/store/calendars.test.js
@@ -2,11 +2,41 @@
  * SPDX-FileCopyrightText: 2019 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
+import useCalendarsStore from '../../../../src/store/calendars.js'
+
+import { setActivePinia, createPinia } from 'pinia'
 
 describe('store/calendars test suite', () => {
+	
+	beforeEach(() => {
+		setActivePinia(createPinia())
+	})
 
-	it('should be true', () => {
-		expect(true).toEqual(true)
+	it('should provide a getter for all writable calendars sorted', () => {
+		const calendarsStore = useCalendarsStore()
+		const calendarOrderLast = {
+			id: "1",
+			order: 2,
+			supportsEvents: false,
+			supportsJournals: true
+		}
+		const calendarReadOnly = {
+			id: "2",
+			readOnly: true,
+			supportsEvents: true,
+		}
+		const calendarOrderFirst = {
+			id: "3",
+			order: 1,
+			supportsEvents: true,
+			supportsJournals: false
+		}
+		calendarsStore.addCalendarMutation({ calendar: calendarOrderLast })
+		calendarsStore.addCalendarMutation({ calendar: calendarReadOnly })
+		calendarsStore.addCalendarMutation({ calendar: calendarOrderFirst })
+
+		writableCalendars = calendarsStore.sortedWritableCalendarsEvenWithoutSupportForEvents
+		expect(writableCalendars).toMatchObject([calendarOrderFirst, calendarOrderLast])
 	})
 
 })


### PR DESCRIPTION
Mark unsupported calendars as non-selectable.
Previously they were fully hidden.

Show a message about why some calendars are not selectable.

Also show calendars that do not support events (and only support tasks and/or journal entries).
Previously, calendars that did not support events were hidden altogether.

Resolves:  #2572

### Before

<img width="1376" height="732" alt="Screenshot From 2026-01-18 23-18-03" src="https://github.com/user-attachments/assets/026a2592-9b78-49cc-9049-cf2aea10f319" />


### After


<img width="1344" height="705" alt="image" src="https://github.com/user-attachments/assets/be5613ed-b6d4-42dc-b892-91138697e774" />

### Test data

[SampleIcsFiles.zip](https://github.com/user-attachments/files/24699054/SampleIcsFiles.zip)

### After (previous iterations)
<details>
  <summary>First iteration</summary>


<img width="1376" height="732" alt="Screenshot From 2026-01-18 23-15-30" src="https://github.com/user-attachments/assets/346aa44b-093c-445f-ae37-99f7462415b0" />
</details>

<details>
  <summary>Second iteraton (vertical margin 10px)</summary>
  <img width="1478" height="801" alt="Screenshot From 2026-01-25 19-38-36" src="https://github.com/user-attachments/assets/f718160f-83eb-4fa7-a69d-5197f895085e" />
  </details>

