### PR TITLE
fix(CalendarGrid): make short events render title on one line

### DIFF
--- a/src/components/CalendarGrid.vue
+++ b/src/components/CalendarGrid.vue
@@ -166,6 +166,7 @@ export default {
 				// Dropping Tasks
 				droppable: true,
 				eventReceive: this.handleEventReceive,
+				eventShortHeight: 40,
 			}
 		},
 


### PR DESCRIPTION
| Before | After |
| - | - |
| <img width="309" height="68" alt="image" src="https://github.com/user-attachments/assets/6016eb96-c717-4d7e-9e67-4c3d4bd1fa8c" />  | <img width="316" height="66" alt="swappy-20260123_115416" src="https://github.com/user-attachments/assets/f511b2a9-2d22-4fb8-834c-ca7ce6c10738" /> |
