### PR TITLE
Revert "chore(release): v6.3.0-beta.0 [skip ci]"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1050 +1,1265 @@
-# [6.3.0-beta.0](https://github.com/nextcloud/calendar/compare/v6.2.0-beta.0...v6.3.0-beta.0) (2026-01-26)
-
-
-### Bug Fixes
-
-* actually create a talk room when converting proposal ([2ed846e](https://github.com/nextcloud/calendar/commit/2ed846e0f551097f29a478125f85835d56606833))
-* add a gap for event dragging ([4cf192d](https://github.com/nextcloud/calendar/commit/4cf192d1827df7bcf81e0b48d0f7e96de9854677))
-* add duplicated event directly to the target calendar ([aa7ad02](https://github.com/nextcloud/calendar/commit/aa7ad02ce660d55d31da57045738c9e23e3c40d8))
-* **AddTalkModal:** add scrolling for long list ([7bb1fde](https://github.com/nextcloud/calendar/commit/7bb1fdec2a24fe6fcb38e8cdfe48d4a61fa568f1))
-* **AddTalkModal:** styling ([70723bb](https://github.com/nextcloud/calendar/commit/70723bb0b1d6e2c512a53d123638dace23a65f4d))
-* adjust tentative status icon colour ([715f7c1](https://github.com/nextcloud/calendar/commit/715f7c1b69a8537183adf3b2196a4a4c53a6af3b))
-* alarm styling ([76c2c59](https://github.com/nextcloud/calendar/commit/76c2c5933063f82b248f659d598aeb9e2d458ddd))
-* alarm type not binding properly ([c1dd80d](https://github.com/nextcloud/calendar/commit/c1dd80d8b9454c5b51fad18dbb7671ee72504cd1))
-* allow all calendars as appointment conflict calendars ([8f10775](https://github.com/nextcloud/calendar/commit/8f107759afaaa562d4218a605c13b669b3d49423))
-* always show alarm unit in pural ([1509e87](https://github.com/nextcloud/calendar/commit/1509e8747f526baed2520d2ce1b85517651467dd))
-* appointment config tests ([998a5f6](https://github.com/nextcloud/calendar/commit/998a5f685806c647f863d3b969e5765a51d37549))
-* appointment duration selection ([d55bea6](https://github.com/nextcloud/calendar/commit/d55bea60d5f23c88f509a1b7c4d3043a13cf6c34))
-* **appointments:** mobile booking view not being responsive ([5a18d85](https://github.com/nextcloud/calendar/commit/5a18d85915aaae0449d4e2428317716732e3afe6))
-* **appointments:** unify IDs ([47084f0](https://github.com/nextcloud/calendar/commit/47084f07daf3288cdc9369905fa34fc44e28f1f8))
-* **attachements:** show confirmation dialog for all links ([1b648ea](https://github.com/nextcloud/calendar/commit/1b648eac3dc59216dac4401704eb7afad8ff1748))
-* **attachments:** improve confirmation dialog message ([ec93e91](https://github.com/nextcloud/calendar/commit/ec93e91e85e4b86927b9a7b4664b41e4600627d5))
-* **AvatarParticipationStatus:** make attendee participation status text not ellipse early ([04a2c9b](https://github.com/nextcloud/calendar/commit/04a2c9b3a32cab6954ae5e11fd1ccea685533bc0))
-* avoid hotkeys in contenteditable ([cad954e](https://github.com/nextcloud/calendar/commit/cad954e7bdf20c591afcf087c2719438b9c7eff2))
-* **calendar-list:** restrict calendar visibility toggle to checkbox only ([f1ceb1a](https://github.com/nextcloud/calendar/commit/f1ceb1a2a32e535f4006a163b96b7819d514777f)), closes [#3027](https://github.com/nextcloud/calendar/issues/3027)
-* **CalendarGrid:** make short events render title on one line ([a1a1276](https://github.com/nextcloud/calendar/commit/a1a12763cff735e6b01f95985a6a8cc825b40a3b))
-* **CalendarPickerHeader:** fix alignment ([4280699](https://github.com/nextcloud/calendar/commit/4280699d45539152bc76ae44a6d1a74e40965897))
-* cancel confirmation dialog ([cd30895](https://github.com/nextcloud/calendar/commit/cd308956d1a92347f921ee3fb564094c97c08434))
-* close modal after creating conversation ([a636ea0](https://github.com/nextcloud/calendar/commit/a636ea09f00fb38c4fb308fda51b627fab7da372))
-* close view selection menu after click ([f189e36](https://github.com/nextcloud/calendar/commit/f189e36a794c479f9ae8143ec8c5697bbeeeeb44))
-* color picker size ([0c1d227](https://github.com/nextcloud/calendar/commit/0c1d22737ef82fb5e76ca5abbf842f178c9912f6))
-* Console-log errors thrown when saving an event ([30f9eb7](https://github.com/nextcloud/calendar/commit/30f9eb75892ef56bac5a5a25140b59d09a2678f0))
-* date selector resetting time ([caf5cf8](https://github.com/nextcloud/calendar/commit/caf5cf87b2a075a061294d09a657b3047cc89b5c))
-* **deps:** add missing parcel watcher packages ([121fe98](https://github.com/nextcloud/calendar/commit/121fe98e23d58483e8213f655ad16918e059e548))
-* **deps:** bump @nextcloud/auth from 2.4.0 to ^2.5.1 (main) ([#6976](https://github.com/nextcloud/calendar/issues/6976)) ([12f442a](https://github.com/nextcloud/calendar/commit/12f442a0107248e2224d05504863193c51bd2aed))
-* **deps:** bump @nextcloud/auth from 2.5.1 to ^2.5.2 ([a5e2e58](https://github.com/nextcloud/calendar/commit/a5e2e586923a1c55431e425ef65d635e2e8acb76))
-* **deps:** bump @nextcloud/auth from 2.5.2 to ^2.5.3 (main) ([#7549](https://github.com/nextcloud/calendar/issues/7549)) ([adb2b39](https://github.com/nextcloud/calendar/commit/adb2b397fe812b188e5e0c0d60e5982f9f4c3cdd))
-* **deps:** bump @nextcloud/axios from 2.5.1 to ^2.5.2 (main) ([#7480](https://github.com/nextcloud/calendar/issues/7480)) ([616951b](https://github.com/nextcloud/calendar/commit/616951b25f176780bf57526914986b8e4c9f3519))
-* **deps:** bump @nextcloud/calendar-availability-vue from 2.2.6 to ^2.2.7 ([4add973](https://github.com/nextcloud/calendar/commit/4add973e8da60e8afc107e5f2167768fdd78836e))
-* **deps:** bump @nextcloud/calendar-availability-vue from 2.2.7 to ^2.2.8 (main) ([#7190](https://github.com/nextcloud/calendar/issues/7190)) ([b5956ec](https://github.com/nextcloud/calendar/commit/b5956ec23da71d4cf61de10dce5ab0e509f8829d))
-* **deps:** bump @nextcloud/calendar-availability-vue from 2.2.8 to ^2.2.9 (main) ([#7272](https://github.com/nextcloud/calendar/issues/7272)) ([93899e2](https://github.com/nextcloud/calendar/commit/93899e260a795f4e783e9c03780586d77e6c47d1))
-* **deps:** bump @nextcloud/calendar-availability-vue from 2.2.9 to ^2.2.10 (main) ([#7281](https://github.com/nextcloud/calendar/issues/7281)) ([59bbc66](https://github.com/nextcloud/calendar/commit/59bbc668d68caa76bb1e8ed4ae5053a0455448c9))
-* **deps:** bump @nextcloud/calendar-js from 8.0.3 to ^8.1.0 (main) ([#6646](https://github.com/nextcloud/calendar/issues/6646)) ([a75bd08](https://github.com/nextcloud/calendar/commit/a75bd08d0548dcaaaeecc54a313a5618f0081a6d))
-* **deps:** bump @nextcloud/calendar-js from 8.1.0 to ^8.1.1 (main) ([#6807](https://github.com/nextcloud/calendar/issues/6807)) ([026cfd5](https://github.com/nextcloud/calendar/commit/026cfd57127a2583abb6e756c454afe8f1a39a88))
-* **deps:** bump @nextcloud/calendar-js from 8.1.2 to ^8.1.3 ([63def13](https://github.com/nextcloud/calendar/commit/63def13358a698663625b1241f41789021e9e684))
-* **deps:** bump @nextcloud/calendar-js from 8.1.4 to ^8.1.5 (main) ([#7273](https://github.com/nextcloud/calendar/issues/7273)) ([bed3fa2](https://github.com/nextcloud/calendar/commit/bed3fa2b7ec7aeb139d1620bf3e65eacbd6fb872))
-* **deps:** bump @nextcloud/calendar-js to ^8.1.4 ([9bbb504](https://github.com/nextcloud/calendar/commit/9bbb504534272273c9ab006b148884206a68b053))
-* **deps:** bump @nextcloud/cdav-library from 1.5.2 to ^1.5.3 (main) ([#6855](https://github.com/nextcloud/calendar/issues/6855)) ([521a4fd](https://github.com/nextcloud/calendar/commit/521a4fd113049ffe3c070921a46096ad8b774e2e))
-* **deps:** bump @nextcloud/cdav-library from 1.5.3 to v2 ([8d13b4c](https://github.com/nextcloud/calendar/commit/8d13b4c0acac1f52e557baf8305ee2e66fa86e5f))
-* **deps:** bump @nextcloud/cdav-library from 2.1.0 to ^2.1.1 (main) ([#7162](https://github.com/nextcloud/calendar/issues/7162)) ([61e9a28](https://github.com/nextcloud/calendar/commit/61e9a28f1aefa8e255154aee53db83af3df8e1cb))
-* **deps:** bump @nextcloud/dialogs from 6.0.1 to ^6.1.1 (main) ([#6647](https://github.com/nextcloud/calendar/issues/6647)) ([d30e56a](https://github.com/nextcloud/calendar/commit/d30e56abb76c0ee642fa3803ee24165d1bee0f1e))
-* **deps:** bump @nextcloud/dialogs from 6.1.1 to ^6.2.0 (main) ([#6946](https://github.com/nextcloud/calendar/issues/6946)) ([05e7009](https://github.com/nextcloud/calendar/commit/05e700965d22974cea7e1ffc0598e65e89728e5c))
-* **deps:** bump @nextcloud/dialogs from 6.2.0 to ^6.3.0 (main) ([#6996](https://github.com/nextcloud/calendar/issues/6996)) ([f6246e4](https://github.com/nextcloud/calendar/commit/f6246e4abb65b09388b4bf66bf3c820f831b9c6e))
-* **deps:** bump @nextcloud/dialogs from 6.3.0 to ^6.3.1 ([ff333fa](https://github.com/nextcloud/calendar/commit/ff333fa637d2d5bbfb96c534d13373fc1f61bf91))
-* **deps:** bump @nextcloud/dialogs from 6.3.1 to ^6.3.2 (main) ([#7437](https://github.com/nextcloud/calendar/issues/7437)) ([73fce1b](https://github.com/nextcloud/calendar/commit/73fce1be321c91e1dbdde6d342df4fbf559495bd))
-* **deps:** bump @nextcloud/event-bus from 3.3.1 to ^3.3.2 (main) ([#6783](https://github.com/nextcloud/calendar/issues/6783)) ([3b4fc40](https://github.com/nextcloud/calendar/commit/3b4fc40e69666e68f76de49358dbe68e3371335f))
-* **deps:** bump @nextcloud/initial-state from 2.2.0 to v3 ([051965d](https://github.com/nextcloud/calendar/commit/051965d65466cf4a811f576ff4a96455c7b5d186))
-* **deps:** bump @nextcloud/l10n from 3.2.0 to ^3.2.0 (main) ([#6745](https://github.com/nextcloud/calendar/issues/6745)) ([e0e0bb3](https://github.com/nextcloud/calendar/commit/e0e0bb32e767b0521fc24a2f6a97a634d6d02467))
-* **deps:** bump @nextcloud/l10n from 3.2.0 to ^3.3.0 ([f7bb5a0](https://github.com/nextcloud/calendar/commit/f7bb5a036c6e27c28b4f90e9430a70cb814a8acd))
-* **deps:** bump @nextcloud/l10n from 3.4.0 to ^3.4.0 (main) ([#7163](https://github.com/nextcloud/calendar/issues/7163)) ([e3f77fe](https://github.com/nextcloud/calendar/commit/e3f77fe871d93f970207697d46ac89f87e744c3f))
-* **deps:** bump @nextcloud/moment from 1.3.2 to ^1.3.4 (main) ([#6962](https://github.com/nextcloud/calendar/issues/6962)) ([ac544e8](https://github.com/nextcloud/calendar/commit/ac544e8d5dc6d67ef0ce70eb0bdd1e3a1fb94e88))
-* **deps:** bump @nextcloud/moment from 1.3.4 to ^1.3.5 ([1294b48](https://github.com/nextcloud/calendar/commit/1294b485793aa530590a1849faba812f6cf61451))
-* **deps:** bump @nextcloud/timezones from ^1.0.0 and @nextcloud/calendar-js to ^8.1.6 ([17299c4](https://github.com/nextcloud/calendar/commit/17299c4af37e6804ae67559aa9e6e70f2ab38008))
-* **deps:** bump @nextcloud/timezones from 1.0.0 to ^1.0.2 (main) ([#7547](https://github.com/nextcloud/calendar/issues/7547)) ([27156e6](https://github.com/nextcloud/calendar/commit/27156e68c311911fed78ee66d5e0e9e9d2302fa7))
-* **deps:** bump @nextcloud/vue from 8.22.0 to ^8.23.1 ([c7e91ab](https://github.com/nextcloud/calendar/commit/c7e91ab1ef08323f158fa151988e24c6631b0d9c))
-* **deps:** bump @nextcloud/vue from 8.23.1 to ^8.24.0 ([ef0cbf6](https://github.com/nextcloud/calendar/commit/ef0cbf6f02902d68091cc9a10ece39f39656e162))
-* **deps:** bump @nextcloud/vue from 8.24.0 to ^8.26.0 ([36d7ec4](https://github.com/nextcloud/calendar/commit/36d7ec4f3afc529d390601b319f0e1abf23d6c0e))
-* **deps:** bump @nextcloud/vue from 8.26.1 to ^8.27.0 ([878110e](https://github.com/nextcloud/calendar/commit/878110e57dad3db1976f2f3f288f961488cdb7ac))
-* **deps:** bump @nextcloud/vue from 8.28.0 to ^8.28.0 ([9bed855](https://github.com/nextcloud/calendar/commit/9bed855be1452a35893e95ac8f77e7666721b1ef))
-* **deps:** bump @nextcloud/vue from 8.28.0 to ^8.29.1 ([327e772](https://github.com/nextcloud/calendar/commit/327e772557d514f8835b9a4ec16e526945dc6c51))
-* **deps:** bump @nextcloud/vue from 8.29.2 to ^8.30.0 ([2247659](https://github.com/nextcloud/calendar/commit/2247659fb78fcaf5a55b67b1a5f5a4ebdeaf6222))
-* **deps:** bump @nextcloud/vue from 8.30.0 to ^8.31.0 ([9a00c87](https://github.com/nextcloud/calendar/commit/9a00c87bb139df894866d2cd322311170ac44777))
-* **deps:** bump @nextcloud/vue from 8.31.0 to ^8.32.0 ([05b0408](https://github.com/nextcloud/calendar/commit/05b04085c7ecf26468a2474fc31ac7aee3fa50f9))
-* **deps:** bump @simolation/vue-hotkey from 2.1.0 to ^2.1.2 (main) ([#7233](https://github.com/nextcloud/calendar/issues/7233)) ([1a86482](https://github.com/nextcloud/calendar/commit/1a86482ed370f8a071aea6778b7d1210051b5671))
-* **deps:** bump color-convert from 2.0.1 to v3 ([dde4ba5](https://github.com/nextcloud/calendar/commit/dde4ba59c31da3a093c5dca0b1a788960db82e84))
-* **deps:** bump color-convert from 3.0.1 to ^3.1.0 (main) ([#7002](https://github.com/nextcloud/calendar/issues/7002)) ([fb56378](https://github.com/nextcloud/calendar/commit/fb56378d0ba87eb4fc61679c38303e20ef2c5478))
-* **deps:** bump color-convert from 3.1.0 to ^3.1.2 (main) ([#7438](https://github.com/nextcloud/calendar/issues/7438)) ([4659107](https://github.com/nextcloud/calendar/commit/4659107fbb040d3b2b44fac2e47bb4fca9d3fe4c))
-* **deps:** bump color-string from 1.9.1 to v2 ([a08c9ee](https://github.com/nextcloud/calendar/commit/a08c9eead5a76af3d6e82a04420f294748145d08))
-* **deps:** bump color-string from 2.0.1 to ^2.1.0 (main) ([#7333](https://github.com/nextcloud/calendar/issues/7333)) ([3a98fc5](https://github.com/nextcloud/calendar/commit/3a98fc5fc020606554305aa80c0c7b8e4f373fd9))
-* **deps:** bump color-string from 2.1.0 to ^2.1.2 (main) ([#7481](https://github.com/nextcloud/calendar/issues/7481)) ([d84e7b7](https://github.com/nextcloud/calendar/commit/d84e7b79034312ac75b1adba7d5f5c59007c254e))
-* **deps:** bump core-js from 3.40.0 to ^3.41.0 (main) ([#6784](https://github.com/nextcloud/calendar/issues/6784)) ([a8920a1](https://github.com/nextcloud/calendar/commit/a8920a1306186ad2463a362e1d83abb12d778169))
-* **deps:** bump core-js from 3.41.0 to ^3.42.0 (main) ([#6947](https://github.com/nextcloud/calendar/issues/6947)) ([71ffe32](https://github.com/nextcloud/calendar/commit/71ffe325696b157c09c88f891432d23e4d4b7d8f))
-* **deps:** bump core-js from 3.42.0 to ^3.43.0 ([2798772](https://github.com/nextcloud/calendar/commit/2798772a810debb85cf835746bb7451dd7d5cec1))
-* **deps:** bump core-js from 3.43.0 to ^3.44.0 (main) ([#7192](https://github.com/nextcloud/calendar/issues/7192)) ([d20f705](https://github.com/nextcloud/calendar/commit/d20f705a8412c87116942f8f5842a31b48102f1d))
-* **deps:** bump core-js from 3.44.0 to ^3.45.0 (main) ([#7201](https://github.com/nextcloud/calendar/issues/7201)) ([853bc2e](https://github.com/nextcloud/calendar/commit/853bc2ec79ee364bf67ea513c4af24e3457cad1a))
-* **deps:** bump core-js from 3.45.0 to ^3.45.1 (main) ([#7248](https://github.com/nextcloud/calendar/issues/7248)) ([f09e5c6](https://github.com/nextcloud/calendar/commit/f09e5c60ccc1b719de9736b410781423f14e6304))
-* **deps:** bump core-js from 3.45.1 to ^3.46.0 (main) ([#7571](https://github.com/nextcloud/calendar/issues/7571)) ([cb2d9f2](https://github.com/nextcloud/calendar/commit/cb2d9f223c22e8c6789dac2edea204228cd46728))
-* **deps:** bump fullcalendar family from 6.1.15 to v6.1.17 ([e617d74](https://github.com/nextcloud/calendar/commit/e617d74fa2d6f8a0bcbbe1394e7aaa05a8b5dcb4))
-* **deps:** bump fullcalendar family from 6.1.17 to v6.1.18 ([d771cc9](https://github.com/nextcloud/calendar/commit/d771cc960fdb6a46831334b625cbdedefc7ec5b4))
-* **deps:** bump fullcalendar family from 6.1.18 to v6.1.19 ([856fce7](https://github.com/nextcloud/calendar/commit/856fce7b1559a3555c0fe6fbbaaea89d4da32ae5))
-* **deps:** bump linkifyjs from 4.2.0 to ^4.3.1 ([0e59ccd](https://github.com/nextcloud/calendar/commit/0e59ccd5a86c1b1c8f2b99241fe3eb5a25474e30))
-* **deps:** bump p-limit from 6.2.0 to v7 ([5827603](https://github.com/nextcloud/calendar/commit/5827603d5706442bdb5b6712972456de1e5e2cad))
-* **deps:** bump p-limit from 7.1.0 to ^7.1.1 (main) ([#7331](https://github.com/nextcloud/calendar/issues/7331)) ([117e258](https://github.com/nextcloud/calendar/commit/117e258f5bd138a69354daedbb228bcea066fbb4))
-* **deps:** bump pinia from 2.3.0 to ^2.3.1 (main) ([#6645](https://github.com/nextcloud/calendar/issues/6645)) ([097f964](https://github.com/nextcloud/calendar/commit/097f9642bef7c7d37c6ea141a722702b5a595095))
-* **deps:** bump webdav from 5.7.1 to ^5.8.0 (main) ([#6769](https://github.com/nextcloud/calendar/issues/6769)) ([e1b1db5](https://github.com/nextcloud/calendar/commit/e1b1db53235626318f803ff62450a38b58d73de1))
-* **deps:** Fix npm audit ([ab77e45](https://github.com/nextcloud/calendar/commit/ab77e457152343b807b9ed1c5507f49b0df4d1ba))
-* **deps:** Fix npm audit ([9e26460](https://github.com/nextcloud/calendar/commit/9e264600b7f4621568227c5122e6200e34441b18))
-* **deps:** Fix npm audit ([0d68254](https://github.com/nextcloud/calendar/commit/0d68254db773924c027077f7d32cecde6733a36e))
-* **deps:** Fix npm audit ([e7d760d](https://github.com/nextcloud/calendar/commit/e7d760d1ef1da2dfecf99713e401c059df923bed))
-* **deps:** Fix npm audit ([6e49ac5](https://github.com/nextcloud/calendar/commit/6e49ac5c1c537fbb865323c4adca7f6d1ef97606))
-* **deps:** Fix npm audit ([538dc6c](https://github.com/nextcloud/calendar/commit/538dc6c9161e1339c4106f092d672dc0c5e33748))
-* **deps:** Fix npm audit ([65f5f7c](https://github.com/nextcloud/calendar/commit/65f5f7c73ef9d0297920bff05164125241899695))
-* **deps:** Fix npm audit ([96b7263](https://github.com/nextcloud/calendar/commit/96b72635e9f1a9b44a2a86b92052635edbf3173f))
-* **deps:** Fix npm audit ([cc225a8](https://github.com/nextcloud/calendar/commit/cc225a85615d5ce4220e5578ea62076d9fdb4128))
-* **deps:** Fix npm audit ([0a82119](https://github.com/nextcloud/calendar/commit/0a8211901778d42bfeb70ce8fa8cc21d4816b92d))
-* **deps:** Fix npm audit ([dc77c02](https://github.com/nextcloud/calendar/commit/dc77c02e4897e9fda4f0918d61b8852506d1356b))
-* **deps:** Fix npm audit ([050f25d](https://github.com/nextcloud/calendar/commit/050f25d3381a8075eb317319dc4e3d50f3f86bac))
-* **deps:** Fix npm audit ([3fa3f18](https://github.com/nextcloud/calendar/commit/3fa3f1831156fffdead028b45b73fccafb886009))
-* **deps:** update dependency @nextcloud/dialogs to ^6.4.1 (main) ([#7625](https://github.com/nextcloud/calendar/issues/7625)) ([254b36b](https://github.com/nextcloud/calendar/commit/254b36b449a38f6e08bd051ba01853d1acb8e8ac))
-* **deps:** update dependency @nextcloud/dialogs to v7 ([402eb04](https://github.com/nextcloud/calendar/commit/402eb04d83f2eda9f2ac601f520716d23416ea46))
-* **deps:** update dependency @nextcloud/event-bus to ^3.3.3 (main) ([#7692](https://github.com/nextcloud/calendar/issues/7692)) ([aad1b9f](https://github.com/nextcloud/calendar/commit/aad1b9f444d8d66ac2e7f776a03a8d1a6d6c335e))
-* **deps:** update dependency @nextcloud/l10n to ^3.4.1 (main) ([#7693](https://github.com/nextcloud/calendar/issues/7693)) ([24dd6fa](https://github.com/nextcloud/calendar/commit/24dd6fa7264e47120da551fbec74bb1e1228c96b))
-* **deps:** update dependency @nextcloud/logger to ^3.0.3 (main) ([#7781](https://github.com/nextcloud/calendar/issues/7781)) ([57c79b9](https://github.com/nextcloud/calendar/commit/57c79b9cffe7f6e6fb72213bb09b8b594e5b8ace))
-* **deps:** update dependency @nextcloud/notify_push to ^1.3.1 (main) ([#7638](https://github.com/nextcloud/calendar/issues/7638)) ([e2de79f](https://github.com/nextcloud/calendar/commit/e2de79fd76de9847ac000e2a1180de7842476df3))
-* **deps:** update dependency @nextcloud/router to ^3.1.0 (main) ([#7723](https://github.com/nextcloud/calendar/issues/7723)) ([40508d5](https://github.com/nextcloud/calendar/commit/40508d58660e699989fa3f072400c86360119422))
-* **deps:** update dependency @nextcloud/vue to ^8.33.0 ([de34426](https://github.com/nextcloud/calendar/commit/de344265eb63d973da44aad754addb4263551aed))
-* **deps:** update dependency @nextcloud/vue to ^8.35.0 ([85d13bd](https://github.com/nextcloud/calendar/commit/85d13bd01ee55b67241e963730f5f9cb00974fd2))
-* **deps:** update dependency @nextcloud/vue to ^8.35.2 ([02168e1](https://github.com/nextcloud/calendar/commit/02168e183a3eadf8dad9a64874de50e1d7f5969e))
-* **deps:** update dependency @nextcloud/vue to ^8.35.3 ([1949948](https://github.com/nextcloud/calendar/commit/194994807a41a2592171df6d7004993687af5534))
-* **deps:** update dependency bamarni/composer-bin-plugin to ^1.8.3 (main) ([#7722](https://github.com/nextcloud/calendar/issues/7722)) ([777ff12](https://github.com/nextcloud/calendar/commit/777ff122e3e3222d50d4da501b4a1e1854afe1cd))
-* **deps:** update dependency color-convert to ^3.1.3 (main) ([#7707](https://github.com/nextcloud/calendar/issues/7707)) ([c02e7b4](https://github.com/nextcloud/calendar/commit/c02e7b4f5ec50f878bc2460ed9868f0492451594))
-* **deps:** update dependency color-string to ^2.1.4 (main) ([#7708](https://github.com/nextcloud/calendar/issues/7708)) ([aeb6383](https://github.com/nextcloud/calendar/commit/aeb6383c975721a8bb3b7af875331780f6c4b4cc))
-* **deps:** update dependency core-js to ^3.47.0 (main) ([#7758](https://github.com/nextcloud/calendar/issues/7758)) ([8fc6b62](https://github.com/nextcloud/calendar/commit/8fc6b62b988cb3c2a31d7c1061847892b0c51444))
-* **deps:** update dependency debounce to v3 (main) ([#7668](https://github.com/nextcloud/calendar/issues/7668)) ([0890e44](https://github.com/nextcloud/calendar/commit/0890e447ee441c61c17386e50e8122facdb17d98))
-* **deps:** update dependency p-limit to ^7.2.0 (main) ([#7611](https://github.com/nextcloud/calendar/issues/7611)) ([8cd9a3e](https://github.com/nextcloud/calendar/commit/8cd9a3e44efef74016cffbe11abde676dba3fe9f))
-* **deps:** update fullcalendar family to v6.1.20 ([01fd499](https://github.com/nextcloud/calendar/commit/01fd499a9bd0d82087a885035ec6c780d2006190))
-* description text wrapping ([4f87afa](https://github.com/nextcloud/calendar/commit/4f87afa351fea42b2db52940bf22cc27e9a8a624))
-* disable federated calendar shares if disabled by admins ([15bdaa2](https://github.com/nextcloud/calendar/commit/15bdaa2efef69fb0ea3940366cfe19389494f2d3))
-* do not show attendee actions in viewing mode ([adcac42](https://github.com/nextcloud/calendar/commit/adcac426f9ec2d0967c96f5d338a46a54995aaba))
-* do not show attendee list when there are no attendees in viewing mode ([0fb2f7a](https://github.com/nextcloud/calendar/commit/0fb2f7a2002bb2faf6a3d2e702a39ea3b5fd2c8e))
-* do not show hidden calendars ([82316d5](https://github.com/nextcloud/calendar/commit/82316d5302d9990d142d2dfbd46f6ff9f1c16409))
-* do not show items from deleted calendars in widget ([9d1d26f](https://github.com/nextcloud/calendar/commit/9d1d26f0dcdfdf39930e8b85808bd087304cb5e8))
-* **EditFull:** alignment ([#7879](https://github.com/nextcloud/calendar/issues/7879)) ([10ee80c](https://github.com/nextcloud/calendar/commit/10ee80c9910ccad3251962edd6fe73354e7cb31c))
-* **EditFull:** readonly event formatting ([e97031c](https://github.com/nextcloud/calendar/commit/e97031cb8c21af2f594903292394eaef0120ebbb))
-* editor cancel error/logic ([5bfc0e3](https://github.com/nextcloud/calendar/commit/5bfc0e359d5fcff6b3af2e5b89f5eff92d7c4c1c))
-* **editor:** Allow edits as attending organizer ([ba6dea5](https://github.com/nextcloud/calendar/commit/ba6dea5fd3906a098a12bf1bb88c15d2d104f54b))
-* **editor:** export button in full page editor not working ([e48479e](https://github.com/nextcloud/calendar/commit/e48479ed4ca126e3ce564d0b5d0c44059b81a2fc))
-* **editor:** full page editor not showing via direct route ([62aabf9](https://github.com/nextcloud/calendar/commit/62aabf9510261f7e39325e9e0d3bd53977d7ba77))
-* **EditorMixin:** add viewed by organizer if no attendees ([3a35fae](https://github.com/nextcloud/calendar/commit/3a35fae9deaa3efe001dcea649e7243868f859df))
-* **EditorMixin:** allow toggling all day when repeating if the event isn't yet saved on server ([c702f01](https://github.com/nextcloud/calendar/commit/c702f01eee8dd6cd6a669a5bb61f76f7f22e2aee))
-* **EditorMixin:** timepicker not adjusting end date ([ddf2d8d](https://github.com/nextcloud/calendar/commit/ddf2d8d0354b92552a81a387f802ab3e85ed6c72))
-* **editor:** Rephraze ambiguous "group" invites ([28745e4](https://github.com/nextcloud/calendar/commit/28745e4ab8032638b6d8e6c00f3273d38042d6a9))
-* **editor:** show add talk button if there are no attendees yet ([9bf6383](https://github.com/nextcloud/calendar/commit/9bf63836f99deaa45d8e26490499748d1d77f405))
-* **editor:** wrap date selects on small screens ([e6bc12b](https://github.com/nextcloud/calendar/commit/e6bc12b2f924bc0101067e4bf419d76f5ba59264))
-* EditSideBar bug ([ab102c7](https://github.com/nextcloud/calendar/commit/ab102c72f133641a0f71457b144b8af34d31ca8c))
-* **EditSidebar:** free busy not updating time ([cac80be](https://github.com/nextcloud/calendar/commit/cac80be0e2dc4d6c5047492d8d02295e74bae8ad))
-* **EditSimple:** a11y on small screens ([d5ebdcf](https://github.com/nextcloud/calendar/commit/d5ebdcf919148e6157f064cd04a7b13acb897627))
-* **EditSimple:** all day toggle ([758981c](https://github.com/nextcloud/calendar/commit/758981c3aade5e48889579f9433c1463d3056206))
-* **EditSimple:** cancel confirmation dialog ([32c5746](https://github.com/nextcloud/calendar/commit/32c574677f51ad7f7f1b755b36f7536d41ba1967))
-* **EditSimple:** resizing ([fcc2aca](https://github.com/nextcloud/calendar/commit/fcc2aca2f0a8289811aec14fd22b34b832972f35))
-* embedded calendar header not responsive ([c0e985b](https://github.com/nextcloud/calendar/commit/c0e985b7bd401a30108701d14da904f888307f20))
-* end time resetting when changing day ([9fe7ffb](https://github.com/nextcloud/calendar/commit/9fe7ffba442d5eca5b1190bc3a1c1a55b56f6695))
-* event color picker ([7a7d9f3](https://github.com/nextcloud/calendar/commit/7a7d9f3ca9198f311c91394cfa7ce7e388771175))
-* event modal overflow ([1e8d972](https://github.com/nextcloud/calendar/commit/1e8d972e9a5a0139ced4f94e2bec6c6960e070d7))
-* **eventDidMount:** make time text color be main text ([53ea163](https://github.com/nextcloud/calendar/commit/53ea1635e56ed440ed9f1a905f63a08c06601876))
-* **EventDidMount:** make transparent events be background color instead of transparent to prevent overlapping issues ([e12d996](https://github.com/nextcloud/calendar/commit/e12d9967ca4ff7037c71303ed7218d92289c8a91))
-* fix compiler SCSS warning ([95376b0](https://github.com/nextcloud/calendar/commit/95376b0839f6a49b5ebe8be4f74c50d3e720c833))
-* force height for descr and location ([832f86d](https://github.com/nextcloud/calendar/commit/832f86dfcc1a3c0d5a0f0ac69a66b5a08c41c21e))
-* free busy not updating date ([3b2d626](https://github.com/nextcloud/calendar/commit/3b2d6269c30d436ef0970807c27168fc33ada18c))
-* **free-busy-modal:** Pin all day events on scroll ([de9d97f](https://github.com/nextcloud/calendar/commit/de9d97fee7f9fa3ad839ae0af82f10d3e2bdb819))
-* **free-busy:** adjust event title color to nextcloud theme ([beae45f](https://github.com/nextcloud/calendar/commit/beae45f4734b85e5902709a1ad1dbf044f1ba20f))
-* **free-busy:** allow selection on top of busy blocks ([a4f8109](https://github.com/nextcloud/calendar/commit/a4f81093a5bb82b4e962e0baf5fbf694d7d25536))
-* **free-busy:** close modal when all attendees removed ([f17465a](https://github.com/nextcloud/calendar/commit/f17465ad6b7cdb01e77c513b36f43bcb18e229b2))
-* **free-busy:** make backgound solid for attendees' slots ([3287aae](https://github.com/nextcloud/calendar/commit/3287aae65b3bf8614a3efd4c0f9bc7606f2da453))
-* **free-busy:** use own calendar color for organiser busy blocks ([e30b875](https://github.com/nextcloud/calendar/commit/e30b87568d6fdf58996037f216372d654c200a64))
-* freebusy ui visual improvements ([2dec06e](https://github.com/nextcloud/calendar/commit/2dec06e2455abd4dbb6a844e3a5501f17cb667bf))
-* **freebusy:** disable set free slot while previous slot is being set ([d268e25](https://github.com/nextcloud/calendar/commit/d268e257ddb031dfa7a0e415b2ba5cb5575a75a7))
-* **freebusy:** free busy ignoring user's time zone ([b3fc6dc](https://github.com/nextcloud/calendar/commit/b3fc6dc0e62906f7db336ca46359578947b67974))
-* **freebusy:** slot header format not respecting user's locale ([8d73bd2](https://github.com/nextcloud/calendar/commit/8d73bd23b08d514ddeeeaef805ec3bda56611ceb))
-* from alignment ([0b8f6b4](https://github.com/nextcloud/calendar/commit/0b8f6b4a6eddd38990f83385a782c1cb11d349b3))
-* full calendar error logging ([#7685](https://github.com/nextcloud/calendar/issues/7685)) ([43e3300](https://github.com/nextcloud/calendar/commit/43e33004db8a7f692597224a030055aeb4a61611))
-* **fullcalendar css:** make event margin be in vw instead of percentage ([6eb2cbb](https://github.com/nextcloud/calendar/commit/6eb2cbb4724c0cfaef26f2ae827f540ffcbcfd98))
-* **fullcalendar.scss:** calendar grid headers overlapping ([#7609](https://github.com/nextcloud/calendar/issues/7609)) ([a9ff6cb](https://github.com/nextcloud/calendar/commit/a9ff6cb655218f676bb27d2c84256e14fc27633b))
-* **fullcalendar:** freezing year view ([bf5372e](https://github.com/nextcloud/calendar/commit/bf5372e2d9229b537e736ee74275842e8fe71f16))
-* get rid of console statement ([c4a559e](https://github.com/nextcloud/calendar/commit/c4a559ebe45dba837fee55543b1419fc9cd0a2ca))
-* **global.css:** z-index style leaking ([035243b](https://github.com/nextcloud/calendar/commit/035243b87841784a2ea08443c3cdfc050c543926))
-* handle missing organizer gracefully when fetching room suggestions ([7abb014](https://github.com/nextcloud/calendar/commit/7abb01472a6af30d7fa61fa1ac761bb025d8c3f8))
-* harden group attendee search ([1147058](https://github.com/nextcloud/calendar/commit/11470585ba39c41fa221373d3748590be9cb07ca))
-* hide resource booking if no backend available ([52e78a8](https://github.com/nextcloud/calendar/commit/52e78a8578da48e4f6fdde770877de56ad2f3ff9))
-* icon style ([3935df3](https://github.com/nextcloud/calendar/commit/3935df32af251aab22d354e369031f3751d30eea))
-* improve confidentiality wording when sharing calendars/events ([d334ffd](https://github.com/nextcloud/calendar/commit/d334ffd747dfbf7b8314399b8b08cf6f470f0980))
-* improve simple editor positioning logic ([cef8970](https://github.com/nextcloud/calendar/commit/cef8970e7886f2c5ea5b8299ee13538f53617ef1))
-* improve title and description word wrapping ([d657275](https://github.com/nextcloud/calendar/commit/d65727591d2b2a95f1da368849a8261e5f289d4b))
-* improve translations ([97587b3](https://github.com/nextcloud/calendar/commit/97587b362f1a740fda6b088244caa64dbd5717a1))
-* **InviteesList:** change attendee summary logic ([#7610](https://github.com/nextcloud/calendar/issues/7610)) ([3e85755](https://github.com/nextcloud/calendar/commit/3e857555e2b507c768be6f3a1683ea7eac7f6681))
-* keyboard shortcut modal not being responsive ([1ecf27b](https://github.com/nextcloud/calendar/commit/1ecf27b67c23c99bd16ecb4e3630743971e660ae))
-* **l10n:** add context for translators (second vs. seconds) ([9d76c8c](https://github.com/nextcloud/calendar/commit/9d76c8c5a3487c58732fe193155a59d59c1a5861))
-* **l10n:** fix typo in server administrator ([1f8f579](https://github.com/nextcloud/calendar/commit/1f8f5799c83b5c077b9bc1aa52f04a5dc0a02a6c))
-* **l10n:** Update translations from Transifex ([fba6cf5](https://github.com/nextcloud/calendar/commit/fba6cf5216e980128d7c4b81786e2ef56fa0ef27))
-* **l10n:** Update translations from Transifex ([7e73f6a](https://github.com/nextcloud/calendar/commit/7e73f6a78b61ab8584285edc5b87c2b40b4b8bd2))
-* **l10n:** Update translations from Transifex ([a28b28d](https://github.com/nextcloud/calendar/commit/a28b28d048a79b8ad1d8c6c94a7f3723203ab383))
-* **l10n:** Update translations from Transifex ([38d68a8](https://github.com/nextcloud/calendar/commit/38d68a8e193bae11914da7a1daf1d4cac312ed40))
-* **l10n:** Update translations from Transifex ([26fa154](https://github.com/nextcloud/calendar/commit/26fa154eb596a5f4f08f98786f739f0346611cf9))
-* **l10n:** Update translations from Transifex ([b127aff](https://github.com/nextcloud/calendar/commit/b127aff6080417836a958ce47cc309773e328ae1))
-* **l10n:** Update translations from Transifex ([6524e20](https://github.com/nextcloud/calendar/commit/6524e20dbb847ac7273435b3e8936b17f704c140))
-* **l10n:** Update translations from Transifex ([da37827](https://github.com/nextcloud/calendar/commit/da37827e35ce3c3b13980de1275625becdd3269f))
-* **l10n:** Update translations from Transifex ([137489e](https://github.com/nextcloud/calendar/commit/137489e59e87258dc518b1b6683f6ea924ee5233))
-* **l10n:** Update translations from Transifex ([3da47a6](https://github.com/nextcloud/calendar/commit/3da47a6046a5b5129cb80d53b56033c52569d484))
-* **l10n:** Update translations from Transifex ([0597cde](https://github.com/nextcloud/calendar/commit/0597cde615ce7d96ab79494633f7f56d4ef7ec73))
-* **l10n:** Update translations from Transifex ([28a01c4](https://github.com/nextcloud/calendar/commit/28a01c4846dba527bbb3a5ab39a360aee5ec0c7d))
-* **l10n:** Update translations from Transifex ([ddf7956](https://github.com/nextcloud/calendar/commit/ddf7956721aff1941376a74f04d65d02659747b5))
-* **l10n:** Update translations from Transifex ([f9188fb](https://github.com/nextcloud/calendar/commit/f9188fbb19dbb26beb126827ce728afa86e2c4e9))
-* **l10n:** Update translations from Transifex ([2992d90](https://github.com/nextcloud/calendar/commit/2992d90b6cc6dd6f9d08d44251f7c7f780dc415e))
-* **l10n:** Update translations from Transifex ([b03e0df](https://github.com/nextcloud/calendar/commit/b03e0dfc48caed4aeb9281434faa36a202b5f214))
-* **l10n:** Update translations from Transifex ([4b6e8aa](https://github.com/nextcloud/calendar/commit/4b6e8aa434ddc19af45ef0892f6761387df61e2a))
-* **l10n:** Update translations from Transifex ([b7696fe](https://github.com/nextcloud/calendar/commit/b7696fe7d86b30452659a2bc8611ddc1707577ac))
-* **l10n:** Update translations from Transifex ([8f1f51f](https://github.com/nextcloud/calendar/commit/8f1f51f5718dc73048f9edeed961ed9111ff21ab))
-* **l10n:** Update translations from Transifex ([e071718](https://github.com/nextcloud/calendar/commit/e0717182e9923e1a77133af2f002ce0086ef8020))
-* **l10n:** Update translations from Transifex ([dc9235e](https://github.com/nextcloud/calendar/commit/dc9235e1c0e7b45b86492d46d47f38f3ddec7b6e))
-* **l10n:** Update translations from Transifex ([bcecf83](https://github.com/nextcloud/calendar/commit/bcecf8311f53c4b424132b4766fb16ab4a401f50))
-* **l10n:** Update translations from Transifex ([a8f7a61](https://github.com/nextcloud/calendar/commit/a8f7a61c6d164b2daa324acc563ed5adb96a2951))
-* **l10n:** Update translations from Transifex ([fd76c85](https://github.com/nextcloud/calendar/commit/fd76c85420f0ac63c9925edcebfd222d683c7006))
-* **l10n:** Update translations from Transifex ([13873b5](https://github.com/nextcloud/calendar/commit/13873b5309700866ca89572f7e44cd9a200a0c40))
-* **l10n:** Update translations from Transifex ([c65646f](https://github.com/nextcloud/calendar/commit/c65646fad2c75b15feb8c3c00b1a1d9e82e445f0))
-* **l10n:** Update translations from Transifex ([d52456e](https://github.com/nextcloud/calendar/commit/d52456ed8db71eabfc5e726a351fa976bdf73875))
-* **l10n:** Update translations from Transifex ([2fe1f26](https://github.com/nextcloud/calendar/commit/2fe1f26fa9e76176b7f583dc0853a8e7b0294113))
-* **l10n:** Update translations from Transifex ([bbe8a1f](https://github.com/nextcloud/calendar/commit/bbe8a1ffd1451c6e905fec7eb6f84465e8efafc2))
-* **l10n:** Update translations from Transifex ([e08c606](https://github.com/nextcloud/calendar/commit/e08c6067ec70833f5036a35c9a4a92906af3d5c5))
-* **l10n:** Update translations from Transifex ([ce2e769](https://github.com/nextcloud/calendar/commit/ce2e769720fbc60ff6906e347284b4f9e820eda8))
-* **l10n:** Update translations from Transifex ([7e888ea](https://github.com/nextcloud/calendar/commit/7e888ea116a77be7a0de9e672cd139fcd1c7bc7a))
-* **l10n:** Update translations from Transifex ([dd9240d](https://github.com/nextcloud/calendar/commit/dd9240d8417da1d1763e37ce092e77ad8444b7f5))
-* **l10n:** Update translations from Transifex ([bf95ff9](https://github.com/nextcloud/calendar/commit/bf95ff91f6885058bd26095ae140afcb6b6666cd))
-* **l10n:** Update translations from Transifex ([038d289](https://github.com/nextcloud/calendar/commit/038d289432da61c0455f589928702bb0a4b3cb68))
-* **l10n:** Update translations from Transifex ([6c60fc2](https://github.com/nextcloud/calendar/commit/6c60fc25c03188cc71e9f216e1f8866af90d2265))
-* **l10n:** Update translations from Transifex ([21ab013](https://github.com/nextcloud/calendar/commit/21ab013839ab0e8fb32e3cf46cbe0b36628a70cc))
-* **l10n:** Update translations from Transifex ([8b61a90](https://github.com/nextcloud/calendar/commit/8b61a9019f37d18c68c345732fec9b3ef766c41f))
-* **l10n:** Update translations from Transifex ([5131824](https://github.com/nextcloud/calendar/commit/51318241487dd998d8bebab0758fb2f1f115e814))
-* **l10n:** Update translations from Transifex ([cdf69eb](https://github.com/nextcloud/calendar/commit/cdf69ebfbdc0dd460126765e62eb590b6039ba6d))
-* **l10n:** Update translations from Transifex ([68f22d6](https://github.com/nextcloud/calendar/commit/68f22d6e99306ea36a5dd0c79c506cc5ae405b39))
-* **l10n:** Update translations from Transifex ([e748d68](https://github.com/nextcloud/calendar/commit/e748d6871dc342a9e412efda14cb048c0bb61e80))
-* **l10n:** Update translations from Transifex ([0017990](https://github.com/nextcloud/calendar/commit/001799065c0a61e0314909d6892869c94edff89d))
-* **l10n:** Update translations from Transifex ([7221998](https://github.com/nextcloud/calendar/commit/7221998ed602e87a5f569717d0c5210cb98fd104))
-* **l10n:** Update translations from Transifex ([adf8b3d](https://github.com/nextcloud/calendar/commit/adf8b3d37321380df92d7e882cc63a246216a0af))
-* **l10n:** Update translations from Transifex ([7ceaf02](https://github.com/nextcloud/calendar/commit/7ceaf02a84f47ad677f1e2dfd742a43c6cfb0a86))
-* **l10n:** Update translations from Transifex ([118a533](https://github.com/nextcloud/calendar/commit/118a53334a571f1d207d2afc2b711013eda9b8ac))
-* **l10n:** Update translations from Transifex ([6deba90](https://github.com/nextcloud/calendar/commit/6deba90adb69830708fb0b7da88e2791c24677fc))
-* **l10n:** Update translations from Transifex ([390732b](https://github.com/nextcloud/calendar/commit/390732ba2c4953c4641d894485457afa42bd6285))
-* **l10n:** Update translations from Transifex ([dd25144](https://github.com/nextcloud/calendar/commit/dd2514405751839fa15fe27867147d8f06d02aa6))
-* **l10n:** Update translations from Transifex ([d8cdb67](https://github.com/nextcloud/calendar/commit/d8cdb6720c45825fc3f8746e54afdc5ebb1cb9be))
-* **l10n:** Update translations from Transifex ([246da20](https://github.com/nextcloud/calendar/commit/246da209af023553b10038f38a263d706e439fe7))
-* **l10n:** Update translations from Transifex ([cb3f98a](https://github.com/nextcloud/calendar/commit/cb3f98a63eca5c296e73182b72a909e514d3fa4c))
-* **l10n:** Update translations from Transifex ([c7094f4](https://github.com/nextcloud/calendar/commit/c7094f4fb1ac00c62ae2cf19c76482a1d0c1260b))
-* **l10n:** Update translations from Transifex ([ec156ac](https://github.com/nextcloud/calendar/commit/ec156acd33b7005c32d801360f4d766d61a24634))
-* **l10n:** Update translations from Transifex ([05a95bf](https://github.com/nextcloud/calendar/commit/05a95bf6f38980f7ecccc1669a21447c057cce99))
-* **l10n:** Update translations from Transifex ([9aa090e](https://github.com/nextcloud/calendar/commit/9aa090ec8a8f2df2bebd1c02471ca33870827bae))
-* **l10n:** Update translations from Transifex ([a609e11](https://github.com/nextcloud/calendar/commit/a609e11654d44ad086e49ea633b3341e0784b6d7))
-* **l10n:** Update translations from Transifex ([32f5939](https://github.com/nextcloud/calendar/commit/32f59391a58d212c53a0f7c863f58fe1a2c7953c))
-* **l10n:** Update translations from Transifex ([b96c624](https://github.com/nextcloud/calendar/commit/b96c62470a31041ce3c44547fc85ec7552925150))
-* **l10n:** Update translations from Transifex ([4560fed](https://github.com/nextcloud/calendar/commit/4560fed0d9b6a782697e33e6595a6100043bd895))
-* **l10n:** Update translations from Transifex ([4c9da70](https://github.com/nextcloud/calendar/commit/4c9da7005c4b1b42e328ac8253a1640bcc0475a9))
-* **l10n:** Update translations from Transifex ([5838623](https://github.com/nextcloud/calendar/commit/5838623e84f1aceb0d2e23c812de05f0992b1deb))
-* **l10n:** Update translations from Transifex ([27a64ff](https://github.com/nextcloud/calendar/commit/27a64ffeb63c9d27d36fec63dacf54f3f2d155a6))
-* **l10n:** Update translations from Transifex ([9d479ee](https://github.com/nextcloud/calendar/commit/9d479ee695a0d54b973b027f2000a1bb8c43872d))
-* **l10n:** Update translations from Transifex ([9eaefa4](https://github.com/nextcloud/calendar/commit/9eaefa48cfce0ef35414e6993c936c690e2a9a0f))
-* **l10n:** Update translations from Transifex ([7f5c626](https://github.com/nextcloud/calendar/commit/7f5c626f615e0e4eee5baf8d82b0e564bb3d4b72))
-* **l10n:** Update translations from Transifex ([501d3e7](https://github.com/nextcloud/calendar/commit/501d3e73c7d6065db3687ffe3f9b2bdf13025440))
-* **l10n:** Update translations from Transifex ([937a88f](https://github.com/nextcloud/calendar/commit/937a88f58183b67e235bd3bc24fa3b51c384074a))
-* **l10n:** Update translations from Transifex ([7e0c599](https://github.com/nextcloud/calendar/commit/7e0c599ff51142a96f9cc5b57e638c3025c813cc))
-* **l10n:** Update translations from Transifex ([bb5ebb2](https://github.com/nextcloud/calendar/commit/bb5ebb220b2ac0c5d90a8b6dd2d524bb159cc181))
-* **l10n:** Update translations from Transifex ([e492429](https://github.com/nextcloud/calendar/commit/e492429c231f84b781e28bc235068d0e066f3068))
-* **l10n:** Update translations from Transifex ([51c2440](https://github.com/nextcloud/calendar/commit/51c24407aeb40315db65b83844ec421baa2f2886))
-* **l10n:** Update translations from Transifex ([3c2de9f](https://github.com/nextcloud/calendar/commit/3c2de9f26604dbd25e8ced3974b201cda87a1ac3))
-* **l10n:** Update translations from Transifex ([7f50efa](https://github.com/nextcloud/calendar/commit/7f50efa15fda91d0dea4b92227ec6507da2ba20c))
-* **l10n:** Update translations from Transifex ([d94a68c](https://github.com/nextcloud/calendar/commit/d94a68c561bba7136dcf3075e5cb1f51b11c8aaf))
-* **l10n:** Update translations from Transifex ([f28ff29](https://github.com/nextcloud/calendar/commit/f28ff29ade8b034d0685aa8f2b4ff11b9dd4b4eb))
-* **l10n:** Update translations from Transifex ([466d3a1](https://github.com/nextcloud/calendar/commit/466d3a1ef7d5078796662abc1adb326d5e7cd248))
-* **l10n:** Update translations from Transifex ([52da6f5](https://github.com/nextcloud/calendar/commit/52da6f54ed7f9c5948596b3d4c7ad7c4744de9eb))
-* **l10n:** Update translations from Transifex ([0e1148a](https://github.com/nextcloud/calendar/commit/0e1148a6f849c0a89d20e7a1d04c5e9b11d915bf))
-* **l10n:** Update translations from Transifex ([b3f7447](https://github.com/nextcloud/calendar/commit/b3f74476d3db842750a3b2afdaa5ba76860cc34f))
-* **l10n:** Update translations from Transifex ([228af4f](https://github.com/nextcloud/calendar/commit/228af4f0b5039da3c807bf38f26e25cef40cda77))
-* **l10n:** Update translations from Transifex ([5d94370](https://github.com/nextcloud/calendar/commit/5d9437005f6cfc9edf25c0f3ff8f4d862117e61a))
-* **l10n:** Update translations from Transifex ([4f5436a](https://github.com/nextcloud/calendar/commit/4f5436ad28a200a624f5f39d7cd24e94ffc5fdf1))
-* **l10n:** Update translations from Transifex ([8454dd9](https://github.com/nextcloud/calendar/commit/8454dd9a324380d5a679420f5e42e3b77e025c1d))
-* **l10n:** Update translations from Transifex ([2fdb835](https://github.com/nextcloud/calendar/commit/2fdb83525fc02989c9191ec677ca9a80a5543c9c))
-* **l10n:** Update translations from Transifex ([f9ca705](https://github.com/nextcloud/calendar/commit/f9ca705c85b0c11fc7be2588b803e70dccf55882))
-* **l10n:** Update translations from Transifex ([41d1c78](https://github.com/nextcloud/calendar/commit/41d1c78f7a56542a32702904280fe4980291c7e8))
-* **l10n:** Update translations from Transifex ([912e894](https://github.com/nextcloud/calendar/commit/912e894a1e463f419ada3a98205b4104b612f13f))
-* **l10n:** Update translations from Transifex ([3ebadef](https://github.com/nextcloud/calendar/commit/3ebadef7f9dcabaf6b22465236f1614a96d010b3))
-* **l10n:** Update translations from Transifex ([e687aeb](https://github.com/nextcloud/calendar/commit/e687aebfacfda525cbbbd57b37af77a5d1e78f9f))
-* **l10n:** Update translations from Transifex ([7edf4e9](https://github.com/nextcloud/calendar/commit/7edf4e9304d665120f4059a2dc4b637cb5d4c965))
-* **l10n:** Update translations from Transifex ([ee6160a](https://github.com/nextcloud/calendar/commit/ee6160a0832136ea55bc3049f43ab24cad6e6415))
-* **l10n:** Update translations from Transifex ([b177bcb](https://github.com/nextcloud/calendar/commit/b177bcb5244bd1f7ac36fa78b289070fa1564874))
-* **l10n:** Update translations from Transifex ([48eab5d](https://github.com/nextcloud/calendar/commit/48eab5d3bdafde5080eb936f93762385b600b84d))
-* **l10n:** Update translations from Transifex ([e6bf463](https://github.com/nextcloud/calendar/commit/e6bf463daa8aacdfa6a9d14f438e82d035e89fd4))
-* **l10n:** Update translations from Transifex ([62a6f8c](https://github.com/nextcloud/calendar/commit/62a6f8c8a3ad9b8253b188de6600f36a75090d70))
-* **l10n:** Update translations from Transifex ([bf224ab](https://github.com/nextcloud/calendar/commit/bf224ab2a621c05297b28c188f6b5477721b0329))
-* **l10n:** Update translations from Transifex ([64b3727](https://github.com/nextcloud/calendar/commit/64b3727fc1aa0d8710e19b246d6736b9f5a738fb))
-* **l10n:** Update translations from Transifex ([7bfccbf](https://github.com/nextcloud/calendar/commit/7bfccbf6a91966dc746d0ab29b2d550205897192))
-* **l10n:** Update translations from Transifex ([9eae23c](https://github.com/nextcloud/calendar/commit/9eae23ce4243b7038646bbcfecf343e918131ee9))
-* **l10n:** Update translations from Transifex ([0a5d661](https://github.com/nextcloud/calendar/commit/0a5d66166c47243df874e88982797e212f88f42d))
-* **l10n:** Update translations from Transifex ([d306098](https://github.com/nextcloud/calendar/commit/d306098089e3aaa356847e76c4f0ab99f271496f))
-* **l10n:** Update translations from Transifex ([029feb4](https://github.com/nextcloud/calendar/commit/029feb46479469eb23b6732e1bf7c71e6b668662))
-* **l10n:** Update translations from Transifex ([bae365b](https://github.com/nextcloud/calendar/commit/bae365b4c9e40458ea320cfab4f5946c8bf08dc7))
-* **l10n:** Update translations from Transifex ([b3342ae](https://github.com/nextcloud/calendar/commit/b3342ae74761908674cb0a1e0291cec12e5fce44))
-* **l10n:** Update translations from Transifex ([b3432bd](https://github.com/nextcloud/calendar/commit/b3432bdd8fcc350d2571da0305366cce33d19187))
-* **l10n:** Update translations from Transifex ([6d4db59](https://github.com/nextcloud/calendar/commit/6d4db59a1ef61e0f9d0099918755dfbe98d6cecb))
-* **l10n:** Update translations from Transifex ([f60838b](https://github.com/nextcloud/calendar/commit/f60838b62122b5da83d39668c052d3a65aa96ced))
-* **l10n:** Update translations from Transifex ([0cb5443](https://github.com/nextcloud/calendar/commit/0cb5443d559f8a559fa05233be6071bc9fb863f5))
-* **l10n:** Update translations from Transifex ([4c3dd76](https://github.com/nextcloud/calendar/commit/4c3dd765011ef8329610e6b2920bf9f46780000a))
-* **l10n:** Update translations from Transifex ([783cd7e](https://github.com/nextcloud/calendar/commit/783cd7e2b8b245e49c3d060f6ab564a3bd674dea))
-* **l10n:** Update translations from Transifex ([1680007](https://github.com/nextcloud/calendar/commit/168000772d7b68f36a4f178b64e2f17f3be184ec))
-* **l10n:** Update translations from Transifex ([70122f6](https://github.com/nextcloud/calendar/commit/70122f62727eb5fd419cdb37fb42bf51f43c7e51))
-* **l10n:** Update translations from Transifex ([9bae64b](https://github.com/nextcloud/calendar/commit/9bae64bfa71eb5c73ed4f0589d8f29797ebb3d62))
-* **l10n:** Update translations from Transifex ([b04984a](https://github.com/nextcloud/calendar/commit/b04984a5dc9c8268713a2b53e7f23f9937c13f55))
-* **l10n:** Update translations from Transifex ([eda1469](https://github.com/nextcloud/calendar/commit/eda1469c0902b48c707bae4773d1309bfe997112))
-* **l10n:** Update translations from Transifex ([3d0f2b1](https://github.com/nextcloud/calendar/commit/3d0f2b10dc05993b7a96fb13c8d8361c0143a8ac))
-* **l10n:** Update translations from Transifex ([d318abb](https://github.com/nextcloud/calendar/commit/d318abb59b8ff3c9a544d84dc94883b992f0d2f0))
-* **l10n:** Update translations from Transifex ([a1fd305](https://github.com/nextcloud/calendar/commit/a1fd305bf5d4740e07e6ab78858e36cb66cb4448))
-* **l10n:** Update translations from Transifex ([ae76972](https://github.com/nextcloud/calendar/commit/ae76972a021e4ee7b728c3b6fd3c00bb7d7ed5dd))
-* **l10n:** Update translations from Transifex ([a4ac133](https://github.com/nextcloud/calendar/commit/a4ac1334efb6ce74c81d13b2c4989d9d6391c5d9))
-* **l10n:** Update translations from Transifex ([5b1dd8c](https://github.com/nextcloud/calendar/commit/5b1dd8c457103d8535984b940edbd76fefef2302))
-* **l10n:** Update translations from Transifex ([bc84c34](https://github.com/nextcloud/calendar/commit/bc84c34492c90a08c63c55ecc25a19206e74a0e0))
-* **l10n:** Update translations from Transifex ([0c622ae](https://github.com/nextcloud/calendar/commit/0c622aea17209b04734313fca72309ab7c5d50c3))
-* **l10n:** Update translations from Transifex ([0147d5b](https://github.com/nextcloud/calendar/commit/0147d5b8305c5e8e100376fa3613d147b5a5b53c))
-* **l10n:** Update translations from Transifex ([58cdcf7](https://github.com/nextcloud/calendar/commit/58cdcf77b96c1fa53fab73e125ed310091e38194))
-* **l10n:** Update translations from Transifex ([c36b7ee](https://github.com/nextcloud/calendar/commit/c36b7eeae0a7179d04de43d89c4d7972c6be1cc5))
-* **l10n:** Update translations from Transifex ([28748f3](https://github.com/nextcloud/calendar/commit/28748f33a837f51200dc1eac406c947fb8492b84))
-* **l10n:** Update translations from Transifex ([799f89a](https://github.com/nextcloud/calendar/commit/799f89a9e09f9da5a9cfd69b7865e8ac90f0e52e))
-* **l10n:** Update translations from Transifex ([cfc6ad0](https://github.com/nextcloud/calendar/commit/cfc6ad0673b948f30e7d355c778194c17fb1c510))
-* **l10n:** Update translations from Transifex ([cc45463](https://github.com/nextcloud/calendar/commit/cc4546302b28a1c94e4998cf55db301087bdf463))
-* **l10n:** Update translations from Transifex ([5cbeda9](https://github.com/nextcloud/calendar/commit/5cbeda9562c79bc32184302f2d5f5393f66dc30e))
-* **l10n:** Update translations from Transifex ([2766e30](https://github.com/nextcloud/calendar/commit/2766e308f2a28d3f67eb59e70d4d8e8e80860e44))
-* **l10n:** Update translations from Transifex ([a3d60b6](https://github.com/nextcloud/calendar/commit/a3d60b65555cbb2e26265e22bbf394860f68bc3f))
-* **l10n:** Update translations from Transifex ([7f7f74e](https://github.com/nextcloud/calendar/commit/7f7f74e347445f5a7057d8c34e0cc9b5461cbfb0))
-* **l10n:** Update translations from Transifex ([12dfadb](https://github.com/nextcloud/calendar/commit/12dfadbc45484f12832b52842867dd7a93c22a97))
-* **l10n:** Update translations from Transifex ([fb94886](https://github.com/nextcloud/calendar/commit/fb948864aa30357ff8c66c3ed889bada41723103))
-* **l10n:** Update translations from Transifex ([ff56450](https://github.com/nextcloud/calendar/commit/ff564500d395cdb29e7e8721f495a12ee4138a0a))
-* **l10n:** Update translations from Transifex ([d45f208](https://github.com/nextcloud/calendar/commit/d45f208e62883192ae61a76037509ce3f157818b))
-* **l10n:** Update translations from Transifex ([7fd2075](https://github.com/nextcloud/calendar/commit/7fd2075e7466eec31f2be028968d4eab52e555b2))
-* **l10n:** Update translations from Transifex ([5050561](https://github.com/nextcloud/calendar/commit/505056158f4a616b27cbc338a5ec0784e7cc5c15))
-* **l10n:** Update translations from Transifex ([b9dcb41](https://github.com/nextcloud/calendar/commit/b9dcb41a05c1ea8919ba564a1ede53e486310419))
-* **l10n:** Update translations from Transifex ([4a4fba8](https://github.com/nextcloud/calendar/commit/4a4fba802017064f9570603643856be47886bab3))
-* **l10n:** Update translations from Transifex ([2891f2b](https://github.com/nextcloud/calendar/commit/2891f2bca5425fecb5f9f4de8625d8e508734a94))
-* **l10n:** Update translations from Transifex ([edeb60b](https://github.com/nextcloud/calendar/commit/edeb60b8fad0237e8f0940b7d3310e0fe2cac6cc))
-* **l10n:** Update translations from Transifex ([94ffb93](https://github.com/nextcloud/calendar/commit/94ffb935caa7bdc4f594604b06c89f28ba1ac01e))
-* **l10n:** Update translations from Transifex ([9d318dd](https://github.com/nextcloud/calendar/commit/9d318dd098285c23702e59fcf99b20fa48ae6c87))
-* **l10n:** Update translations from Transifex ([ffe24c3](https://github.com/nextcloud/calendar/commit/ffe24c33cc57b91d5cf17cee83535c1f4503b7a3))
-* **l10n:** Update translations from Transifex ([31ce986](https://github.com/nextcloud/calendar/commit/31ce9865e630bb5bec6dff81c540674acd9aa3c6))
-* **l10n:** Update translations from Transifex ([babb6fa](https://github.com/nextcloud/calendar/commit/babb6fa7b3703a01bf98f23eacc60151d1f5e7c7))
-* **l10n:** Update translations from Transifex ([4e13554](https://github.com/nextcloud/calendar/commit/4e13554342fbfde3201fc98408595cb3ed7bfe44))
-* **l10n:** Update translations from Transifex ([3c3b022](https://github.com/nextcloud/calendar/commit/3c3b022a163413c2a275bab1deea6cd7c0ac775c))
-* **l10n:** Update translations from Transifex ([ee39d94](https://github.com/nextcloud/calendar/commit/ee39d94082998abb6bb2a8a5d0d7e7da8670c44e))
-* **l10n:** Update translations from Transifex ([f952872](https://github.com/nextcloud/calendar/commit/f952872015fcd57f4d6a192b3609d5bc4904f6a1))
-* **l10n:** Update translations from Transifex ([f653814](https://github.com/nextcloud/calendar/commit/f653814ddb0fc5611a0e608aad08c2ca97b8b57c))
-* **l10n:** Update translations from Transifex ([6e33b26](https://github.com/nextcloud/calendar/commit/6e33b2646f20d2b47dfb27941c1de91448330658))
-* **l10n:** Update translations from Transifex ([e4a1d48](https://github.com/nextcloud/calendar/commit/e4a1d4842fb6a4f0e1070d7f34f0a0ba87cd5c33))
-* **l10n:** Update translations from Transifex ([0441999](https://github.com/nextcloud/calendar/commit/0441999f821c210189442e635f0ee592a716001b))
-* **l10n:** Update translations from Transifex ([cbc2a07](https://github.com/nextcloud/calendar/commit/cbc2a073ca2d4d41ce78c3a4ac4300815f7ada1d))
-* **l10n:** Update translations from Transifex ([9cd4b3d](https://github.com/nextcloud/calendar/commit/9cd4b3d41b6ae90291b7616ae554f660bba6e493))
-* **l10n:** Update translations from Transifex ([5f56c03](https://github.com/nextcloud/calendar/commit/5f56c031378a58da384d27c7351a950f6b53d9a1))
-* **l10n:** Update translations from Transifex ([1a18a06](https://github.com/nextcloud/calendar/commit/1a18a06db9c507c0d242c95a05d94476404f8e64))
-* **l10n:** Update translations from Transifex ([16bbc54](https://github.com/nextcloud/calendar/commit/16bbc5460ce7987911a3c27929770705530ffe77))
-* **l10n:** Update translations from Transifex ([0438b48](https://github.com/nextcloud/calendar/commit/0438b48565aa6119e5290f78cad85651f53776e1))
-* **l10n:** Update translations from Transifex ([64e478e](https://github.com/nextcloud/calendar/commit/64e478e145b827d8b4ee01628def8859677cb536))
-* **l10n:** Update translations from Transifex ([94157dc](https://github.com/nextcloud/calendar/commit/94157dc948071f6e8a052eb0b91c324abb51f2f6))
-* **l10n:** Update translations from Transifex ([3034699](https://github.com/nextcloud/calendar/commit/303469935faf1c3cd8ff15e5428791b59ec2152b))
-* **l10n:** Update translations from Transifex ([15c1542](https://github.com/nextcloud/calendar/commit/15c154208de1d83d7020a8526e90577a7f87bcac))
-* **l10n:** Update translations from Transifex ([a3494ac](https://github.com/nextcloud/calendar/commit/a3494ac69e25241872e5844fb996a7d25e4196fc))
-* **l10n:** Update translations from Transifex ([fb2db82](https://github.com/nextcloud/calendar/commit/fb2db8282549127c8fae202fcca3a6d1e659349d))
-* **l10n:** Update translations from Transifex ([833ed68](https://github.com/nextcloud/calendar/commit/833ed68680946d5481ec47184c6672a1490d29aa))
-* **l10n:** Update translations from Transifex ([f0bc20e](https://github.com/nextcloud/calendar/commit/f0bc20eb0bf361e21f2aa350da64637ec0705a4c))
-* **l10n:** Update translations from Transifex ([42fb748](https://github.com/nextcloud/calendar/commit/42fb7489653ddbb82f3a898f28e773fc35b992a6))
-* **l10n:** Update translations from Transifex ([ee5cbdd](https://github.com/nextcloud/calendar/commit/ee5cbddc547cb23d6be1c4409cf273e942f04965))
-* **l10n:** Update translations from Transifex ([728fb5e](https://github.com/nextcloud/calendar/commit/728fb5e2f907bdebf089c80859afdd7ae2128cb4))
-* **l10n:** Update translations from Transifex ([94f3a9a](https://github.com/nextcloud/calendar/commit/94f3a9afc26f57678b420ae083477b173b6cdb70))
-* **l10n:** Update translations from Transifex ([7a889c9](https://github.com/nextcloud/calendar/commit/7a889c948f3a83e84f25f5b6907ff019d054c6fc))
-* **l10n:** Update translations from Transifex ([6277baf](https://github.com/nextcloud/calendar/commit/6277baf13f06525376083b8a7c9becebab6ad012))
-* **l10n:** Update translations from Transifex ([1625208](https://github.com/nextcloud/calendar/commit/16252088e29ce3f1335a81f5d373c8bfdb53e65f))
-* **l10n:** Update translations from Transifex ([358cf00](https://github.com/nextcloud/calendar/commit/358cf004862f4789ca39cb315f57c5f8ec676ef1))
-* **l10n:** Update translations from Transifex ([d8e50e0](https://github.com/nextcloud/calendar/commit/d8e50e0c76ad1f81ba16e8bdb176b7f2ae5f3c70))
-* **l10n:** Update translations from Transifex ([7c9387a](https://github.com/nextcloud/calendar/commit/7c9387a2e8629c8e299765f8f2a24b98b7eab1b5))
-* **l10n:** Update translations from Transifex ([42ea5a5](https://github.com/nextcloud/calendar/commit/42ea5a57b2be2243bca27c0d46c1a3c3c138a46f))
-* **l10n:** Update translations from Transifex ([64a2cf1](https://github.com/nextcloud/calendar/commit/64a2cf14a0e08b6383578362c40794049c91855a))
-* **l10n:** Update translations from Transifex ([84e1b09](https://github.com/nextcloud/calendar/commit/84e1b0912bd3ec8e5bd9678b066cfa29138d29f0))
-* **l10n:** Update translations from Transifex ([634b6a6](https://github.com/nextcloud/calendar/commit/634b6a6f6aa6e5753d7a3ed67a1a86c62d582a11))
-* **l10n:** Update translations from Transifex ([34b3d58](https://github.com/nextcloud/calendar/commit/34b3d589a5c658f6d1298d02434c7e30215d9b01))
-* **l10n:** Update translations from Transifex ([97a73bf](https://github.com/nextcloud/calendar/commit/97a73bffc5780e4cd07a1604e355d264f47d1dda))
-* **l10n:** Update translations from Transifex ([f33c90f](https://github.com/nextcloud/calendar/commit/f33c90f13f7a929e93ef91fc5945406df0453c40))
-* **l10n:** Update translations from Transifex ([9198fbd](https://github.com/nextcloud/calendar/commit/9198fbd0b9c9aaec02bd19cf4f632d4e57c34a5f))
-* **l10n:** Update translations from Transifex ([965ee9e](https://github.com/nextcloud/calendar/commit/965ee9e339784ed2ca08b53cbcd4301a8863c105))
-* **l10n:** Update translations from Transifex ([43f427a](https://github.com/nextcloud/calendar/commit/43f427a4e2a227766ac6d191baca42077083dd97))
-* **l10n:** Update translations from Transifex ([657f9c4](https://github.com/nextcloud/calendar/commit/657f9c42e5c3a4b65968d74fe126d17bc5f8a3df))
-* **l10n:** Update translations from Transifex ([d19ed5d](https://github.com/nextcloud/calendar/commit/d19ed5d78894f8a851c852f134602b5793b2c87c))
-* **l10n:** Update translations from Transifex ([6c37b2d](https://github.com/nextcloud/calendar/commit/6c37b2d240202e1b03aeaef8bed212b134fd321b))
-* **l10n:** Update translations from Transifex ([b224dab](https://github.com/nextcloud/calendar/commit/b224dab8abcdd9b9f1b4ea407e11796270cfbd1a))
-* **l10n:** Update translations from Transifex ([7499428](https://github.com/nextcloud/calendar/commit/749942815bf3e47f34f68c553b92c98ca4af9284))
-* **l10n:** Update translations from Transifex ([d719b79](https://github.com/nextcloud/calendar/commit/d719b79b0d83d15e00f400b837e5e77159dbbaea))
-* **l10n:** Update translations from Transifex ([e43a3f8](https://github.com/nextcloud/calendar/commit/e43a3f8a64ceac0d2a0d808a74ec17bd162ed740))
-* **l10n:** Update translations from Transifex ([18c2a61](https://github.com/nextcloud/calendar/commit/18c2a61f27c1ceae15f10ebae3f662d2b166f3f1))
-* **l10n:** Update translations from Transifex ([cc758db](https://github.com/nextcloud/calendar/commit/cc758dbb9f7b54df33eed881ec9b92ccd212633b))
-* **l10n:** Update translations from Transifex ([eefcbc2](https://github.com/nextcloud/calendar/commit/eefcbc24d71ebc3c524dc7376d53ce3efc8dbce4))
-* **l10n:** Update translations from Transifex ([e33da56](https://github.com/nextcloud/calendar/commit/e33da56c108e36389788f196e21a832047ced8c4))
-* **l10n:** Update translations from Transifex ([1f49d01](https://github.com/nextcloud/calendar/commit/1f49d01a58ae7548b3decd9aabe29f738dd3db6f))
-* **l10n:** Update translations from Transifex ([597fc06](https://github.com/nextcloud/calendar/commit/597fc06995b054e6975242e989bc729509e252c5))
-* **l10n:** Update translations from Transifex ([c9dc23d](https://github.com/nextcloud/calendar/commit/c9dc23d175dc1c8475b5c7a40ed0a0e86c55a9e9))
-* **l10n:** Update translations from Transifex ([969a8d8](https://github.com/nextcloud/calendar/commit/969a8d80c141eb39ef6bf44c6456ac98e0076d4b))
-* **lint-php-cs:** use minimum available php version ([906868c](https://github.com/nextcloud/calendar/commit/906868c45fa9882626d4406bedb345625c2284db))
-* lint:fix, disable adding param docs ([a3846f9](https://github.com/nextcloud/calendar/commit/a3846f9d627aa22fe58b65d61beb11c9935f9e5c))
-* make absolute URL generation more robust ([c42c8f7](https://github.com/nextcloud/calendar/commit/c42c8f79de1ce3794e65107470501bcde25a0da0))
-* Make the wording "Selected slot" translatable ([889f09d](https://github.com/nextcloud/calendar/commit/889f09db012e9b4d4c2374dee8423ca10fec5b3e))
-* margin when dragging on selected events ([ae7275f](https://github.com/nextcloud/calendar/commit/ae7275f830d677615f39152f0221da6e6b59346b))
-* match main route more strictly to prevent conflicts in the contacts menu ([2f12115](https://github.com/nextcloud/calendar/commit/2f12115b04197400900fddb6e16521980d5c3e03))
-* meeting proposal calendar blockers ([ccbeef2](https://github.com/nextcloud/calendar/commit/ccbeef2a0aed72004eae8ef512b74829ea9ff394))
-* meeting proposal conversion error ([311d792](https://github.com/nextcloud/calendar/commit/311d792d065e3f1e74749d80218695a6dd4cb02d))
-* meeting proposal freeze and error ([13661ca](https://github.com/nextcloud/calendar/commit/13661ca360a88f1d5592ddae53aaa9566d4a2eff))
-* meeting proposal system mailer from address ([9bb2776](https://github.com/nextcloud/calendar/commit/9bb27761b15dbaa24a7674b9203331a1c74927cf))
-* meeting proposal url and errors handling ([6fdbab7](https://github.com/nextcloud/calendar/commit/6fdbab73ac8d0e6e84276985869d0ce80c556292))
-* meeting proposals minor ui fixes ([ca9027c](https://github.com/nextcloud/calendar/commit/ca9027c72eb67e619c843a5b37ba44ca39bfd63a))
-* meeting proposals participant no reponse ([617c607](https://github.com/nextcloud/calendar/commit/617c607da9ab2b83f3a9a3464f03df6d0a03f66b))
-* merge global full page editor styles into the SFC ([acf2b6a](https://github.com/nextcloud/calendar/commit/acf2b6ab10f136612bcd50d0189c72d3a1e2a440))
-* monthly recurrance type and bymonthday selection ([7afb1b4](https://github.com/nextcloud/calendar/commit/7afb1b4091a32804f233d226c3489e5d9630639c))
-* order all-day events by name ([ca8cb66](https://github.com/nextcloud/calendar/commit/ca8cb660d6f7b1b8d0209185090e8a9c5d67f541))
-* **OrganizerNoEmailError:** update styling ([dbc6229](https://github.com/nextcloud/calendar/commit/dbc62297e00e7b327beecbd300c6db1733bdee53))
-* prevent event date change glitch ([fc0a0a4](https://github.com/nextcloud/calendar/commit/fc0a0a4306cb656d5cad776ba7ef96a42e122504))
-* **PropertyTitleTimePicker:** debounce date time picker ([9f41604](https://github.com/nextcloud/calendar/commit/9f41604df3b5ea75c5237913cf2276c272b538de))
-* **PropertyTitleTimePicker:** improve styling for local time subtitle ([#7721](https://github.com/nextcloud/calendar/issues/7721)) ([90f5de1](https://github.com/nextcloud/calendar/commit/90f5de1cce4f0f3e5ce637d2f8d670c0ab418bb2))
-* proposal links ([7da31f1](https://github.com/nextcloud/calendar/commit/7da31f1f8727bf63185eb02bf4868c37f616ae3c))
-* psalm error for ci ([8b8ba63](https://github.com/nextcloud/calendar/commit/8b8ba6390a27f735d3aae5d0601806398c33cbc8))
-* **public-calendar:** remove toggle functionality from public view ([8fb5f97](https://github.com/nextcloud/calendar/commit/8fb5f9743f507f5d8679e77571fd3268e472945f))
-* redirect sidebar editor route for activity deep links ([bdd003c](https://github.com/nextcloud/calendar/commit/bdd003c54ba6eb17b9c6dffe2166c367d33bd8e3))
-* reduce background sync interval a bit ([90b5a17](https://github.com/nextcloud/calendar/commit/90b5a177d841eba0b6b418599fb629f813eedac5))
-* reduce long press event delay to 500 ms ([0473bd3](https://github.com/nextcloud/calendar/commit/0473bd3164b5549baf56c12bb4b7392ba227740a))
-* Release automation ([6a941c9](https://github.com/nextcloud/calendar/commit/6a941c96b41e3d2345eb28d53873b1f4e1cecfed))
-* remove organizer when there are no attendees ([7d936f8](https://github.com/nextcloud/calendar/commit/7d936f8c0de46d4ce3d55f71d462c0bb54ee0bbb))
-* **Repeat:** add button to submit ([#7878](https://github.com/nextcloud/calendar/issues/7878)) ([11f1e20](https://github.com/nextcloud/calendar/commit/11f1e207facbfdd2dfb9450a5ff77fd3faf7926a))
-* **Repeat:** change all day is visually disabled when recurrence is set ([3d6e1ff](https://github.com/nextcloud/calendar/commit/3d6e1ff31d83c4ad62b993d63c27103f15daf11d))
-* respect Talk config when creating a new conversation for an event ([8703e5b](https://github.com/nextcloud/calendar/commit/8703e5b9a23ec0b448dfcdbd2764e37e61e21e4c))
-* restrict attendees edit priveleges in the frontend ([7c77be2](https://github.com/nextcloud/calendar/commit/7c77be260ba54b70b060c60c1d258b5410897578))
-* room suggestions not being rendered ([c674fac](https://github.com/nextcloud/calendar/commit/c674fac39a3d920e2236ff74f51111f3297ca7f1))
-* **rtl:** calendar grid direction ([66c68fb](https://github.com/nextcloud/calendar/commit/66c68fb01d59e5bd100a4c9d7975e42e2567983b))
-* scheduling tasks with a DTSTART of type date ([ffef89a](https://github.com/nextcloud/calendar/commit/ffef89a61f79af938e0e50e8d2ddc65a0fe42e93))
-* scope css rules for calendar full view ([bf76a6f](https://github.com/nextcloud/calendar/commit/bf76a6fff08de1bf69e9efe1331d0fbb8abb4988))
-* search for possible Talk room attendees by displayed name instead of email ([8ccce9d](https://github.com/nextcloud/calendar/commit/8ccce9dc69fe3a76ab12c134b053fa37f000b4e4))
-* set vue loader to compatible version ([90539a9](https://github.com/nextcloud/calendar/commit/90539a96fb3d702ecd08ac0d0afd2597b29ecae0))
-* settings getCurrentUserPrincipal error ([5e7e1ea](https://github.com/nextcloud/calendar/commit/5e7e1ea3970af74eac1e8942ab19574c0f6f176d))
-* **settings:** forward compatibility of all checkboxes ([f2f0ac2](https://github.com/nextcloud/calendar/commit/f2f0ac2e7301f124f4fce3f550c377243f9e3107))
-* show display name instead of user id in availability integration ([cb7d9aa](https://github.com/nextcloud/calendar/commit/cb7d9aa2b02ebe7a9ec3caea1c711349dae3f082))
-* show generic participation status for the organizer ([983a6dc](https://github.com/nextcloud/calendar/commit/983a6dc04da8e2571a2a063486cc1b2d8b57e694))
-* show server address for ios ([47920ae](https://github.com/nextcloud/calendar/commit/47920aec34c9b7d0406b0fd2b6169f06b3d81317))
-* show the right icons on calendar ([40bae34](https://github.com/nextcloud/calendar/commit/40bae34c1dd14a6919f3bb11aa0758c6107bfba5))
-* show time zone selector ([ad038e1](https://github.com/nextcloud/calendar/commit/ad038e1c342f5ddaf5bced6f6557ce68be8a3d77))
-* simple calendar view width ([27d7852](https://github.com/nextcloud/calendar/commit/27d7852bff6120d7763bdb36ada927f7003fe1b2))
-* simple editor position issues ([50fc39c](https://github.com/nextcloud/calendar/commit/50fc39cdbab6deed8a88cecb77677ed4a1c79a1a))
-* simple editor size and jumping ([11f766f](https://github.com/nextcloud/calendar/commit/11f766f2dd6f89636859b69b431b3508525eaeaf))
-* sort talk conversations by most recent activity ([056a8aa](https://github.com/nextcloud/calendar/commit/056a8aa333121a7d88a071cdb0a3e9a7816d3c66))
-* **stylelint:** apply fixes ([d1e6259](https://github.com/nextcloud/calendar/commit/d1e62590a3ebaf1c1ad5b3ae428ddf33b16ee5b1))
-* talk service tests ([1290cd1](https://github.com/nextcloud/calendar/commit/1290cd1f85e194158d4c1933809d1cc18fce4375))
-* **talkintegration:** allow room creation with description ([65195e8](https://github.com/nextcloud/calendar/commit/65195e826539916daa8e1eab69dd7d4db92604ef))
-* **talk:** make it clearer that new conversations are public ([b30a425](https://github.com/nextcloud/calendar/commit/b30a425a08642aa28d3c1ddcca9cddae603113a8))
-* **talkService:** make attendees be synced with talk room members ([#7733](https://github.com/nextcloud/calendar/issues/7733)) ([899876f](https://github.com/nextcloud/calendar/commit/899876fbb2300b9f991adefa795b0553b74738db))
-* **transifex:** backport to stable5.1 ([d081af5](https://github.com/nextcloud/calendar/commit/d081af5839ce520427a375d7de1681fe13165903))
-* trashbin error toast wording when deleting items ([826dade](https://github.com/nextcloud/calendar/commit/826daded3039953550ccbaac845e748a2d116340))
-* **ui:** scope mobile css rules for full editor ([2f543a6](https://github.com/nextcloud/calendar/commit/2f543a6db035f94df8e0b6b9d91357875d89deb4))
-* update app store description ([9f0c255](https://github.com/nextcloud/calendar/commit/9f0c2550255f074e5a2a8eff2b3eebb1705ce152))
-* use createFromStringMinimal() instead of createFromString() ([f256232](https://github.com/nextcloud/calendar/commit/f256232df27411ac0518d091156155e1d1ec4bf6))
-* use outlined checkbox for disabled/hidden calendars ([0720b1a](https://github.com/nextcloud/calendar/commit/0720b1a006bd716e84f5df224f68dea75554b0ef))
-* use proper linter config and fix errors ([11fc845](https://github.com/nextcloud/calendar/commit/11fc845d8f97dd12cd52a8c19bccad0345394908))
-* use system button sytles for top navigation buttons ([f40d24f](https://github.com/nextcloud/calendar/commit/f40d24f229e7f1be5f77afcbe299e3b9247622c4))
-* Warning: Undefined variable $mailService ([53b61ea](https://github.com/nextcloud/calendar/commit/53b61ea213bd8286690bc667b4f06740f8e69490))
-* week day view issue with tentetive status ([78a507e](https://github.com/nextcloud/calendar/commit/78a507e61c20ace44cfa13b1d67b212dc36950cb))
-* wrong end date mutation ([a6f72c9](https://github.com/nextcloud/calendar/commit/a6f72c9de1ba1e00b2d0715a437de42bb1c161bb))
-* yearly recurrance options - month selection ([49f98be](https://github.com/nextcloud/calendar/commit/49f98bec6f7373157109cb768f502b4ce6ee0fa9))
-* yearly recurrance options - month selection ([43fb124](https://github.com/nextcloud/calendar/commit/43fb124e4524806a94c97992859daaeb6b9b194b))
-
-
-### Features
-
-* add confirmation dialog before cancel ([c2ba077](https://github.com/nextcloud/calendar/commit/c2ba077f0a4dac99e913936f0876ced008c44460))
-* add description to booked appointment and pre appointment blocker ([481a8c3](https://github.com/nextcloud/calendar/commit/481a8c3f2f447d6396458412260c8f15d8da5dc9))
-* add full page event editor ([bb8f8bb](https://github.com/nextcloud/calendar/commit/bb8f8bbcc9204397a63abc12b7e4cd195cd0567c))
-* add local time when inviting attendees to events ([ca64b24](https://github.com/nextcloud/calendar/commit/ca64b2420161c5865d59f07354b9d3803f80ae33))
-* add support for nextcloud 32 ([5be4249](https://github.com/nextcloud/calendar/commit/5be4249857a0ba83dd73b14da41e062b0386ae98))
-* added ability to create private talk room ([71b5a40](https://github.com/nextcloud/calendar/commit/71b5a40ca22e1004a61132337523d5411ae35a99))
-* **appointments:** add duplicate button to clone appointments ([9cc396a](https://github.com/nextcloud/calendar/commit/9cc396ab1fa9b378a2818b019a3855b3e370c676))
-* calendar icon not outline ([5f66141](https://github.com/nextcloud/calendar/commit/5f66141f63f83975b577d9c5508db107819ce8cc))
-* **CalendarList:** keep hidden calendars in main list ([b05feac](https://github.com/nextcloud/calendar/commit/b05feaca02dab05eddcb101311948c9603d6c675))
-* change calendar icons into outline ones ([9c29b1b](https://github.com/nextcloud/calendar/commit/9c29b1b081d4e9545f87cc37143b542c2d2aa75e))
-* **deps:** Add Nextcloud 33 support ([cdbafd9](https://github.com/nextcloud/calendar/commit/cdbafd9a0e0f12c9bd39a0457b1631cf84f1d7ee))
-* **EditSimple:** show alarms in viewing mode ([d21a389](https://github.com/nextcloud/calendar/commit/d21a3894b49f2acc448a41bc54a594942defeb37))
-* exit event edit popover without click on X ([300cf85](https://github.com/nextcloud/calendar/commit/300cf854f5432cbe27d23318ec2956923cb4d546))
-* federated calendar sharing ([d08a9ba](https://github.com/nextcloud/calendar/commit/d08a9ba14c9de8d94f4e6d7a0a2d1e71b9e7a1ac))
-* **FullCalendar:** add conditional styling for participation status in grid ([a68f90c](https://github.com/nextcloud/calendar/commit/a68f90ccb2456c86a2fb3d9a77618a75e10af3ec))
-* **invitees:** add copy button for attendee  emails ([48a58d6](https://github.com/nextcloud/calendar/commit/48a58d64e70524a0e94fcd7f232647e8bea2bccc))
-* meeting proposal convertion options ([b7b76d0](https://github.com/nextcloud/calendar/commit/b7b76d02a5a8203229b5e0a84c17e8347bc438c6))
-* Meeting Proposals ([4a948f0](https://github.com/nextcloud/calendar/commit/4a948f00cd5ebcb25bb7ee2ea9866a65ba60e589))
-* Meeting proposals calendar time blockers ([8d68329](https://github.com/nextcloud/calendar/commit/8d68329af498b9b17fce49924a1fbe7ff2b59df2))
-* move calendar setting to modal ([2e17227](https://github.com/nextcloud/calendar/commit/2e1722743e82ddd10a0d841eda8b0311bec17459))
-* **PropertyTitleTimePicker:** add local time subtitle ([8a5909a](https://github.com/nextcloud/calendar/commit/8a5909a116dd4757f46b8be960586392fc78216f))
-* proposal and appointment configuration migrator ([060bcd2](https://github.com/nextcloud/calendar/commit/060bcd294c95529d9c2193bf08d995c8996385b5))
-* restrict calendar invitation users ([0505cef](https://github.com/nextcloud/calendar/commit/0505ceff259ac5c9d090bc116abae5a8da54cca2))
-* rework freebusy modal ([c00e7ab](https://github.com/nextcloud/calendar/commit/c00e7ab4d40094e04292d848bd291adb8888ebff))
-* **SaveButtons:** group update buttons ([4a51fb1](https://github.com/nextcloud/calendar/commit/4a51fb1b29dd66b30debc2132e1d99193aa6fdbc))
-* **Settings:** redesign to new vue components ([#7682](https://github.com/nextcloud/calendar/issues/7682)) ([a35d149](https://github.com/nextcloud/calendar/commit/a35d14915e5d2f0e1e8f262e795824161aeb94aa))
-* strike through cancelled event title ([6b43f6c](https://github.com/nextcloud/calendar/commit/6b43f6cc237c1b8b9d10d132a10a8ff412743f60))
-* sync calendar instantly on changes ([e0eb03d](https://github.com/nextcloud/calendar/commit/e0eb03d246a9f6f8e428d30f50f8036e2421d0ba))
-* **talkintegration:** add object type to talk room creation ([85bec05](https://github.com/nextcloud/calendar/commit/85bec05b878c3dafccbcdd2610a3ac0196bc9bd0))
-* **talkintegration:** filter out event type rooms from suggestions ([909f399](https://github.com/nextcloud/calendar/commit/909f399a04a1283c366b4224e7dec36e72a143c9))
-* Task scheduling for tasks without end date ([9a754e6](https://github.com/nextcloud/calendar/commit/9a754e6ed2d19461e768cbca478de0c8e812a7c7))
-
-
-### Performance Improvements
-
-* don't load ContactsMenuScript when not logged in ([a0853ee](https://github.com/nextcloud/calendar/commit/a0853ee9787ed838a959f37f45ea0743953dcc94))
-* reduce contacts menu entrypoint bundle size ([2e03c8c](https://github.com/nextcloud/calendar/commit/2e03c8c00eeab4db6b74045f3662b839f3cece74))
-* system addressbook enumeration disabled in contacts search ([dcf13c9](https://github.com/nextcloud/calendar/commit/dcf13c92495d4c21e8f6775c02d5aa08f7f6492f))
-
-
-
-# [5.1.0-beta2](https://github.com/nextcloud/calendar/compare/v5.1.0-beta1...v5.1.0-beta2) (2025-01-16)
-
-
-### Bug Fixes
-
-* **deps:** bump @nextcloud/calendar-availability-vue from 2.2.4 to ^2.2.6 (main) ([#6628](https://github.com/nextcloud/calendar/issues/6628)) ([a67b49f](https://github.com/nextcloud/calendar/commit/a67b49f2b21ad691bef6bd128e9f5d8f633c94df))
-* **deps:** bump core-js from 3.39.0 to ^3.40.0 (main) ([#6629](https://github.com/nextcloud/calendar/issues/6629)) ([7a8ede3](https://github.com/nextcloud/calendar/commit/7a8ede390f21f34c69e65df48f68dc4139c550ed))
-* location and description not being saved ([5348612](https://github.com/nextcloud/calendar/commit/5348612ffae9196963b495b9c71007489c29f685))
-
-
-### Features
-
-* **editor:** improve attendee and resource status display ([9c23ed8](https://github.com/nextcloud/calendar/commit/9c23ed8e11811faa94d5b91e406d272d36918c9b))
-
-
-
-# [5.1.0-beta1](https://github.com/nextcloud/calendar/compare/v5.1.0-alpha2...v5.1.0-beta1) (2025-01-14)
-
-
-### Features
-
-* add availability action to the contacts menu ([266a345](https://github.com/nextcloud/calendar/commit/266a34543e8ca552b5bd164472676379a80ae8de))
-* Add overlay between calendar and open simple editor ([8699a65](https://github.com/nextcloud/calendar/commit/8699a658475e8a511b23187056bc7308b535b6f8))
-
-
-
-# [5.1.0-alpha2](https://github.com/nextcloud/calendar/compare/v5.1.0-alpha1...v5.1.0-alpha2) (2025-01-09)
-
-
-### Bug Fixes
-
-* firefox avatar icon styling inconsistency ([02e8ed4](https://github.com/nextcloud/calendar/commit/02e8ed422aba9d2edf543196d317b4f2a0d84c62))
-* max-width for long timezones names ([c27f067](https://github.com/nextcloud/calendar/commit/c27f067da8efcce8a77ad120b8930e022b202703))
-
-
-
-# [5.1.0-alpha1](https://github.com/nextcloud/calendar/compare/v5.0.0-alpha4...v5.1.0-alpha1) (2025-01-07)
-
-
-### Bug Fixes
-
-* add border to sidebar button ([50878bf](https://github.com/nextcloud/calendar/commit/50878bfea41f1c9e372afc4c83db46a60b8244a7))
-* add missing license ([9196525](https://github.com/nextcloud/calendar/commit/91965257efe918bbac804aedc43f066895bffdfa))
-* adjust url for task links ([#6550](https://github.com/nextcloud/calendar/issues/6550)) ([e86c82a](https://github.com/nextcloud/calendar/commit/e86c82a965a791fae0e9ee14966f2949502011b8))
-* **alarms:** also update DISPLAY alarms ([b66f96a](https://github.com/nextcloud/calendar/commit/b66f96ab30cdd5011695b52001179edbacb99f2a))
-* allow adding self to shared event ([479ba82](https://github.com/nextcloud/calendar/commit/479ba82475b81687c6d6dc4355acead16c2f081a))
-* appointment slots start and end time ([6e06e87](https://github.com/nextcloud/calendar/commit/6e06e87c416120482f3ae38dcb26c967564b8050))
-* **appointments:** log calculated start and end times for slot generation ([13ad251](https://github.com/nextcloud/calendar/commit/13ad251c07e5eda8cd2b1859b7b2fd4a82573295))
-* **appointments:** properly localise the calendar events ([74df703](https://github.com/nextcloud/calendar/commit/74df7032d0a03855ad98bf4b678a49ac96313780))
-* **appointments:** Set organiser email to correct langauge ([7893c95](https://github.com/nextcloud/calendar/commit/7893c95cd2c5d04d4b231553855ce423b289ab82))
-* **appointments:** simplify booking response ([3acd930](https://github.com/nextcloud/calendar/commit/3acd93027c3948eb52a4091408e6fe0128269afc))
-* attachment folder picker ([93374fa](https://github.com/nextcloud/calendar/commit/93374fad5e8fd1d16b31fd776077a2e0b560d483))
-* **attachments:** add missing file picker confirm ([df34ac0](https://github.com/nextcloud/calendar/commit/df34ac087e28f547ab3d06f81762b18693e7273e))
-* **attachments:** adjust click handler ([9346664](https://github.com/nextcloud/calendar/commit/9346664359110c0a052d6933b57b4fc99c94dd5c))
-* **attachmentService, propfindErrorParse:** add an error message for when a file is not compatible for windows ([d7288b0](https://github.com/nextcloud/calendar/commit/d7288b06368b3fa0e4a3999c7e70338322e02f02))
-* **attachments:** improve layout ([e9e9bcf](https://github.com/nextcloud/calendar/commit/e9e9bcf209e1ae3a051e44f7cfb24d62ff30c533))
-* avatar status icon text misalignment ([f837082](https://github.com/nextcloud/calendar/commit/f8370822b0c7f697b8683bf0c453725d21ce357d))
-* **CalendarListNew:** Public Calendar Modal Opening ([0ae73bc](https://github.com/nextcloud/calendar/commit/0ae73bcb63ace8cb5c268b2a49d174d73441fb6e))
-* **CalendarObjectInstance:** reset attendee participation status on duplication of an event ([0b7f8dc](https://github.com/nextcloud/calendar/commit/0b7f8dc5d9d339218c2cc9990f01e15adad32e65))
-* **calendarPicker:** undefined calendar ([94fc5d1](https://github.com/nextcloud/calendar/commit/94fc5d12b7772f7aa3e06aef28e6feb8a812926a))
-* check if userId is null ([a123dc8](https://github.com/nextcloud/calendar/commit/a123dc80d6e80f17d3f985f6c3ad34818240a687))
-* CI ([75445bd](https://github.com/nextcloud/calendar/commit/75445bd624e9d1ba0fb06b25c683a6cb4f6528cc))
-* default calendar needs to support VEVENTs ([99921bc](https://github.com/nextcloud/calendar/commit/99921bc9ce7e243b9bbf028d90f7195d815380e3))
-* default reminder ui bug ([def95a6](https://github.com/nextcloud/calendar/commit/def95a6b109b11485ee176aa4ab0fea94f0ac6ab))
-* **deps:** bump @nextcloud/auth from 2.2.1 to ^2.3.0 (main) ([#5946](https://github.com/nextcloud/calendar/issues/5946)) ([9f1f387](https://github.com/nextcloud/calendar/commit/9f1f3878ede2499f0abbf1510bf40285c9383b3d))
-* **deps:** bump @nextcloud/auth from 2.4.0 to ^2.4.0 (main) ([#6257](https://github.com/nextcloud/calendar/issues/6257)) ([8d3357f](https://github.com/nextcloud/calendar/commit/8d3357f8bd72776e3f7a18eabfbc55ac1b3b6864))
-* **deps:** bump @nextcloud/axios from 2.4.0 to ^2.5.0 (main) ([#5989](https://github.com/nextcloud/calendar/issues/5989)) ([928d36b](https://github.com/nextcloud/calendar/commit/928d36bc50c687f7901b25678e9e726b03f11865))
-* **deps:** bump @nextcloud/axios from 2.5.0 to ^2.5.1 (main) ([#6366](https://github.com/nextcloud/calendar/issues/6366)) ([5203eeb](https://github.com/nextcloud/calendar/commit/5203eebd680cdf2325ae6de6f3e32e90e7320129))
-* **deps:** bump @nextcloud/calendar-availability-vue from 2.2.0 to ^2.2.1 (main) ([#6019](https://github.com/nextcloud/calendar/issues/6019)) ([70b8ae7](https://github.com/nextcloud/calendar/commit/70b8ae7b3c2813b7aa07dbf3766609a05d0324e6))
-* **deps:** bump @nextcloud/calendar-availability-vue from 2.2.1 to ^2.2.2 (main) ([#6085](https://github.com/nextcloud/calendar/issues/6085)) ([4081035](https://github.com/nextcloud/calendar/commit/408103599f1c7cfacc68b9d19940ff793e762125))
-* **deps:** bump @nextcloud/calendar-availability-vue from 2.2.2 to ^2.2.4 (main) ([#6272](https://github.com/nextcloud/calendar/issues/6272)) ([37f6e34](https://github.com/nextcloud/calendar/commit/37f6e345e8149657dda9ff84c9c7d14ec42a2428))
-* **deps:** bump @nextcloud/calendar-js from 8.0.2 to ^8.0.3 (main) ([#6526](https://github.com/nextcloud/calendar/issues/6526)) ([d674751](https://github.com/nextcloud/calendar/commit/d674751988b334342f94acb508f1978d2ce1d527))
-* **deps:** bump @nextcloud/cdav-library from 1.3.0 to ^1.4.0 ([b8e713c](https://github.com/nextcloud/calendar/commit/b8e713c8138cff678e5cfd8221020494ce9899ae))
-* **deps:** bump @nextcloud/cdav-library from 1.4.0 to ^1.5.0 (main) ([#6174](https://github.com/nextcloud/calendar/issues/6174)) ([5e5a9a0](https://github.com/nextcloud/calendar/commit/5e5a9a061d91f9258a06e5872d8884d1d93e6e91))
-* **deps:** bump @nextcloud/cdav-library from 1.5.0 to ^1.5.1 (main) ([#6182](https://github.com/nextcloud/calendar/issues/6182)) ([48116a4](https://github.com/nextcloud/calendar/commit/48116a4fcfd8edd9a26ff6244a04ccb79f702911))
-* **deps:** bump @nextcloud/cdav-library from 1.5.1 to ^1.5.2 (main) ([#6426](https://github.com/nextcloud/calendar/issues/6426)) ([faf4cd6](https://github.com/nextcloud/calendar/commit/faf4cd6a46062cf0d5c1f1b8d8391a38773a7292))
-* **deps:** bump @nextcloud/dialogs from 4.2.6 to v5 ([e93fb34](https://github.com/nextcloud/calendar/commit/e93fb34070a4f8575bb1ab9ff3ed2dc36cc1836f))
-* **deps:** bump @nextcloud/dialogs from 5.3.1 to ^5.3.2 (main) ([#6055](https://github.com/nextcloud/calendar/issues/6055)) ([c384096](https://github.com/nextcloud/calendar/commit/c384096f2a614563c6c30b6df795475ca7fd4f97))
-* **deps:** bump @nextcloud/dialogs from 5.3.2 to ^5.3.4 (main) ([#6086](https://github.com/nextcloud/calendar/issues/6086)) ([d3ba8ce](https://github.com/nextcloud/calendar/commit/d3ba8cec1597d3273b9029f29b86266fbfc6d342))
-* **deps:** bump @nextcloud/dialogs from 5.3.4 to ^5.3.5 (main) ([#6132](https://github.com/nextcloud/calendar/issues/6132)) ([ad5a518](https://github.com/nextcloud/calendar/commit/ad5a518abc2565d78c3aaf73f518124d47fae1cd))
-* **deps:** bump @nextcloud/dialogs from 5.3.5 to ^5.3.6 (main) ([#6273](https://github.com/nextcloud/calendar/issues/6273)) ([da7cc68](https://github.com/nextcloud/calendar/commit/da7cc685fc6681bb4b7a4e1476223662094946ad))
-* **deps:** bump @nextcloud/dialogs from 5.3.6 to ^5.3.7 (main) ([#6296](https://github.com/nextcloud/calendar/issues/6296)) ([e21d65e](https://github.com/nextcloud/calendar/commit/e21d65e41fb30541ee75da21e14bf8baf1b3f99d))
-* **deps:** bump @nextcloud/dialogs from 5.3.7 to ^5.3.8 (main) ([#6464](https://github.com/nextcloud/calendar/issues/6464)) ([aa30c8f](https://github.com/nextcloud/calendar/commit/aa30c8f6c164b420cfeb4b40cb3d91d4c1d39716))
-* **deps:** bump @nextcloud/dialogs from 5.3.8 to v6 ([e2a85a4](https://github.com/nextcloud/calendar/commit/e2a85a471778594d0638fbe28fc9549423c1d274))
-* **deps:** bump @nextcloud/event-bus from 3.2.0 to ^3.2.0 (main) ([#5947](https://github.com/nextcloud/calendar/issues/5947)) ([3cb4d04](https://github.com/nextcloud/calendar/commit/3cb4d04baa389a838fc383d8c57d3563c3626443))
-* **deps:** bump @nextcloud/event-bus from 3.2.0 to ^3.3.1 (main) ([#6028](https://github.com/nextcloud/calendar/issues/6028)) ([f242ae8](https://github.com/nextcloud/calendar/commit/f242ae81d976e1a83ea65ee3324d63fad5e4aca5))
-* **deps:** bump @nextcloud/initial-state from 2.1.0 to ^2.2.0 (main) ([#5990](https://github.com/nextcloud/calendar/issues/5990)) ([8f695f8](https://github.com/nextcloud/calendar/commit/8f695f83f26a7c608fba03e7737ae3388fba7bb6))
-* **deps:** bump @nextcloud/l10n from 2.2.0 to v3 ([bd67b27](https://github.com/nextcloud/calendar/commit/bd67b275a0454689612ecc8b7f447af6c29cf9e1))
-* **deps:** bump @nextcloud/logger from 2.7.0 to v3 ([5f84062](https://github.com/nextcloud/calendar/commit/5f84062945a27e5f373ca17f4b4b03fb5857c95a))
-* **deps:** bump @nextcloud/logger from 3.0.1 to ^3.0.2 (main) ([#6020](https://github.com/nextcloud/calendar/issues/6020)) ([f75b2a6](https://github.com/nextcloud/calendar/commit/f75b2a6c98830dd9b5720412e9f0172c5d953814))
-* **deps:** bump @nextcloud/moment from 1.3.1 to ^1.3.2 (main) ([#6575](https://github.com/nextcloud/calendar/issues/6575)) ([8d3b8b4](https://github.com/nextcloud/calendar/commit/8d3b8b46b662716cfc8e7c23f4780cfd541d2167))
-* **deps:** bump @nextcloud/router from 3.0.0 to ^3.0.1 (main) ([#5945](https://github.com/nextcloud/calendar/issues/5945)) ([2f8515d](https://github.com/nextcloud/calendar/commit/2f8515d0fe28696fa81173dc484d7b91ce23d747))
-* **deps:** bump @nextcloud/vue from 8.11.2 to ^8.11.2 ([e15a1a2](https://github.com/nextcloud/calendar/commit/e15a1a266374672555e0ee5e9d0394fa97b1f310))
-* **deps:** bump @nextcloud/vue from 8.11.2 to ^8.11.3 ([ccf5f95](https://github.com/nextcloud/calendar/commit/ccf5f95d88842b91e2944066d76ac6628b95495f))
-* **deps:** bump @nextcloud/vue from 8.11.3 to ^8.12.0 ([d5af6fc](https://github.com/nextcloud/calendar/commit/d5af6fc5fe920539bb6b3b8d0d5bdde941cb1dfa))
-* **deps:** bump @nextcloud/vue from 8.12.0 to ^8.13.0 ([f3a79a7](https://github.com/nextcloud/calendar/commit/f3a79a7416ba5ad933982e1f86b7a6bc48107a85))
-* **deps:** bump @nextcloud/vue from 8.13.0 to ^8.14.0 ([60d03d4](https://github.com/nextcloud/calendar/commit/60d03d4e4d9489cf4befd197b2a8669a67b90c97))
-* **deps:** bump @nextcloud/vue from 8.14.0 to ^8.15.0 ([0271a5b](https://github.com/nextcloud/calendar/commit/0271a5b1496eaa7c9d957301d4479e63bce6ad75))
-* **deps:** bump @nextcloud/vue from 8.15.0 to ^8.15.1 ([de9bebb](https://github.com/nextcloud/calendar/commit/de9bebb62449de8b30fc5b704d6d3337824231ab))
-* **deps:** bump @nextcloud/vue from 8.15.1 to ^8.16.0 ([48a812c](https://github.com/nextcloud/calendar/commit/48a812cf3b615d58f276a944b43299e894ef5734))
-* **deps:** bump @nextcloud/vue from 8.18.0 to ^8.18.0 ([bd73f27](https://github.com/nextcloud/calendar/commit/bd73f27ab5fd9a793fbaec15feb6cc1bbc8107d7))
-* **deps:** bump @nextcloud/vue from 8.19.0 to ^8.19.0 ([6309905](https://github.com/nextcloud/calendar/commit/6309905c58c85b58118d825354b6d369e38f9b94))
-* **deps:** bump @nextcloud/vue from 8.19.0 to ^8.20.0 ([128c0ba](https://github.com/nextcloud/calendar/commit/128c0ba612c97b39f0c1676b38051de5f1bb91e3))
-* **deps:** bump @nextcloud/vue from 8.20.0 to ^8.22.0 ([5350abb](https://github.com/nextcloud/calendar/commit/5350abb88d020e6a085dcb7686c75a7b2d8a2084))
-* **deps:** bump core-js from 3.36.1 to ^3.37.0 (main) ([#5927](https://github.com/nextcloud/calendar/issues/5927)) ([7c62824](https://github.com/nextcloud/calendar/commit/7c62824dab7f3a25a8a04ba9b505894d0c027020))
-* **deps:** bump core-js from 3.37.0 to ^3.37.1 (main) ([#6006](https://github.com/nextcloud/calendar/issues/6006)) ([fb1d43c](https://github.com/nextcloud/calendar/commit/fb1d43c65dce261c28d7a0a899878fc021762299))
-* **deps:** bump core-js from 3.37.1 to ^3.38.0 (main) ([#6242](https://github.com/nextcloud/calendar/issues/6242)) ([399c8b6](https://github.com/nextcloud/calendar/commit/399c8b66746093f58635204e5d5481984fe64649))
-* **deps:** bump core-js from 3.38.0 to ^3.38.1 (main) ([#6298](https://github.com/nextcloud/calendar/issues/6298)) ([2ada469](https://github.com/nextcloud/calendar/commit/2ada469e5561588205d3f264d307dd3543826749))
-* **deps:** bump core-js from 3.38.1 to ^3.39.0 (main) ([#6491](https://github.com/nextcloud/calendar/issues/6491)) ([5f6bbbf](https://github.com/nextcloud/calendar/commit/5f6bbbf2e7416f7ba856d2973af1e491d7c22192))
-* **deps:** bump debounce from 2.0.0 to ^2.1.0 (main) ([#6030](https://github.com/nextcloud/calendar/issues/6030)) ([cb76a3f](https://github.com/nextcloud/calendar/commit/cb76a3f1cb45e9c8303957fbc58de16ee4655488))
-* **deps:** bump debounce from 2.1.1 to ^2.1.1 (main) ([#6334](https://github.com/nextcloud/calendar/issues/6334)) ([696cb0b](https://github.com/nextcloud/calendar/commit/696cb0b8c62542b841969dcf09d0ae80eeeccaf8))
-* **deps:** bump debounce from 2.1.1 to ^2.2.0 ([13545a6](https://github.com/nextcloud/calendar/commit/13545a6f288efed6bf88dd4d018e46ce0cfac0f8))
-* **deps:** bump fullcalendar family from 6.1.11 to v6.1.14 ([8c443cc](https://github.com/nextcloud/calendar/commit/8c443cc3195c64078a110a93533f25fdf5e30b72))
-* **deps:** bump fullcalendar family from 6.1.14 to v6.1.15 ([7fb8727](https://github.com/nextcloud/calendar/commit/7fb872793d73bdc785603a14e76079c43579b29a))
-* **deps:** bump linkifyjs from 4.1.3 to ^4.2.0 (main) ([#6576](https://github.com/nextcloud/calendar/issues/6576)) ([f31991d](https://github.com/nextcloud/calendar/commit/f31991dbaa3e5d589c829abfb615a9ee6de67002))
-* **deps:** bump p-limit from 5.0.0 to v6 ([b093b06](https://github.com/nextcloud/calendar/commit/b093b06ded3b784751712bbd5afdca692842a608))
-* **deps:** bump p-limit from 6.1.0 to ^6.2.0 (main) ([#6592](https://github.com/nextcloud/calendar/issues/6592)) ([8fdb932](https://github.com/nextcloud/calendar/commit/8fdb932240ab550441175d4016108d724f0c98fb))
-* **deps:** bump pinia from 2.1.7 to ^2.2.0 (main) ([#6209](https://github.com/nextcloud/calendar/issues/6209)) ([e4b2139](https://github.com/nextcloud/calendar/commit/e4b21392b4833f025012780ca502d81a4301ad7c))
-* **deps:** bump pinia from 2.2.0 to ^2.2.1 (main) ([#6240](https://github.com/nextcloud/calendar/issues/6240)) ([795a49d](https://github.com/nextcloud/calendar/commit/795a49d4d8be16a4c8a423233175e925fd6589f3))
-* **deps:** bump pinia from 2.2.1 to ^2.2.2 (main) ([#6299](https://github.com/nextcloud/calendar/issues/6299)) ([7b55dd5](https://github.com/nextcloud/calendar/commit/7b55dd54835eaaaeacac9379b51e33d2271d172a))
-* **deps:** bump pinia from 2.2.2 to ^2.2.4 (main) ([#6387](https://github.com/nextcloud/calendar/issues/6387)) ([d59146b](https://github.com/nextcloud/calendar/commit/d59146b64e1529ef30a0fc369d9bff987f0cfdc7))
-* **deps:** bump pinia from 2.2.4 to ^2.2.5 (main) ([#6450](https://github.com/nextcloud/calendar/issues/6450)) ([730b9e8](https://github.com/nextcloud/calendar/commit/730b9e8d986f207fe497fd2bd3884821887d358c))
-* **deps:** bump pinia from 2.2.5 to ^2.2.6 (main) ([#6465](https://github.com/nextcloud/calendar/issues/6465)) ([1ab521c](https://github.com/nextcloud/calendar/commit/1ab521c0db8e05c589d32cf3fa2092d0104520b8))
-* **deps:** bump pinia from 2.2.6 to ^2.3.0 (main) ([#6577](https://github.com/nextcloud/calendar/issues/6577)) ([fcc3182](https://github.com/nextcloud/calendar/commit/fcc318245d24ef2c8d6012146247a57751c3c1e0))
-* **deps:** bump vue-material-design-icons from 5.3.0 to ^5.3.1 (main) ([#6412](https://github.com/nextcloud/calendar/issues/6412)) ([b097235](https://github.com/nextcloud/calendar/commit/b097235cb35caede9e41e115a5a221c6c969d4e1))
-* **deps:** bump webdav from 5.5.0 to ^5.6.0 (main) ([#6007](https://github.com/nextcloud/calendar/issues/6007)) ([e3f9fe8](https://github.com/nextcloud/calendar/commit/e3f9fe845801aa2cfa0f27399b75abd0d3bf7cec))
-* **deps:** bump webdav from 5.6.0 to ^5.7.1 (main) ([#6243](https://github.com/nextcloud/calendar/issues/6243)) ([9fc1b6a](https://github.com/nextcloud/calendar/commit/9fc1b6a79815262cd068b39b585f97dba0ae7885))
-* **deps:** Fix npm audit ([492beb5](https://github.com/nextcloud/calendar/commit/492beb5d16cc1db0161c22f506c8168fb8338619))
-* **deps:** Fix npm audit ([dac1c26](https://github.com/nextcloud/calendar/commit/dac1c2677bc9301fef88629e97128ac6fa9e4500))
-* **deps:** Fix npm audit ([6a5ba16](https://github.com/nextcloud/calendar/commit/6a5ba160ec0af4bd25ea191057259230959335ad))
-* **deps:** Fix npm audit ([ccf2a1a](https://github.com/nextcloud/calendar/commit/ccf2a1a1cee4226ef6dc56af46aca42dcec116d6))
-* **deps:** Fix npm audit ([ef73eaf](https://github.com/nextcloud/calendar/commit/ef73eaf695a063a624228e4a3285d9ce3958bd09))
-* **deps:** Fix npm audit ([3d6e499](https://github.com/nextcloud/calendar/commit/3d6e499865a84121b0ab28712d61f1bafb01526b))
-* disable save appointment button ([6bdbb85](https://github.com/nextcloud/calendar/commit/6bdbb85a89139111d24e3cc40597f2a36204f736))
-* don't apply default calendar on Nextcloud < 29 ([b46ea0d](https://github.com/nextcloud/calendar/commit/b46ea0d50edff571dff2b6280efbef0507186fc0))
-* **editor:** add and remove categories from events ([97f62e6](https://github.com/nextcloud/calendar/commit/97f62e604fd5ff61466ff12ef9ead9a0b492b755))
-* **editor:** add indicator to calendar picker ([0dfb690](https://github.com/nextcloud/calendar/commit/0dfb6902a0375bbe6fdf1d0336919373c599d813))
-* **editor:** calendar picker width ([e35da5f](https://github.com/nextcloud/calendar/commit/e35da5f9922dbb8f127ee28e2c15c6076eab4b50))
-* **editor:** creating custom categories ([403ed95](https://github.com/nextcloud/calendar/commit/403ed95864b989502e1b73f77b28d4bc490d224d))
-* **editor:** don't respect default calendar in the calendar picker ([4f2caf6](https://github.com/nextcloud/calendar/commit/4f2caf615b8ecdcb0f2f63abd71093581a0a68bb))
-* **editor:** sidebar editor custom header styling ([aec306b](https://github.com/nextcloud/calendar/commit/aec306b16cb06eaaf0e0ce1aa45b94aec43482b9))
-* **editor:** switching to sidebar after creating a new event ([c3df245](https://github.com/nextcloud/calendar/commit/c3df245dcc9c1ace74123e7d89654592b75ec04e)), closes [#5840](https://github.com/nextcloud/calendar/issues/5840)
-* **embed:** calendar header overlapping and adjust to compact design ([96fb2c7](https://github.com/nextcloud/calendar/commit/96fb2c736cf3543842f00317e85598912ada4667))
-* enable attendee selection on shared calendars ([34de776](https://github.com/nextcloud/calendar/commit/34de776798486161e49e195722aa88288dbb4715))
-* enable directory selection in file picker ([4944b64](https://github.com/nextcloud/calendar/commit/4944b64c335c0cc93642f0d2d9fc3a606a39204a))
-* Entity parameter types ([c413f8d](https://github.com/nextcloud/calendar/commit/c413f8d1776924c1ba9c8994b80e60fc4e9734c8))
-* Events with overlapping time visually overlap ([ae0cc82](https://github.com/nextcloud/calendar/commit/ae0cc8222105b07ff7aa62891333ab6b9a74d1d6))
-* external attachment dialog mounted warning ([3fd760f](https://github.com/nextcloud/calendar/commit/3fd760f2466d472760fce345f0e4da9fe8eee106))
-* **fc:** Adjust *today* border radius ([8dbff4c](https://github.com/nextcloud/calendar/commit/8dbff4c4b4ae5f4d58dc87982c68c3bd73bc96d8))
-* **fc:** adjust week day header border radius to new design ([e4dd483](https://github.com/nextcloud/calendar/commit/e4dd483879f8c053def835bbc1023799b5bbcee5))
-* **fc:** tiny white border on highlighted cells ([1017e40](https://github.com/nextcloud/calendar/commit/1017e40e4cc110c317f85ba6da12057db6278426))
-* **files:** fix misplaced empty content ([80e131a](https://github.com/nextcloud/calendar/commit/80e131a0900162d74a1373b6cda96d6502cd0388))
-* **files:** replace input fields with `NcTextField` ([31dd0e9](https://github.com/nextcloud/calendar/commit/31dd0e9bc4ff126aa52ec005d0d67aeab884e25a))
-* **FreeBusySlotService:** improve suggested slots ([aac9479](https://github.com/nextcloud/calendar/commit/aac9479f7176e75ea329fdc3c960eb76aab4efeb))
-* **FullCalendar CSS:** make events in weekly view have the correct width ([0dad0f8](https://github.com/nextcloud/calendar/commit/0dad0f80adc223418909783cd9a0dced79ae99a8))
-* handle timezones with no transitions properly ([991402f](https://github.com/nextcloud/calendar/commit/991402f8669db6508f3f525c1db35bf451f0cd0a))
-* Ignore existing attendee without email in search results ([58fb57b](https://github.com/nextcloud/calendar/commit/58fb57b856cfababeebaa32cc6d2f737a17eb2e0))
-* Ignore VScode IDE directory ([ba60a11](https://github.com/nextcloud/calendar/commit/ba60a1190a2ff000e7c553bc6069f43ac62f0ad3))
-* input label warnings ([bc58a38](https://github.com/nextcloud/calendar/commit/bc58a38efb336bb536b644470b0318f4fbedc985))
-* **InviteesListSearch:** make avatar status not clip ([3cfb3a2](https://github.com/nextcloud/calendar/commit/3cfb3a24726bb4a75741f19aef874baf0df5c9f6))
-* **l10n:** propfind error message translation source ([343fe47](https://github.com/nextcloud/calendar/commit/343fe476439551e79167906e111155fecf491783))
-* make call token extraction more robust ([401f674](https://github.com/nextcloud/calendar/commit/401f674a92c41248fdd383f8da386c382ca8ecde))
-* make sidebar tabs spacing consistent ([bc2cc6d](https://github.com/nextcloud/calendar/commit/bc2cc6d5ad1046a65ae5c5431a184f28bb37972f))
-* missing default props warnings ([4ca0dca](https://github.com/nextcloud/calendar/commit/4ca0dca377b1a6d5d2113fef6dd8f1d0790ae449))
-* modified unit test to include arguments ([c8626fb](https://github.com/nextcloud/calendar/commit/c8626fb8c3986a01901cdd91a7f1f0ec34d249a4))
-* navigation when clicking on the grid on a custom week/month ([209bb44](https://github.com/nextcloud/calendar/commit/209bb44eec28e3ff77dc1d15bda3f6023b3269e4))
-* **navigation:** scope all styles to the calendar app ([307a265](https://github.com/nextcloud/calendar/commit/307a26546e66e5676edb1df9e9c928948cef14a1))
-* **notifications:** Notifier::prepare() threw \InvalidArgumentException which is deprecated ([2ab1b8f](https://github.com/nextcloud/calendar/commit/2ab1b8f033f09cd39d723875f8d7aa6c9061d51d))
-* php lint complaints ([0b9f4cb](https://github.com/nextcloud/calendar/commit/0b9f4cb7311549f3cfd3571b9fe6dec66626c355))
-* phpUnit required time zone object not string ([3c369e4](https://github.com/nextcloud/calendar/commit/3c369e44706a2ab18f62a5a26b1e53468fe4fb81))
-* popover custom trigger warnings ([b8b6490](https://github.com/nextcloud/calendar/commit/b8b6490272b6140d983050c7933f1009eec07ba6))
-* **PropertyColor:** now color is selected with submit button instead of directly ([16ebe41](https://github.com/nextcloud/calendar/commit/16ebe4165f2b403477d2a4f362e7fed9d99d72e2))
-* recurrance selection ([3927688](https://github.com/nextcloud/calendar/commit/3927688e749ff1a3ce28bf5e04bd5087f764b09a))
-* recurrance until selection ([692ea9e](https://github.com/nextcloud/calendar/commit/692ea9e605e340392eb187a8c496d73f6eea20e1))
-* **release:** Fix wget output option ([f77d285](https://github.com/nextcloud/calendar/commit/f77d285fe4a54d8fde47af5fb1d594af49ae13dc))
-* **release:** Ignore unnecessary files ([30efafe](https://github.com/nextcloud/calendar/commit/30efafe12b53d22779606dab000f5c2eae80a43c))
-* **rtl:** align event title ([9bc72ad](https://github.com/nextcloud/calendar/commit/9bc72adfad0e6e18268a7afb650b475853418999))
-* **rtl:** invitees list ([1a4c008](https://github.com/nextcloud/calendar/commit/1a4c008bbbbe1a228908491c39714bda7a201246))
-* **rtl:** navigation buttons ([4f88b3c](https://github.com/nextcloud/calendar/commit/4f88b3c0e9104ebcea017105dd5f724fa9f3e347))
-* **scheduling:** Find attendee via email ([3c0ec2a](https://github.com/nextcloud/calendar/commit/3c0ec2ade0541729384f3e2c7807db48783f22f6))
-* scope global sidebar styles to the app ([2460c53](https://github.com/nextcloud/calendar/commit/2460c539e8b7fdd0b867012006e0f0484ba91d48))
-* send date as sting instead of epoch ([91d787c](https://github.com/nextcloud/calendar/commit/91d787ca37af9ecf3c06d2dfdc22e8018a9b8111))
-* send requestee and requester correct date and time when timezones differ [#5198](https://github.com/nextcloud/calendar/issues/5198) ([01e7e2d](https://github.com/nextcloud/calendar/commit/01e7e2d68a6610d33f77d82b089890d19c5a3969))
-* **settings:** adjust design of import button ([911d5b9](https://github.com/nextcloud/calendar/commit/911d5b93be0b26aa7245e061fc9f741f2d37aff0))
-* **Settings:** invert edit simple checkbox ([761a6cb](https://github.com/nextcloud/calendar/commit/761a6cba7f1c0330847b02c9f66056302a61c293))
-* sidebar editor tab scrolling ([9cb56bd](https://github.com/nextcloud/calendar/commit/9cb56bd2f74c66808cffcee612c03ada1b12ea7c))
-* **teams:** resolve undefined variable error and add logging ([9d1688c](https://github.com/nextcloud/calendar/commit/9d1688c87b4fdf77d66d97c49458dd8334f0a9b7))
-* thrown error on json decoding errors ([2f5c5ba](https://github.com/nextcloud/calendar/commit/2f5c5baa66c1c065e5b231bcfc82d1d27d737b5d))
-* time zone picker when using the simple editor ([dd4d83c](https://github.com/nextcloud/calendar/commit/dd4d83ca787b667db5f4c477ad7fab3654437183))
-* update calendar sharing icon ([55cb697](https://github.com/nextcloud/calendar/commit/55cb69718bf0cc76d2c105eeb6b533ab7d00009a))
-* use first day of week setting from server ([3203378](https://github.com/nextcloud/calendar/commit/3203378112f9a681061ab5bb2837197d0633b597))
-* use folder icon as fallback ([a099e7b](https://github.com/nextcloud/calendar/commit/a099e7bf7409bb4d4222cc62fc23d06861c30c00))
-
-
-### Features
-
-* add organizer selection ([cbfbda2](https://github.com/nextcloud/calendar/commit/cbfbda2468e3f1de864a06a1d8bb4c65cbf8d11f))
-* allow inviting contact groups ([7f70db9](https://github.com/nextcloud/calendar/commit/7f70db9929144ab31afe169d3ac6d68816e74447))
-* Allow shared calendars as appointment conflict calendars ([c08f7d1](https://github.com/nextcloud/calendar/commit/c08f7d1ada4c0547c98343ded48c69f0f9c5221f))
-* **appointments:** add timezone to all emails ([d30e6a7](https://github.com/nextcloud/calendar/commit/d30e6a78288a535e5b7385564881bf15a9923cc9))
-* **CalendarList:** fix dragging to order calendars ([619f4f0](https://github.com/nextcloud/calendar/commit/619f4f0e9f93788e7c0c43c379544493cc531603))
-* **dashboard:** reload widget once every 10 minutes ([af94950](https://github.com/nextcloud/calendar/commit/af94950cbd81445e64f6b70dc7429a207175e356))
-* **DatePicker:** use native date and time picker ([7ed3e6e](https://github.com/nextcloud/calendar/commit/7ed3e6ea1960c0663d69ec2fc8a3b3076fe86b4c))
-* **deps:** Add Nextcloud 30 support ([00ba483](https://github.com/nextcloud/calendar/commit/00ba4834f000ed4df81cafb659c8926919ab6929))
-* disable autocompletion for event property field ([cc04b57](https://github.com/nextcloud/calendar/commit/cc04b577ccfb404a16bfec8fe929b045d479f4a8))
-* **editor:** allow adding attendees in simple editor ([7953d6a](https://github.com/nextcloud/calendar/commit/7953d6adf8372ac2b1a79926dc28212cb16bfb2e))
-* implement resources and rooms overview ([8b09651](https://github.com/nextcloud/calendar/commit/8b0965144982eb3f35a4379c9d35febb217858ea))
-* improve sidebar organization ([6bebd61](https://github.com/nextcloud/calendar/commit/6bebd61e442ef70e748c1f3962e128c1c53f46ec))
-* improve the description text ([8f9e504](https://github.com/nextcloud/calendar/commit/8f9e5048c693190d99bea9aadd0001f082ad7aae))
-* rebrand circles to teams in calendar sharing modal ([27f98ba](https://github.com/nextcloud/calendar/commit/27f98ba8aeca3541122cae949924d203e0758df9))
-* reduce header sizes in calendar modal ([3bd39a1](https://github.com/nextcloud/calendar/commit/3bd39a13cc2e070f82523582389004eab6edc780))
-* reduce opacitiy for past events ([3fa906b](https://github.com/nextcloud/calendar/commit/3fa906b67c54fb426b87fed8d41137c840f79daa))
-* refresh calenders on remote changes ([6d1a23d](https://github.com/nextcloud/calendar/commit/6d1a23d2ac17226bd7f7495303bbe21a696892cc))
-* require caldav backend ([5b3293f](https://github.com/nextcloud/calendar/commit/5b3293fabf2e0c7a05dcf5dbae8e6df3e4dd9b0b))
-* update to php8.1 ([1917636](https://github.com/nextcloud/calendar/commit/1917636fe5d8c30b7cdc95a493350aeb9631736f))
-
-
-
-# [4.7.0-beta4](https://github.com/nextcloud/calendar/compare/v4.7.0-beta3...v4.7.0-beta4) (2024-03-20)
-
-
-### Bug Fixes
-
-* add VTIMEZONE to Appointments ([496896a](https://github.com/nextcloud/calendar/commit/496896a34daa2b728d659708d083af55d3158565))
-* **appointments:** add date to booking detail view ([eeacfa6](https://github.com/nextcloud/calendar/commit/eeacfa694adeed2de9e3286c3e3b8c54ec5d7fc1))
-* **appointments:** allow 5 minute increments for rounding in slot bookings ([37b2047](https://github.com/nextcloud/calendar/commit/37b20472427614af913a081ee8ad8431f9bda731))
-* **appointments:** Decide rounding by increment OR length ([e49e4a6](https://github.com/nextcloud/calendar/commit/e49e4a6e9431dc5aefa94277a26d4c6988b37a0b))
-* **appointments:** Fix button style ([da06ac5](https://github.com/nextcloud/calendar/commit/da06ac5986022b6849666e571c7525488ef6e7f1))
-* **appointments:** Make rooms public ([d39352f](https://github.com/nextcloud/calendar/commit/d39352f9a2638691b0cffa461ebd8ad7710ffa13))
-* **appointments:** Rate limit config creation and booking ([0f77b41](https://github.com/nextcloud/calendar/commit/0f77b41942d67c58daccdac1ff3a7f80d3b569a7))
-* **appointments:** slot generation deviation for increments that don't fit modulo ([0176063](https://github.com/nextcloud/calendar/commit/0176063a82c78c3970f146552b2d45f4a22197e1))
-* **appointments:** Write Talk link to event ([dcb2524](https://github.com/nextcloud/calendar/commit/dcb2524ecc77801a6e06dbd5e50d05b10cdde87e))
-* **attachments:** Convert FileList to array ([d8ed0ff](https://github.com/nextcloud/calendar/commit/d8ed0ffab5a499ecb7c26f8b6ac82d2d961c89ee))
-* **attachments:** folder picker opening twice ([d520471](https://github.com/nextcloud/calendar/commit/d52047176599cbe5f14e58b8c5d854996ff38793))
-* **dashboard:** properly handle recurring events ([babc444](https://github.com/nextcloud/calendar/commit/babc444245f6e6cef2fd1a88773532074c9cad0e))
-* default calendar picker search and make it not clearable ([9dcc3bb](https://github.com/nextcloud/calendar/commit/9dcc3bbeca324867eb6126f0106f45af7f452d63))
-* **deps:** bump @nextcloud/auth from 2.1.0 to ^2.2.1 (main) ([#5522](https://github.com/nextcloud/calendar/issues/5522)) ([884bf79](https://github.com/nextcloud/calendar/commit/884bf79a6da0bc07a1085662e498ee043367d2f3))
-* **deps:** bump @nextcloud/calendar-availability-vue from 1.0.0 to ^1.0.1 (main) ([#5520](https://github.com/nextcloud/calendar/issues/5520)) ([ab04d3a](https://github.com/nextcloud/calendar/commit/ab04d3aa73af11963ccf52b9a7dbcee9c212b8bc))
-* **deps:** bump @nextcloud/calendar-availability-vue from 2.1.0 to ^2.2.0 ([205dbcb](https://github.com/nextcloud/calendar/commit/205dbcb93ca78e836d1006a75af6668e38190daf))
-* **deps:** bump @nextcloud/calendar-js from 6.0.1 to ^6.1.0 (main) ([#5562](https://github.com/nextcloud/calendar/issues/5562)) ([066f9d9](https://github.com/nextcloud/calendar/commit/066f9d9b97c7ae7a4e953f41ea55ae01a7597ce6))
-* **deps:** bump @nextcloud/dialogs from 4.1.0 to ^4.2.0-beta.2 (main) ([#5415](https://github.com/nextcloud/calendar/issues/5415)) ([2eb9c0a](https://github.com/nextcloud/calendar/commit/2eb9c0aefecfbf72a0ab8832d49bf2aef9e0767d))
-* **deps:** bump @nextcloud/dialogs from 4.2.0 to ^4.2.1 (main) ([#5493](https://github.com/nextcloud/calendar/issues/5493)) ([940bafa](https://github.com/nextcloud/calendar/commit/940bafaccb6f6d83198abf9cacf2bcc14fd636c9))
-* **deps:** bump @nextcloud/dialogs from 4.2.0-beta.2 to ^4.2.0-beta.3 (main) ([#5423](https://github.com/nextcloud/calendar/issues/5423)) ([bf1aab4](https://github.com/nextcloud/calendar/commit/bf1aab4152b8b5f1bdd083d767977523eab06933))
-* **deps:** bump @nextcloud/dialogs from 4.2.0-beta.3 to ^4.2.0-beta.4 (main) ([#5428](https://github.com/nextcloud/calendar/issues/5428)) ([75e3294](https://github.com/nextcloud/calendar/commit/75e3294154b25445cec918586414f8de151df724))
-* **deps:** bump @nextcloud/dialogs from 4.2.0-beta.4 to ^4.2.0 (main) ([#5452](https://github.com/nextcloud/calendar/issues/5452)) ([d717473](https://github.com/nextcloud/calendar/commit/d717473e6917b120b379170a313787402b715c29))
-* **deps:** bump @nextcloud/dialogs from 4.2.1 to ^4.2.2 (main) ([#5576](https://github.com/nextcloud/calendar/issues/5576)) ([fe03d46](https://github.com/nextcloud/calendar/commit/fe03d463615a6092bbb2ed9661848b0b45b63cb9))
-* **deps:** bump @nextcloud/dialogs from 4.2.2 to ^4.2.3 (main) ([#5711](https://github.com/nextcloud/calendar/issues/5711)) ([58df3da](https://github.com/nextcloud/calendar/commit/58df3da170679b1f04c5025fb7f9d44f0528a122))
-* **deps:** bump @nextcloud/dialogs from 4.2.3 to ^4.2.4 (main) ([#5725](https://github.com/nextcloud/calendar/issues/5725)) ([5728a3d](https://github.com/nextcloud/calendar/commit/5728a3d0eb12985cc7317f554b7c159572543d85))
-* **deps:** bump @nextcloud/dialogs from 4.2.4 to ^4.2.5 (main) ([#5740](https://github.com/nextcloud/calendar/issues/5740)) ([c7f5aa9](https://github.com/nextcloud/calendar/commit/c7f5aa9141d16908d230a8936823a4b3d30f2404))
-* **deps:** bump @nextcloud/dialogs from 4.2.5 to ^4.2.6 (main) ([#5803](https://github.com/nextcloud/calendar/issues/5803)) ([27a33d8](https://github.com/nextcloud/calendar/commit/27a33d85d1702f41002b81345ef7ec50f46e6f6b))
-* **deps:** bump @nextcloud/logger from 2.5.0 to ^2.7.0 (main) ([#5523](https://github.com/nextcloud/calendar/issues/5523)) ([c53bde0](https://github.com/nextcloud/calendar/commit/c53bde0f16ef4c234de0362078b69b065ae52312))
-* **deps:** bump @nextcloud/moment from 1.2.1 to ^1.2.2 (main) ([#5535](https://github.com/nextcloud/calendar/issues/5535)) ([b91ec46](https://github.com/nextcloud/calendar/commit/b91ec469238824627a941990e4068b5298468286))
-* **deps:** bump @nextcloud/moment from 1.2.2 to ^1.3.1 (main) ([#5699](https://github.com/nextcloud/calendar/issues/5699)) ([9382732](https://github.com/nextcloud/calendar/commit/93827329ed2651d2f37a9396be0766186a6e3943))
-* **deps:** bump @nextcloud/router from 2.1.2 to ^2.2.0 (main) ([#5548](https://github.com/nextcloud/calendar/issues/5548)) ([ffa118b](https://github.com/nextcloud/calendar/commit/ffa118b2302803a6a70652ca1bd8a097d8a5197e))
-* **deps:** bump @nextcloud/router from 2.2.0 to ^2.2.1 (main) ([#5726](https://github.com/nextcloud/calendar/issues/5726)) ([28d5a02](https://github.com/nextcloud/calendar/commit/28d5a029d4ab36ee11580b72605aa2448622a702))
-* **deps:** bump @nextcloud/router from 2.2.1 to v3 ([fa9c2a1](https://github.com/nextcloud/calendar/commit/fa9c2a126eb345cc46b5c92ad79e1220ab88f3bb))
-* **deps:** bump @nextcloud/vue from 7.12.1 to ^7.12.2 ([b6e4fae](https://github.com/nextcloud/calendar/commit/b6e4faeccc12c03e72958c49610562fcd96e5587))
-* **deps:** bump @nextcloud/vue from 7.12.2 to ^7.12.4 ([0462476](https://github.com/nextcloud/calendar/commit/04624765597a266563207970b2a6816643fb7f07))
-* **deps:** bump @nextcloud/vue from 7.12.4 to ^7.12.5 ([f05aee2](https://github.com/nextcloud/calendar/commit/f05aee245fb1fa393dbe82ab7f748c62e79bc650))
-* **deps:** bump @nextcloud/vue from 7.12.5 to ^7.12.6 ([aa7c81d](https://github.com/nextcloud/calendar/commit/aa7c81d956ee56ec432f93ad9d9c2f971b7a2b09))
-* **deps:** bump @nextcloud/vue from 7.12.6 to ^7.12.7 ([7bc57a8](https://github.com/nextcloud/calendar/commit/7bc57a8d49616302b6a6057f0182b9d490252a28))
-* **deps:** bump @nextcloud/vue from 8.6.2 to ^8.7.0 ([eb7c054](https://github.com/nextcloud/calendar/commit/eb7c05436be67c59be1a3755d40c90f770f82101))
-* **deps:** bump @nextcloud/vue from 8.7.0 to ^8.7.1 ([7833b1e](https://github.com/nextcloud/calendar/commit/7833b1ea4a29903e58b078d2d9ffdb462d3ba007))
-* **deps:** bump core-js from 3.32.0 to ^3.32.1 (main) ([#5430](https://github.com/nextcloud/calendar/issues/5430)) ([0b8ec0d](https://github.com/nextcloud/calendar/commit/0b8ec0da85a3d6605953dc53161396fdd5050c1a))
-* **deps:** bump core-js from 3.32.1 to ^3.32.2 (main) ([#5470](https://github.com/nextcloud/calendar/issues/5470)) ([df6b600](https://github.com/nextcloud/calendar/commit/df6b600e118cdd5631e2a46c4e6ede773ac5b620))
-* **deps:** bump core-js from 3.32.2 to ^3.33.0 (main) ([#5524](https://github.com/nextcloud/calendar/issues/5524)) ([63fd15e](https://github.com/nextcloud/calendar/commit/63fd15e585c49ada7b4da5b369d58706b6508ae9))
-* **deps:** bump core-js from 3.33.0 to ^3.33.1 (main) ([#5546](https://github.com/nextcloud/calendar/issues/5546)) ([b6446c4](https://github.com/nextcloud/calendar/commit/b6446c41b508384c39c61ace250f5af7e200eae7))
-* **deps:** bump core-js from 3.33.1 to ^3.33.2 (main) ([#5558](https://github.com/nextcloud/calendar/issues/5558)) ([4315fbf](https://github.com/nextcloud/calendar/commit/4315fbf61af061da2b5f17ac0086f383b34ed274))
-* **deps:** bump core-js from 3.33.2 to ^3.33.3 (main) ([#5585](https://github.com/nextcloud/calendar/issues/5585)) ([c6b1ed3](https://github.com/nextcloud/calendar/commit/c6b1ed34ba69e09ffab2e32b7f8a40b01bcaa917))
-* **deps:** bump core-js from 3.33.3 to ^3.34.0 (main) ([#5626](https://github.com/nextcloud/calendar/issues/5626)) ([0648771](https://github.com/nextcloud/calendar/commit/0648771a9fe4fd111e7cd90516b7b66e50afd960))
-* **deps:** bump core-js from 3.34.0 to ^3.35.0 (main) ([#5661](https://github.com/nextcloud/calendar/issues/5661)) ([5e60295](https://github.com/nextcloud/calendar/commit/5e60295d0e74712d7b420e5dacabed83cda62e53))
-* **deps:** bump core-js from 3.35.0 to ^3.35.1 (main) ([#5712](https://github.com/nextcloud/calendar/issues/5712)) ([84e98c6](https://github.com/nextcloud/calendar/commit/84e98c6baaf95299e17b4afe592bd310e5f137ef))
-* **deps:** bump core-js from 3.35.1 to ^3.36.0 (main) ([#5811](https://github.com/nextcloud/calendar/issues/5811)) ([752b87e](https://github.com/nextcloud/calendar/commit/752b87eb99b4190933cd639cb0d3e7d60d63f697))
-* **deps:** bump core-js from 3.36.0 to ^3.36.1 (main) ([#5858](https://github.com/nextcloud/calendar/issues/5858)) ([59fe5d0](https://github.com/nextcloud/calendar/commit/59fe5d0cacc0eff31336ed3ce99505587b49e4fb))
-* **deps:** bump debounce from 1.2.1 to v2 ([dba8c91](https://github.com/nextcloud/calendar/commit/dba8c91c4e105daa6da6f31168e72923a641485d))
-* **deps:** bump fullcalendar family from 6.1.10 to v6.1.11 ([82b6908](https://github.com/nextcloud/calendar/commit/82b6908b6aac573aa9539caab348144d8b28c146))
-* **deps:** bump fullcalendar family from 6.1.8 to v6.1.9 ([7d484a9](https://github.com/nextcloud/calendar/commit/7d484a9fa92356a0db0289e2e32e27d35d1fa4ec))
-* **deps:** bump fullcalendar family from 6.1.9 to v6.1.10 ([6d29805](https://github.com/nextcloud/calendar/commit/6d298059ce9bc6e35a1542a82406bce77bf12f19))
-* **deps:** bump linkifyjs from 4.1.1 to ^4.1.2 (main) ([#5577](https://github.com/nextcloud/calendar/issues/5577)) ([1e2df09](https://github.com/nextcloud/calendar/commit/1e2df0964a24a009d8a5fd7b0877480ffaefeec9))
-* **deps:** bump linkifyjs from 4.1.2 to ^4.1.3 (main) ([#5610](https://github.com/nextcloud/calendar/issues/5610)) ([fe924ae](https://github.com/nextcloud/calendar/commit/fe924ae3694da8ee9efa92bbcfac3ebad6887322))
-* **deps:** bump p-limit from 4.0.0 to v5 ([a8120b9](https://github.com/nextcloud/calendar/commit/a8120b90f6c30cc1bffb15fdbd63251509405565))
-* **deps:** bump vue monorepo from 2.7.14 to ^2.7.15 (main) ([#5547](https://github.com/nextcloud/calendar/issues/5547)) ([d6f7259](https://github.com/nextcloud/calendar/commit/d6f72593b56f786ebdca8540836935ad44c2864d))
-* **deps:** bump vue monorepo from 2.7.15 to ^2.7.16 (main) ([#5623](https://github.com/nextcloud/calendar/issues/5623)) ([2e712e6](https://github.com/nextcloud/calendar/commit/2e712e65cc1f5524e93af46f87c84ac76238e0c0))
-* **deps:** bump vue-material-design-icons from 5.2.0 to ^5.3.0 (main) ([#5728](https://github.com/nextcloud/calendar/issues/5728)) ([38ebbcf](https://github.com/nextcloud/calendar/commit/38ebbcf3bcc647b909b2e8d4905c0964f086d04c))
-* **deps:** bump webdav from 5.2.3 to ^5.3.0 (main) ([#5453](https://github.com/nextcloud/calendar/issues/5453)) ([50ddadf](https://github.com/nextcloud/calendar/commit/50ddadf37b5b58dfbd17ca6e93f160807db94317))
-* **deps:** bump webdav from 5.3.0 to ^5.3.1 (main) ([#5624](https://github.com/nextcloud/calendar/issues/5624)) ([c1cdd74](https://github.com/nextcloud/calendar/commit/c1cdd7416d46a8447da385a28562cd6f02a8f736))
-* **deps:** bump webdav from 5.3.1 to ^5.3.2 (main) ([#5739](https://github.com/nextcloud/calendar/issues/5739)) ([50991fd](https://github.com/nextcloud/calendar/commit/50991fdc38b5b2bf7cd3e16d866b3603978acb82))
-* **deps:** bump webdav from 5.3.2 to ^5.4.0 (main) ([#5812](https://github.com/nextcloud/calendar/issues/5812)) ([07e87f4](https://github.com/nextcloud/calendar/commit/07e87f49d93dd19a160cc87aa382ebc2e410b5eb))
-* **deps:** bump webdav from 5.4.0 to ^5.5.0 (main) ([#5859](https://github.com/nextcloud/calendar/issues/5859)) ([6244af9](https://github.com/nextcloud/calendar/commit/6244af93bfca824ce32bfec5db25b1594a159fb6))
-* disable resharing of incoming shared calendars ([c370c11](https://github.com/nextcloud/calendar/commit/c370c1163af69926c48394dc4569fbf7b5e2fd61))
-* dont forward internal exceptions ([3b5ecd0](https://github.com/nextcloud/calendar/commit/3b5ecd08ff8fc7bc7fa502cef5a0dd652447967a))
-* **editor:** bring back the three-dot menu ([de1cf84](https://github.com/nextcloud/calendar/commit/de1cf849af30518efd22d32e8f88af93bef00cb1))
-* **editor:** convert start date to user's tz for the sub line ([0716226](https://github.com/nextcloud/calendar/commit/0716226f34af38060a03021eb22988365e537911))
-* **editor:** grow save buttons and change their order ([f2e6975](https://github.com/nextcloud/calendar/commit/f2e6975f29225326ece58d6613a0ee8856a56948))
-* **editor:** show placeholder if an event's title is empty ([b6383fe](https://github.com/nextcloud/calendar/commit/b6383fe0908646bdc62d01dcf2fb04056a7ec245))
-* **editor:** top right actions not positioned properly ([af4e4c1](https://github.com/nextcloud/calendar/commit/af4e4c1fc19c07871d4fac24bcc1d0654e5cbd6e))
-* error handling for exceptions for recurrence next ([cc02049](https://github.com/nextcloud/calendar/commit/cc0204971a851819d32866543367c01ae290496c))
-* **freebusy:** free for all blocks ([fd46192](https://github.com/nextcloud/calendar/commit/fd4619256466e93f767443392e0ce77dd7f93c38))
-* kazakhstan holiday calendars ([66223fd](https://github.com/nextcloud/calendar/commit/66223fd8e8395d82be4c887bc9d6e04c8ab2ee8c))
-* missing public calendar initial state ([c9398b7](https://github.com/nextcloud/calendar/commit/c9398b72f7ff69461547cfdab1c8506af6d78d43))
-* move global sidebar style overrides to sfc ([d1edd61](https://github.com/nextcloud/calendar/commit/d1edd61e46254de5482d60994856013219af3c54))
-* restore original event ordering ([ded1f29](https://github.com/nextcloud/calendar/commit/ded1f294eb40f7299167fcb12c8d6cb63387c9bb)), closes [#4431](https://github.com/nextcloud/calendar/issues/4431) [#4646](https://github.com/nextcloud/calendar/issues/4646)
-* **scheduling:** Disable free/busy for attendees ([d9e67db](https://github.com/nextcloud/calendar/commit/d9e67dbb1b8106f8d028fce1246580c09937729c))
-* **scheduling:** Rephraze "Invitation sent" to "Awaiting response" ([5d4e3e2](https://github.com/nextcloud/calendar/commit/5d4e3e224dc47295ee75d4bb148ad63bff00e419))
-* **scheduling:** Use attendee placeholder avatars ([521b530](https://github.com/nextcloud/calendar/commit/521b5303e27dfdf793ccdbb94289e40ec393d131)), closes [#3099](https://github.com/nextcloud/calendar/issues/3099)
-* **sidebar:** hide alarm actions menu when starting to edit ([25a6f13](https://github.com/nextcloud/calendar/commit/25a6f1397a67ed6a84bb3e8c60b006d2056b95db))
-* **talk:** Do not invite guest participants ([e6e8c2a](https://github.com/nextcloud/calendar/commit/e6e8c2a531ae75c4223a5ea50036f75892715439))
-* update changelog v4.5.3 ([c0ade81](https://github.com/nextcloud/calendar/commit/c0ade818b857e458b3855267737d11e55fe6e2e0))
-* update holiday calendars ([5a45f89](https://github.com/nextcloud/calendar/commit/5a45f8916f3ff393636d664d62ee1f87c7c73751))
-
-
-### Features
-
-* Ability to invite circles ([df2d51b](https://github.com/nextcloud/calendar/commit/df2d51b66631c5149e5a4d7db73c0ccad60bb6fc))
-* Ability to render groups as attendees ([33e236c](https://github.com/nextcloud/calendar/commit/33e236c285513db01f1232722c5ea59974f332a7))
-* add a setting for the default calendar url ([7a307bb](https://github.com/nextcloud/calendar/commit/7a307bbcf0160ca9dd2202ccfe123d086de4c141))
-* **appointments:** show indicator when loading slots and show toast in case of error ([4d3172f](https://github.com/nextcloud/calendar/commit/4d3172f09773e6547b35a592eae3ffb11bc5354c))
-* **editors:** redesign editors ([3369fc8](https://github.com/nextcloud/calendar/commit/3369fc8ea9ac88e0344d9c91f12941585a7a60aa))
-* **scheduling:** Automate free/busy slot selection ([d47632e](https://github.com/nextcloud/calendar/commit/d47632eb0906de5be957fe6b8b0197af049564c0))
-* update info.xml and appversion ([1c32a12](https://github.com/nextcloud/calendar/commit/1c32a12b9c99e79ecdb49ec92db7923ab3fb0d61))
-
-
-### Performance Improvements
-
-* **bundles:** refactor @nextcloud/vue imports to use the esm bundle ([baeeae2](https://github.com/nextcloud/calendar/commit/baeeae244614586bbc3c1efd3233f26a84ec0a01))
-* **dashboard:** implement widget item api v2 ([a00f344](https://github.com/nextcloud/calendar/commit/a00f34419eed45d709082b3601cb995ca1855fed))
-
-
-### Reverts
-
-* Revert "fix(appointments): Ignore extraneous columns in AppointmentConfigMapper::findByToken" ([8838fba](https://github.com/nextcloud/calendar/commit/8838fba6c0c4be347ff0fa160f6a9dcaa3d216b5))
-* Augment the category menu by system tags and already used categories ([eae6dea](https://github.com/nextcloud/calendar/commit/eae6deada277e718a153a5ff48836f8dba509dd0))
-
-
-
-# [4.5.0-beta1](https://github.com/nextcloud/calendar/compare/v4.5.0-alpha2...v4.5.0-beta1) (2023-08-11)
-
-
-### Features
-
-* **editor:** make links clickable in locations and description areas ([8fa9d99](https://github.com/nextcloud/calendar/commit/8fa9d99ea7877f0355f357a6511d0698bcd9ad72))
-
-
-
-# [4.5.0-alpha2](https://github.com/nextcloud/calendar/compare/v4.5.0-alpha1...v4.5.0-alpha2) (2023-08-07)
-
-
-### Bug Fixes
-
-* add requistes link to README ([28ccf72](https://github.com/nextcloud/calendar/commit/28ccf729534b9362b1bb66584dc806172108b9f4))
-* Allow dynamic autoloading for classes added during upgrade ([c88cb60](https://github.com/nextcloud/calendar/commit/c88cb60b810fb2055db9b4806468de9926c359b6))
-* **appointements:** add context for translators for the talk room name string ([ac9e7e5](https://github.com/nextcloud/calendar/commit/ac9e7e5b03f6d9abb9b2d83010209f79ef9d754d)), closes [#5297](https://github.com/nextcloud/calendar/issues/5297)
-* **appointments:** calendar booking notifications ([a61f7a9](https://github.com/nextcloud/calendar/commit/a61f7a91559c5da569453b6ac6ded8d3e986faa8))
-* **appointments:** equalize slot booking button width ([7866b18](https://github.com/nextcloud/calendar/commit/7866b18e9a4655352e05443ee8f500ed5241ca77))
-* **appointments:** Fix disabling appointments feature ([f00ce71](https://github.com/nextcloud/calendar/commit/f00ce710d01089d85ff9f6b1df564de6fbbb66d8))
-* **appointments:** Ignore extraneous columns in AppointmentConfigMapper::findByToken ([94c93f1](https://github.com/nextcloud/calendar/commit/94c93f1f457d8fd4910d38cf6e80ef3d4caa0fd3))
-* **appointments:** set visibility to private by default ([e35ba35](https://github.com/nextcloud/calendar/commit/e35ba352eaf7fcb21b3eb4da6b8529884a8485b2))
-* **attachments:** generate proper urls to dav service ([ba04707](https://github.com/nextcloud/calendar/commit/ba047076d1d51c0f27295065a333084b011befee))
-* bring back advanced color picker fields ([3c987b5](https://github.com/nextcloud/calendar/commit/3c987b5184456bd5c438a0adf7a0dedba46f29a5))
-* calendar export button ([07b58ab](https://github.com/nextcloud/calendar/commit/07b58ab939dd166a33f589bae3857bb0bea2692b))
-* **categories:** fall back to empty array ([32fa3fa](https://github.com/nextcloud/calendar/commit/32fa3fa114c7611b41c1d61f0c6e3118c45556b1))
-* debounce calendar modal save and edit methods ([eef9e1b](https://github.com/nextcloud/calendar/commit/eef9e1b75af67e28375c10356e519f2533c5a25c))
-* **deps:** bump @nextcloud/axios from 2.3.0 to ^2.4.0 ([64fe74a](https://github.com/nextcloud/calendar/commit/64fe74ae5775c01b0e39435d6d3bb5a6a6ca6ff6))
-* **deps:** bump @nextcloud/calendar-availability-vue from 0.6.0-alpha1 to v1 ([a937482](https://github.com/nextcloud/calendar/commit/a937482c8c5e6daa4a1ca705e8c0ea431b2de4db))
-* **deps:** bump @nextcloud/dialogs from 4.0.1 to ^4.1.0 ([934f40b](https://github.com/nextcloud/calendar/commit/934f40b36da1f2c7d6e41996ed7b7d2707df6807))
-* **deps:** bump @nextcloud/initial-state from 2.0.0 to ^2.1.0 ([f28d5c4](https://github.com/nextcloud/calendar/commit/f28d5c44a97f00cd9f8a6800635b28c5289286a7))
-* **deps:** bump @nextcloud/l10n from 2.1.0 to ^2.2.0 ([bc18ffa](https://github.com/nextcloud/calendar/commit/bc18ffaaffe7fd7b6c3608bc78b57d0dce95aa44))
-* **deps:** bump @nextcloud/router from 2.1.1 to ^2.1.2 ([63a9f41](https://github.com/nextcloud/calendar/commit/63a9f411ba51b0a1cbdf9d83cd85b1fbcd912ce5))
-* **deps:** bump @nextcloud/vue from 7.11.6 to ^7.12.0 ([9ac0475](https://github.com/nextcloud/calendar/commit/9ac047536cbc9b1818d422321f832ce8b4188426))
-* **deps:** bump @nextcloud/vue from 7.12.0 to ^7.12.1 ([8e0ac6f](https://github.com/nextcloud/calendar/commit/8e0ac6f393cd2901d12206776826010d75d3a1aa))
-* **deps:** bump bamarni/composer-bin-plugin from 1.8.2 to ^1.8.2 ([b46131d](https://github.com/nextcloud/calendar/commit/b46131de549349ead6bad4a8c0187377371a4e40))
-* **deps:** bump core-js from 3.30.2 to ^3.31.0 ([1c029d1](https://github.com/nextcloud/calendar/commit/1c029d10b907ec16141628e1083c07a6d29fbb2c))
-* **deps:** bump core-js from 3.31.0 to ^3.31.1 ([bb4b86a](https://github.com/nextcloud/calendar/commit/bb4b86a9141aa0453b667f5803f16d6ee79d8db7))
-* **deps:** bump core-js from 3.31.1 to ^3.32.0 (main) ([#5388](https://github.com/nextcloud/calendar/issues/5388)) ([4dc430f](https://github.com/nextcloud/calendar/commit/4dc430fa3f563b7827a97796313618a472d84525))
-* **deps:** bump webdav from 5.0.0 to ^5.1.0 ([882008f](https://github.com/nextcloud/calendar/commit/882008fc59139d9cabdf9dd4360886f986332543))
-* **deps:** bump webdav from 5.1.0 to ^5.2.1 ([f41a986](https://github.com/nextcloud/calendar/commit/f41a986f9ca56b3d7f4fb13dd5dacb54153755f8))
-* **deps:** bump webdav from 5.2.1 to ^5.2.2 ([1e9a34d](https://github.com/nextcloud/calendar/commit/1e9a34dad7747d9996ac208ec30ff4dbba43c179))
-* **deps:** bump webdav from 5.2.2 to ^5.2.3 ([302b84a](https://github.com/nextcloud/calendar/commit/302b84a0c273f9e930164d3554ecea4cb02947d9))
-* **deps:** pin dependencies ([9ae057a](https://github.com/nextcloud/calendar/commit/9ae057afcd6512643e6802b6bd46d42a43a711a8))
-* **duplicateEvent:** Open duplicate in sidebar not original ([3dfd7fa](https://github.com/nextcloud/calendar/commit/3dfd7fab060fa534d066e26e54c06929ba13cffe))
-* improve grammar ([edfe0d5](https://github.com/nextcloud/calendar/commit/edfe0d54ab098330aad7487ea8ac72469f213171))
-* indicate if calendar is shared by me ([0e609c6](https://github.com/nextcloud/calendar/commit/0e609c6a8af590d88d65f17b35916943537552d0))
-* **public-embed:** Fix header showing on embed view ([ff17233](https://github.com/nextcloud/calendar/commit/ff17233536ae5ff2a7796a06818ff6f6bc71aee6))
-* **Public-Sharing:** Show footer with server details and eventual ToS through PublicTemplateResponse ([3a42cf6](https://github.com/nextcloud/calendar/commit/3a42cf6ced848c7a7d4f697540558f9a1f9c6c43))
-* **settings:** Fix link to personal availability settings depending on NC version ([df16051](https://github.com/nextcloud/calendar/commit/df16051b84f616bf4ad1375d2e7ee0e65e25591b)), closes [#5226](https://github.com/nextcloud/calendar/issues/5226)
-* **sharing:** skip long email addresses ([7899440](https://github.com/nextcloud/calendar/commit/7899440bbbf1a7ab9d68749595668e335cbc4913))
-* sidebar editor subtitle not respecting event's timezone ([de03f3b](https://github.com/nextcloud/calendar/commit/de03f3bc1f90e2dee797b21ec6d3caecefd3d2d9))
-* userAsAttendee failing in case of public links ([e9c0ba9](https://github.com/nextcloud/calendar/commit/e9c0ba997670007a3faaeb14f84ae829e2ca44f3))
-
-
-### Features
-
-* Add link to the Thunderbird holiday calendar page ([5f071dd](https://github.com/nextcloud/calendar/commit/5f071dd393be332d94416f0d5cc2481c45652bec))
-* **alarms:** improve email alarm RFC compliance ([150cc29](https://github.com/nextcloud/calendar/commit/150cc2976db52ce61f0ef394e148029adc2fc975))
-* **appointments:** Disable the booking button while loading ([#5244](https://github.com/nextcloud/calendar/issues/5244)) ([da158a0](https://github.com/nextcloud/calendar/commit/da158a07a753acf1c990db9174ce38835c117b3e))
-* **deps:** Revive PHP7.4 support ([5d88b22](https://github.com/nextcloud/calendar/commit/5d88b229fce11c485d7c72ff0ab5b60f30b9eb8d))
-* **editor:** implement app config to hide resources tab ([28d672c](https://github.com/nextcloud/calendar/commit/28d672c368a6fd27c40c9a06f4215d7ec2a716cb))
-* implement dedicated calendar modal save button ([f8d52c8](https://github.com/nextcloud/calendar/commit/f8d52c83ba98b451db5ae619868dc49a0b64f464))
-* migrate trash bin buttons to NcButton ([34577d2](https://github.com/nextcloud/calendar/commit/34577d2b50836eebdeea5f0da504701b368a4285))
-* support Nextcloud 28 ([da70650](https://github.com/nextcloud/calendar/commit/da70650ba9ec699225e15288d9ceb7b0b1eaa322))
-* **talkintegration:** Set Talk conversation description ([9f53311](https://github.com/nextcloud/calendar/commit/9f5331141485232e3351daa0efaacca13e9d3868))
-* **talk:** Make event attendees Talk room participants ([8820948](https://github.com/nextcloud/calendar/commit/8820948844096cf165d41abef315f07dea91eccd))
-* **view:** Introduce year grid view (with FC multiMonthYear plugin) ([e4ab210](https://github.com/nextcloud/calendar/commit/e4ab21072bc8f872ad879d1673f127b322dd7312)), closes [#159](https://github.com/nextcloud/calendar/issues/159)
-* **webcal:** Name button *Subscribed* for existing calendars ([d66843d](https://github.com/nextcloud/calendar/commit/d66843d3c4383db68b7ed24a6858c078371d7d14))
-* **webcal:** Thunderbird holiday subscription picker ([1de6116](https://github.com/nextcloud/calendar/commit/1de611697ddbcb3fb441e40da791e1cf1f467c7a))
-* Write Talk URL into location, not description ([7f39c7b](https://github.com/nextcloud/calendar/commit/7f39c7b7dc2690d3bd7532cceb1090d7f4e097b4))
-
-
-### Performance Improvements
-
-* **autoloader:** Use Composer's authoritative classmap ([0eb41dc](https://github.com/nextcloud/calendar/commit/0eb41dc1bc2d72a91eb59375c38a36edfd29e97b))
-* Lazy load dashboard components ([e927aa5](https://github.com/nextcloud/calendar/commit/e927aa543df8183e5a084441d69ee6780c1a7257))
-
-
-### Reverts
-
-* Revert "Create Talk rooms for appointments" ([5b9c879](https://github.com/nextcloud/calendar/commit/5b9c8796e904004d5a40f8a1f02469fa6615ef06))
-* Revert "Create command-rebase.yml" ([8ffc2df](https://github.com/nextcloud/calendar/commit/8ffc2dfd0f852ad20d74c09731a00a824e6e77e8))
-* Revert "Move event rendering to vue" ([ca2abbb](https://github.com/nextcloud/calendar/commit/ca2abbb2e82a753bcd6b5bbf34561b862819c955))
-* Revert "Show icon for events with attendees" ([7582e1c](https://github.com/nextcloud/calendar/commit/7582e1c75fd9e9fb5d0c1c2f457f01fa21c8d278))
-* Revert "Fix events being editable by invitees" ([cb92d5c](https://github.com/nextcloud/calendar/commit/cb92d5c478819cb86f2dc801f27f6ef6178f9f80))
-
-
-
-# [3.0.0-rc1](https://github.com/nextcloud/calendar/compare/v3.0.0-beta2...v3.0.0-rc1) (2021-11-26)
-
-
-
-# [3.0.0-beta2](https://github.com/nextcloud/calendar/compare/v3.0.0-beta1...v3.0.0-beta2) (2021-11-26)
-
-
-
-# [3.0.0-beta1](https://github.com/nextcloud/calendar/compare/v2.4.0-rc2...v3.0.0-beta1) (2021-11-25)
-
-
-
-# [2.4.0-rc2](https://github.com/nextcloud/calendar/compare/v2.4.0-rc.1...v2.4.0-rc2) (2021-11-15)
-
-
-
-# [2.4.0-rc.1](https://github.com/nextcloud/calendar/compare/v2.3.0-RC.1...v2.4.0-rc.1) (2021-11-09)
-
-
-
-# [2.3.0-RC.1](https://github.com/nextcloud/calendar/compare/v2.3.0-alpha.3...v2.3.0-RC.1) (2021-06-22)
-
-
-
-# [2.3.0-alpha.3](https://github.com/nextcloud/calendar/compare/v2.3.0-alpha.2...v2.3.0-alpha.3) (2021-06-04)
-
-
-
-# [2.3.0-alpha.2](https://github.com/nextcloud/calendar/compare/v2.3.0-alpha.1...v2.3.0-alpha.2) (2021-06-01)
-
-
-
-# [2.3.0-alpha.1](https://github.com/nextcloud/calendar/compare/v2.2.0...v2.3.0-alpha.1) (2021-06-01)
-
-
-### Reverts
-
-* Revert "Add Dependabot for stable2.2" ([9697327](https://github.com/nextcloud/calendar/commit/9697327072cef227f1c414c0764b287402ef66a7))
-
-
-
-# [2.2.0](https://github.com/nextcloud/calendar/compare/v2.1.3...v2.2.0) (2021-03-24)
-
-
-
-## [2.1.3](https://github.com/nextcloud/calendar/compare/v2.1.2...v2.1.3) (2021-01-04)
-
-
-
-## [2.1.2](https://github.com/nextcloud/calendar/compare/v2.1.1...v2.1.2) (2020-09-24)
-
-
-### Reverts
-
-* Revert "Bump css-loader from 3.6.0 to 4.2.0" ([c128a1f](https://github.com/nextcloud/calendar/commit/c128a1fabe52eabca84f4ee78fb6b31c39dcce0d))
-
-
-
-## [1.6.3](https://github.com/nextcloud/calendar/compare/v1.6.2...v1.6.3) (2018-10-16)
-
-
-
-## [1.6.2](https://github.com/nextcloud/calendar/compare/v1.6.1...v1.6.2) (2018-09-05)
-
-
-
-## [1.6.1](https://github.com/nextcloud/calendar/compare/v1.6.0...v1.6.1) (2018-03-06)
-
-
-
-## [1.5.1](https://github.com/nextcloud/calendar/compare/v1.5.0...v1.5.1) (2017-03-01)
-
-
-
-# [1.4.0](https://github.com/nextcloud/calendar/compare/v1.3.3...v1.4.0) (2016-09-19)
-
-
-### Reverts
-
-* Revert "hide random color button" ([c575c0e](https://github.com/nextcloud/calendar/commit/c575c0e2ff00254a5b35f7680cf4d08140f42a0c))
-
-
-
-## [1.3.3](https://github.com/nextcloud/calendar/compare/v1.3.2...v1.3.3) (2016-08-24)
-
-
-### Reverts
-
-* Revert "Fix handling of UTC and "floating" tz." ([846b42d](https://github.com/nextcloud/calendar/commit/846b42d8e774b8cf5126986b9dbb5bd644965018))
-* Revert "Fixed  tzid on floating date" ([a6a5a5a](https://github.com/nextcloud/calendar/commit/a6a5a5a63a70d44e5e2736d77c53bbdd839262a6))
-* Revert "fix code formatting of pr" ([784b481](https://github.com/nextcloud/calendar/commit/784b481416880d7ef7ec635be2280e91e969ebb7))
-
-
-
-## [1.3.2](https://github.com/nextcloud/calendar/compare/v1.3.1...v1.3.2) (2016-08-05)
-
-
-
-## [1.3.1](https://github.com/nextcloud/calendar/compare/v1.3.0...v1.3.1) (2016-07-24)
-
-
-
-# [1.3.0](https://github.com/nextcloud/calendar/compare/v1.2.2...v1.3.0) (2016-07-24)
-
-
-
-## [1.2.2](https://github.com/nextcloud/calendar/compare/v1.2.1...v1.2.2) (2016-05-20)
-
-
-
-## [1.2.1](https://github.com/nextcloud/calendar/compare/4854f3b5ce16bf442bc7cc1729349dd92851af7f...v1.2.1) (2016-05-17)
-
-
-### Reverts
-
-* Revert "Increment version number" ([4854f3b](https://github.com/nextcloud/calendar/commit/4854f3b5ce16bf442bc7cc1729349dd92851af7f))
-
-
-
+# Changelog
+
+## 5.0.0 - Unreleased
+### Added
+- Nextcloud 30 support
+- PHP8.1 minimum requirement
+- Rooms and resources overview
+- New sidebar organisation
+- Calendar-wide transparency settings
+- Calendar refresh on remote changes
+- Widget for private calendars
+- Caldav backend requirement
+### Changed
+- Dropped Nextcloud 29 support
+- Dropped support for PHP 8.0
+- New design: Material Symbols, general design overhaul
+- Reduced CSS opacity for past events
+- Circles renamed to Teams
+- Automatic widget reloading
+- More translations for appointments
+- ### Fixed
+- Teams missing from placeholder texts
+
+## 4.7.12 - 2024-07-17
+### Fixed
+- Localisation for Appointments
+
+## 4.7.11 - 2024-07-11
+### Fixed
+- First day of the week
+
+## 4.7.10 - 2024-07-04
+### Fixed
+- Broken file sharing
+
+## 4.7.9 - 2024-07-03
+### Fixed
+- Broken initial state
+- Button state on appointment creation
+
+## 4.7.8 - 2024-06-28
+### Fixed
+- Broken sidebar styles
+
+## 4.7.7 - 2024-06-27
+### Fixed
+- Appointments logging
+- Global styles scope
+
+## 4.7.6 - 2024-06-04
+### Fixed
+- Default calendar not supporting VEVENTs
+- Width of disabled calendar picker, take two
+- Calendar picker always choosing default calendar
+
+## 4.7.5 - 2024-06-04
+### Fixed
+- File picker loading indefinitely
+- Width of disabled calendar picker
+- Simple editor time zone picker
+
+## 4.7.4 - 2024-05-15
+### Fixed
+- DISPLAY Alarms not having a DESCRIPTION
+- Custom categories
+
+## 4.7.3 - 2024-05-08
+### Fixed
+- Default calendar not being used for new events
+
+## 4.7.2 - 2024-04-30
+### Fixed
+- Attachment links
+
+## 4.7.1 - 2024-04-25
+### Changed
+- Slot booking response
+
+## 4.7.0 - 2024-04-22
+### Added
+- Ability to invite circles to events
+- Custom public calendar subscriptions
+- Automatically find free slots for an event
+- Calendar widget for publicly shared calendars
+### Changed
+- Editor redesign
+### Fixed
+- Find attendees via email address
+- Misplaced empty content
+
+## 4.6.5 - 2024-02-15
+### Fixed
+- "Send Email" checkbox renamed to "Request reply"
+- "Invitation sent" rephrased to "Awaiting response"
+- Disabled resharing of incoming calendar shares
+- Booking date not displayed in appointment booking popover
+- Appointment slots not being bookable when the time doesn't fit into duration or increment
+
+## 4.6.4 - 2024-01-18
+### Fixed
+- Guests being added to talk rooms not open for guests
+
+## 4.6.3 - 2024-01-10
+### Fixed
+- Rate limit appointment booking and config creation
+- Apointment confirmation modal button style
+- Filtering in sharing search
+- Attachment folder picker opening twice
+
+## 4.6.2 - 2024-01-03
+### Fixed
+- Uploading attachments in Firefox
+
+## 4.6.1 - 2023-12-21
+### Fixed
+- Localisation for month view
+- From/To order in booking emails
+- Alarm not editable when menu is open
+
+## 4.6.0 - 2023-11-30
+### Added
+- v2 for widget API
+- PHP8.3 support
+### Changed
+- Appointment UI error handling
+- Disable adding attendees on shared calendars
+- Appointment rooms are now public
+### Fixed
+- Recurring events on the dashboard
+- Event participation when event is updated
+- Timezone overlap (Firefox)
+- Recurrence error handling
+- Toggle overlap
+- Locale fallback
+- Leaked internal exceptions
+
+## 4.5.3 - 2023-10-07
+### Changed
+- Participtation status reset for changed events
+- Appointment rooms are now public by default
+### Fixed
+- Internal exception leak
+- Missing VTIMEZONE for Appointment ics
+
+## 4.5.2 - 2023-10-02
+### Changed
+- Reverted persistent custom categories (for now)
+### Fixed
+- Sidebar toggle overlay for Firefox
+- Reocurring events on the dashboard
+
+## 4.5.1 - 2023-09-21
+### Fixed
+- Sidebar toggle overlay
+
+## 4.5.0 - 2023-09-14
+### Added
+- Year grid view
+- Talk rooms for appointments are back
+- Location and description links clickable
+- App config option to hide resources tab
+### Changed
+- Talk url now written to location
+- "New event" button renamed to "Event"
+- Categories extended to include system tags and already used categories
+### Fixed
+- Categories for public calendars
+
+## 4.4.5 – 2023–09-07
+### Fixed
+- Avatars now use placeholders for attendees
+- FreeBusy disabled for attendees
+
+## 4.4.4 – 2023–08-03
+### Fixed
+- Navigation button positioning
+- Navigation toggle overlap
+- Long email addresses in sharing
+
+## 4.4.3 – 2023–06-29
+### Changed
+- Frontend now uses NcSelect
+### Fixed
+- Empty events
+
+## 4.4.2 – 2023–06-12
+### Fixed
+- Temporarily revert Talk room feature for appointments due to upgrade issues
+
+## 4.4.1 - 2023-06-09
+### Fixed
+- Allow dynamic autoloading for classes added during upgrade
+
+## 4.4.0 - 2023-06-07
+### Added
+- Create Talk rooms for appointments
+### Changed
+- Add back PHP 7.4 support
+- Add save button to calendar settings
+- Icon for appointment confirmation dialogue
+- Include booking person's name in appointment event
+- Add server details and ToS link to public sharing page 
+### Fixed
+- Public sharing footer
+- Date formatting in list view
+- Import button alignment
+- Use locale instead of language
+- DAV urls for attachments
+- Calendar booking notifications
+- Calendar invitees buttons (width and space between)
+
+## 4.3.2 - 2023-04-06
+### Fixed
+- Attachments folder
+- Appointments default visibility
+- Sidebar editor timezone
+- Share indicator
+- Date picker
+
+## 4.3.1 - 2023-03-22
+### Changed
+- Webpack version
+
+## 4.3.0 - 2023-03-20
+### Added
+- File attachments for calendar events
+- Organizer booking emails
+### Changed
+- Lazy load dashboard component
+- Wider input for recurrences
+### Fixed
+- Exception handing for booking controller
+- Current day color sticker
+- Calendar export button
+- Share dialogue focus loss
+- Disabling appointments
+- Color picker
+
+## 4.2.2 - 2023-01-26
+### Fixed
+- Disabling appointments feature
+- can_subscribe_link fallback
+- Save and edit methods in calendar modal
+
+## 4.2.1 - 2023-01-05
+### Fixed
+- Reminder form field width
+- Calendar export
+
+## 4.2.0 - 2022-12-29
+### Added
+- Calendar sharing and settings modal
+- Parameters to allow / disallow sharing via link
+- Error handling for Widget SVG generation
+### Changed
+- Set round-icons: true for clients
+### Fixed
+- Equalize slot booking button width
+- Trash bin buttons
+- Black calendar icon on dashboard widget in dark mode
+- Unclear field label for appointment config
+- Typo in meditation.svg
+- Duplicate location in booking email
+- Widget search results returning past events
+- Handling of EMail VALARMs
+
+## 4.1.1 - 2022-12-15
+### Fixed
+- Disabled timezone popup 
+- Style for timezone popup
+- Location in booking VEVENT
+- Bottom part cut off for public calendar
+- Lost app navigation styles
+- Delete X-ALT-DESC property when changing description
+- Clipboard copy
+
+## 4.1.0 - 2022-11-02
+### Added
+- IButtonWidget and IIconWidget implementation
+### Fixed
+- Widget Icon in Dashboard
+- Appointment detail styling for small screen
+- Appointment overview page design
+
+## 4.0.1 - 2022-10-18
+### Changed
+- Remove iconfont and associated dependecies
+### Fixed
+- Appointment overview page design
+- Appointment details styling
+- Title only added in week view
+
+## 4.0.0 - 2022-10-13
+### Added
+- New design
+- Primary light background to month, week and header
+- Booking email with .ics for the event
+### Changed
+- Drop Nextcloud 22-24 support
+- Remove unused icons and icon stylesheets
+- Rename elements to items
+- More information in booking confirmation email
+- Appointments page redesign
+### Fixed
+- Some translation issues with whitespaces
+- Padding of left sidebar header
+- Cut off datetime picker in simple editor
+- Contrast for day header
+- Category Selection
+- Missing background color for appoitments
+
+## 3.5.0 - 2022-08-25
+### Added
+- Option to copy calendar events
+- Config setting to disable appointments
+### Changed
+- Moved icons to material design
+- Settings name
+### Fixed
+- White space on calendar title
+- Trashbin layout
+
+## 3.4.3 - 2022-08-23
+### Fixed
+- Missing events in week view
+- Invitee and resource name wrapping
+- Relying on guessed mime type on import
+
+## 3.4.2 - 2022-07-07
+### Fixed
+- Performance issues with Vue Event Rendering
+- Settings modal closing when using import
+
+## 3.4.1 - 2022-06-28
+### Fixed
+- Calendar not loading in month view
+
+## 3.4.0 - 2022-06-21
+### Added
+- Visually distinguish events with attendees from ones without
+- Visually distinguish events with reminders from ones without
+- More key events on the simple editor
+### Changed
+- Drop PHP7.3 support (EOL)
+- Drop Nextcloud 21 support (EOL)
+- Event rendering now uses Vue
+- Appointment booking message
+### Fixed
+- Logic to extract avatar link from inivitees list
+- Missing stylelint
+- Hide 3-dot menu button
+- Attendee search
+- Color dot and event alignment
+
+## 3.3.2 – 2022-06-02
+### Fixed
+- Squished settings checkbox label
+
+## 3.3.1 – 2022-05-19
+### Fixed
+- Free/busy view rendering
+- Switching view modes
+- Search term casing
+- Sidebar scrolling
+
+## 3.3.0 - 2022-05-05
+### Added
+- PHP8.1 compatability
+- More uses for the popover modal
+### Changed
+- Rename "Download" to "Export"
+### Fixed
+- Crash on Chrome / Chromium for Simple Editor URL
+- Invitation response button for readonly events
+
+## 3.2.2 - 2022-03-16
+### Fixed
+- Email Validation for appointment booking
+- Calendar resource attendance state display
+- Alarm type selection
+
+## 3.2.1 - 2022-03-14
+### Fixed
+- Public Calendar Link
+- Disabled Calendar Icon
+- Missing Translations
+
+## 3.2.0 - 2022-03-09
+### Changed
+- Allow admins to force an event type
+- Allow admins to hide event exports
+- Rename 'Download' to 'Export'
+### Fixed
+- Navigation icon bullet
+- Remove dot in plural string
+- Remove blurriness from event participation indicator
+
+## 3.1.0 - 2022-02-28
+### Added
+- Accept & decline invitations from web
+- Conflict calendars for appointments
+- Limit how far in the future appointments can be booked
+### Changed
+- Time-insensitive background jobs are now run at off-peak times
+- Illustrations for Voting, BBQ, Weddings, etc.
+- Calendar monthly and weekly view now grey out days of other months
+- Full calendar week view now highlights "Today"
+- Date & time picker enhancements - end time now influences start time, lets you choose a time first
+- Show the whole title of an event if the display field is large enough
+- Metadata for appointments config prep- and followup time
+### Removed
+- Nextcloud 20 support
+- PHP7.2 support
+### Fixed
+- Accessibility
+- Broken appointment modal if destination calendar was deleted
+- Fix vertical scrolling issues on mobile devices
+
+## 3.0.6 – 2022-02-16
+### Fixed
+- Invalid X-APPLE-STRUCTURED-LOCATION on location update
+- Trashbin being unavaliable
+- Previously ignored DESCRIPTION;ALTREP property
+
+## 3.0.5 – 2022-01-18
+### Fixed
+- Events being editable locally by attendees reenabled
+- Fix reminder time zone picker and formatting
+
+## 3.0.4 – 2021-12-28
+### Fixed
+- Calendar picker in the editor sidebar
+
+## 3.0.3 – 2021-12-21
+### Fixed
+- Events editable by anyone
+- Time display for short events
+- Event title cut off even for long events with enough display space
+
+## 3.0.2 – 2021-12-15
+### Fixed
+- Previous/next month buttons
+- Cancelled and free events cause appointment slot conflicts
+- User deletion SQL error
+- User doc URL
+- Outdated screenshots
+- Appointments booking page with mobile browsers
+
+## 3.0.1 - 2021-12-01
+### Fixed
+- PHP7.2 syntax errors
+- Usage of Nextcloud 21+ API on Nextcloud 20
+- Vertical padding of the appointments booking page
+- White space handling of appointments description
+
+## 3.0.0 – 2021-11-29
+### Added
+- Appointments - configure your appointment configuration, send out the link or show it on your profile, and let other people book an appointment with you
+### Fixed
+- Empty calendar widget on dashboard
+
+## 2.4.0 – 2021-11-25
+### Added
+- Advanced Search for Rooms and Resources
+- Room Auto Suggestions for events that will fit all attendees
+### Changed
+- Design Polishing of Right Sidebar
+  - Merged Alarm, Detail and Repeat tab in right sidebar
+  - Moved Resources to separate tab
+  - Placeholder Text and field heights
+  - Timepicker
+  - Simplified Simple Editor
+  - ...
+- Event recurrences
+  - Calendar can't be edited any longer
+- Dependencies
+- Translations
+### Fixed
+- Sharing: Groups and Principal URIs with spaces and other special characters
+- Trashbin timestamp
+
+## 2.3.4 – 2021-09-28
+### Fixed
+- Event height in weekly view
+- Events disappearing from grid
+- Movnig calendars on Android
+- Missing default status
+- Simple editor size
+- Sidebar datepicker rendering
+
+## 2.3.3 – 2021-08-30
+### Fixed
+- Development dependencies shipped with production build
+- Missing email address in attendee search
+
+## 2.3.2 – 2021-08-18
+### Changed
+- Details of editor design
+- Make save buttons sticky
+- Sort objects in trash bin by newest first
+- Size of text fields in event pop-up
+### Fixed
+- Settings design regressions
+- Scrolling for trash bin
+- Unusable sidebar on mobile
+- List table issues
+- Month view issues
+- Week view issues
+- Rendering of vobject in trash bin
+- Missing loading view for trash bin
+- Task restoring error handling
+
+## 2.3.1 – 2021-07-14
+### Fixed
+- Create Talk room for event
+- Searching for sharees when resources exist on the back-end
+- Removing recurrence rule
+- 'Add reminder' dropdown position
+- Event repeat multiselect and position on low resolutions
+- Timestamps in trash bin view
+- Vue prop validation error
+
+## 2.3.0 – 2021-06-29
+### Added
+- Trash bin for calendars and their events
+- Default reminder setting
+### Changed
+- Event now have a minimum display height
+- Rendering of attendees and their state
+- Show organizer in free-busy view
+- Illustrations
+- Show shared calendars by default
+- Dropped webcals support (not webcal !)
+- Dependencies
+- Translations
+### Fixed
+- Missing right border in month and week view
+- Missing date picker
+- Principal encoding for sharing with groups with spaces in their name
+
+## 2.2.2 – 2021-05-26
+### Fixed
+- Unable to pick date in monthly view
+
+## 2.2.1 – 2021-04-27
+### Changed
+- Updated dependencies
+
+## 2.2.0 – 2021-03-24
+### Added
+- Datepicker in free/busy view
+- Grey background for all attendees in free/busy when at least one person is busy
+- Free/busy view shows day of the week
+- Nextcloud 22 (dev) support
+### Changed
+- Improved dashboard widget styling
+- Updated translations
+- Updated dependencies
+- Vary event illustrations when multiple illustrations match
+### Fixed
+- Hide cancelled events on dashboard
+- Styling of free/busy slots
+- Browser compatibility issues
+- Search DAV principal as display name or email
+- Handling of invalid calendar objects when rending a calendar
+- Sorting of free/busy resources
+- Hover background in list view with Nextcloud's dark theme
+
+## 2.1.3 - 2021-01-04
+### Fixed
+- Let apps handle clicks on todo entries #2478
+- Fix calendar rendering with complex locale #2741
+- Fix encoded display of names that contain a special character #2726
+- Fix blank page on browsers without support for ResizeObserver #2620
+- Fix broken link #2715
+- RRULE UNTIL must be in UTC if DTSTART is timezone-aware #2709
+- Add some margin for organizer hint in attendee list #2683
+- Updated translations
+- Updated dependencies
+
+## 2.1.2 - 2020-09-24
+### Added
+- 21 compatibility
+- Fixed reminder editing
+  [#2605](https://github.com/nextcloud/calendar/pull/2605)
+  [#2606](https://github.com/nextcloud/calendar/pull/2606)
+
+## 2.1.1 - 2020-09-11
+### Fixed
+- Dashboard fixes
+  [#2574](https://github.com/nextcloud/calendar/pull/2574)
+  [#2575](https://github.com/nextcloud/calendar/pull/2575)
+  [#2579](https://github.com/nextcloud/calendar/pull/2579)
+- Fix opening an event from search
+  [#2578](https://github.com/nextcloud/calendar/pull/2578)
+- Updated dependencies
+- Updated translations
+
+## 2.1.0 - 2020-09-02
+### Added
+- Dashboard integration
+  [#2414](https://github.com/nextcloud/calendar/pull/2414)
+- Better routes to link to calendar from outside
+  [#2483](https://github.com/nextcloud/calendar/pull/2483)
+- Different style for all-day / timed events
+  [#30](https://github.com/nextcloud/calendar/issues/30)
+- List view
+  [#402](https://github.com/nextcloud/calendar/issues/402)
+- Search
+  [#8](https://github.com/nextcloud/calendar/issues/8)
+
+### Fixed
+- Better localization of calendar-grid
+  [#1844](https://github.com/nextcloud/calendar/issues/1844)
+- Remove double scrollbars in Firefox
+  [#1815](https://github.com/nextcloud/calendar/issues/1815)
+- Better error handling for missing events
+  [#2459](https://github.com/nextcloud/calendar/issues/2459)
+- Long description box
+  [#2187](https://github.com/nextcloud/calendar/issues/2187)
+
+## 2.0.4 - 2020-08-27
+### Added
+- Center date in month view cell
+  [#2451](https://github.com/nextcloud/calendar/pull/2451)
+- Sortable calendar list
+  [#9](https://github.com/nextcloud/calendar/issues/9)
+- Display tasks with a due-date in calendar app
+  [#28](https://github.com/nextcloud/calendar/issues/28)
+- Keyboard support
+  [#157](https://github.com/nextcloud/calendar/issues/157)
+- Add illustration to videoconference
+  [#2217](https://github.com/nextcloud/calendar/issues/2217)
+- Change Illustration for Lunch
+  [#2218](https://github.com/nextcloud/calendar/issues/2218)
+- Convert URLs into links inside description
+  [#674](https://github.com/nextcloud/calendar/issues/674)
+- Picking a date in date-time-picker does not open time-picker
+  [#2198](https://github.com/nextcloud/calendar/issues/2198)
+
+### Fixed
+- Sharing Calendar public links via email sends only a link to the cloud
+  [#2471](https://github.com/nextcloud/calendar/issues/2471)
+- Also mark tasks as done when STATUS is set to COMPLETED
+  [#2339](https://github.com/nextcloud/calendar/pull/2339)
+- Long calendar names overflowing in calendar-picker
+  [#2324](https://github.com/nextcloud/calendar/issues/2324)
+- Datepicker not localized
+  [#2174](https://github.com/nextcloud/calendar/issues/2174)
+- Hide submit button in editor sidebar
+  [#2291](https://github.com/nextcloud/calendar/issues/2291)
+- Fix timezone names
+  [#2292](https://github.com/nextcloud/calendar/pull/2292)
+- Fixes warning about duplicate ids
+  [#2287](https://github.com/nextcloud/calendar/pull/2287)
+- Make calendar-picker more prominent
+  [#2007](https://github.com/nextcloud/calendar/issues/2007)
+- Circle not found when full name is given
+  [#2220](https://github.com/nextcloud/calendar/issues/2220)
+
+## 2.0.3 - 2020-04-09
+### Added
+- Show week number in Datepicker
+  [#2060](https://github.com/nextcloud/calendar/pull/2060)
+- Support am/pm in Datepicker
+  [#2060](https://github.com/nextcloud/calendar/pull/2060)
+- Allow to jump to timepicker, without reselecting the date
+  [#2060](https://github.com/nextcloud/calendar/pull/2060)
+
+### Fixed
+- Calendar list has trouble loading when shared from account or group with non-latin characters.
+  [#1894](https://github.com/nextcloud/calendar/issues/1894)
+- CSP Issue when embedding calendar
+  [#13627](https://github.com/nextcloud/server/issues/13627)
+  [#169](https://github.com/nextcloud/calendar/issues/169)
+- Alarm trigger was a date in all-day event
+  [#2128](https://github.com/nextcloud/calendar/issues/2128)
+- Blank screen when create new date by opened editor
+  [#2051](https://github.com/nextcloud/calendar/issues/2051)
+- Popover outside viewport when double-clicking event
+  [#1925](https://github.com/nextcloud/calendar/issues/1925)
+- Popover outside viewport when event is hidden behind "More"
+  [#1934](https://github.com/nextcloud/calendar/issues/1934)
+- Popover outside viewport in day-view
+  [#2109](https://github.com/nextcloud/calendar/issues/2109)
+- Optimized view icons
+  [#2154](https://github.com/nextcloud/calendar/pull/2154)
+- Always allow editing an alarm when it is absolute
+  [#2001](https://github.com/nextcloud/calendar/issues/2001)
+- Fix opening animation of sidebar editor
+  [#2089](https://github.com/nextcloud/calendar/pull/2089)
+- Long repeating events not correctly shown on web-calender under certain conditions
+  [#2048](https://github.com/nextcloud/calendar/issues/2048)
+- Repeating events not displayed on first day of monthly calendar 
+  [#1913](https://github.com/nextcloud/calendar/issues/1913)
+
+## 2.0.2 - 2020-03-02
+### Added
+- Recognize Gym as event title for illustrations
+  [#1888](https://github.com/nextcloud/calendar/issues/1888)
+- Improve illustration matching for less false positives
+  [#1916](https://github.com/nextcloud/calendar/issues/1916)
+- Add illustrations keywords related to agile development
+  [#1873](https://github.com/nextcloud/calendar/pull/1873)
+- Add hint to new calendar dropdown that subscriptions are read-only
+  [#1938](https://github.com/nextcloud/calendar/pull/1938)
+- Move navigation to appinfo
+  [#1979](https://github.com/nextcloud/calendar/pull/1979)
+- Use InitialState API
+  [#1759](https://github.com/nextcloud/calendar/issues/1759)
+- Monthly-mode: scroll-bar instead of "more"
+  [#1889](https://github.com/nextcloud/calendar/issues/1889)
+- Adds a minimum height for fullcalendar-events
+  [#2020](https://github.com/nextcloud/calendar/pull/2020)
+- Better feedback for import failures
+  [#1920](https://github.com/nextcloud/calendar/issues/1920)
+- Custom color per event
+  [#71](https://github.com/nextcloud/calendar/issues/71)
+- Allow to configure slotDuration
+  [#2042](https://github.com/nextcloud/calendar/pull/2042)
+
+### Fixed
+- Undefined color variable
+  [#1905](https://github.com/nextcloud/calendar/issues/1905)
+- Localization of sub-title in AppSidebar
+  [#1912](https://github.com/nextcloud/calendar/issues/1912)
+- Localization of tab-title
+  [#1871](https://github.com/nextcloud/calendar/issues/1871)
+- Next month button skips one month the first time
+  [#1936](https://github.com/nextcloud/calendar/issues/1936)
+- Issue with background-color for icon in datepicker
+  [#1939](https://github.com/nextcloud/calendar/pull/1939)
+- Calendar color generator doesn't handle undefined calendar displayname
+  [#1941](https://github.com/nextcloud/calendar/issues/1941)
+- Sharing with users and groups with spaces
+  [#1985](https://github.com/nextcloud/calendar/pull/1985)
+- Birthday calender entries in wrong date format (in sidebar)
+  [#1923](https://github.com/nextcloud/calendar/issues/1923)
+- Stop hardcoding saturday and sunday as weekend, change it based on locale
+  [#2016](https://github.com/nextcloud/calendar/issues/2016)
+- Duration display issue with entries having a duration of a minute or less
+  [#1963](https://github.com/nextcloud/calendar/issues/1963)
+- Navigation and Display issue in day view
+  [#1944](https://github.com/nextcloud/calendar/issues/1944)
+- Handle files_sharing app being disabled
+  [#1967](https://github.com/nextcloud/calendar/issues/1967)
+- No calendar import (in Firefox and Edge on Windows)
+  [#1898](https://github.com/nextcloud/calendar/issues/1898)
+- Issue setting the end-timezone of an event
+  [#1914](https://github.com/nextcloud/calendar/issues/1914)
+- Calendar app cannot add repeats to an event after the event is created
+  [#2013](https://github.com/nextcloud/calendar/issues/2013)
+- Preserve duration when editing start time
+  [#1929](https://github.com/nextcloud/calendar/issues/1929)
+- Changes inside subcomponents not properly tracked
+  [#1891](https://github.com/nextcloud/calendar/issues/1891)
+
+## 2.0.1 - 2020-01-20
+### Fixed
+- Sort categories alphabetically
+  [#1827](https://github.com/nextcloud/calendar/issues/1827)
+- Missing styles of "more events" popover
+  [#1865](https://github.com/nextcloud/calendar/pull/1865)
+- Resolving timezone aliases not working
+  [#1841](https://github.com/nextcloud/calendar/issues/1841)
+- Generated embed code for public calendar contains wrong link
+  [#1861](https://github.com/nextcloud/calendar/issues/1861)
+- Add sanity check for route name in case migration didn't run
+  [#1831](https://github.com/nextcloud/calendar/issues/1831)
+- Positioning of new-event popover in day and week view
+  [#1818](https://github.com/nextcloud/calendar/issues/1818)
+- Display self-added categories in list, making it easier to remove them again
+  [#1819](https://github.com/nextcloud/calendar/issues/1819)
+
+## 2.0.0 - 2020-01-17
+### Fixed
+- Do not include index.php in the url of sharing links if url rewrite is enabled
+  [#1821](https://github.com/nextcloud/calendar/pull/1821)
+- Fix PHP warning when accessing public / embedded routes
+  [#1822](https://github.com/nextcloud/calendar/pull/1822)
+- Include index.php in router base if necessary despite url rewrite enabled
+  [#1823](https://github.com/nextcloud/calendar/pull/1823)
+
+## 2.0.0 RC1 - 2020-01-15
+### Fixed
+- Hide horizontal scrollbar in Firefox
+  [#1809](https://github.com/nextcloud/calendar/pull/1809)
+- Cannot enter minutes off slot
+  [#1756](https://github.com/nextcloud/calendar/issues/1756)
+- Fix downsizing calendar-grid when making window smaller
+  [#1806](https://github.com/nextcloud/calendar/pull/1806)
+- Always make all-day DTEND exclusive
+  [#1810](https://github.com/nextcloud/calendar/pull/1810)
+- Convert eventRenderer from event to property
+  [#1807](https://github.com/nextcloud/calendar/pull/1807)
+- Fix opening calendar when not logged in
+  [#1803](https://github.com/nextcloud/calendar/pull/1803)
+- Style of today indicator in agendaDay and agendaWeek
+  [#1804](https://github.com/nextcloud/calendar/issues/1804)
+- Fix double-escape of ampersand of settings title
+  [#1760](https://github.com/nextcloud/calendar/pull/1760)
+
+### Added
+- Editing event-time without punctuation
+  [#1621](https://github.com/nextcloud/calendar/issues/1621)
+- Allow entering incomplete time-values
+  [#1144](https://github.com/nextcloud/calendar/issues/1144)
+- Add reminder icon to events with an alarm
+  [#1197](https://github.com/nextcloud/calendar/issues/1197)
+- Free/Busy UI
+  [#1731](https://github.com/nextcloud/calendar/pull/1731)
+- Event-limit in calendar-grid
+  [#1800](https://github.com/nextcloud/calendar/pull/1800)
+- Add more illustration keywords
+  [#1780](https://github.com/nextcloud/calendar/pull/1780)
+- Create talk rooms from event editor
+  [#1732](https://github.com/nextcloud/calendar/pull/1732)
+-  Allow to provide defaults for user-settings
+  [#1787](https://github.com/nextcloud/calendar/issues/1787)
+
+## 2.0.0 beta3 - 2019-12-09
+### Fixed
+- Hide the resize handler of textareas, whenever we use autosize
+  [#1629](https://github.com/nextcloud/calendar/pull/1629)
+- Give the description field a default height of two rows
+  [#1630](https://github.com/nextcloud/calendar/pull/1630)
+- Hide calendar-picker if user has only one writable calendar
+  [#1631](https://github.com/nextcloud/calendar/pull/1631)
+- Do not show recurrence-summary, when the event is not repeating
+  [#1632](https://github.com/nextcloud/calendar/pull/1632)
+- Update timezone-database to 2019c
+  [#1635](https://github.com/nextcloud/calendar/pull/1635)
+- Replace with @babel/polyfill with core-js
+  [#1634](https://github.com/nextcloud/calendar/pull/1634)
+- Fix delay when toggling the all-day checkbox
+  [#1637](https://github.com/nextcloud/calendar/pull/1637)
+- Fixed missing translatable strings
+  [#1639](https://github.com/nextcloud/calendar/pull/1639)
+- Promise-related error in Firefox (catch is not a function)
+  [#1633](https://github.com/nextcloud/calendar/issues/1633)
+- Shared calendar entry to crowded in the navigation
+  [#1655](https://github.com/nextcloud/calendar/issues/1655)
+- Sharing published link via email doesn't work
+  [#1640](https://github.com/nextcloud/calendar/issues/1640)
+- Order All-day events by calendar 
+  [#760](https://github.com/nextcloud/calendar/issues/769)
+- Restructure menu for reminders
+  [#1638](https://github.com/nextcloud/calendar/pull/1638)
+- Do not show Empty message when clicking the search attendee multiselect
+  [#1699](https://github.com/nextcloud/calendar/pull/1699)
+- use FullCalendar navLinks
+  [#796](https://github.com/nextcloud/calendar/issues/796)
+- Replace New Reminder button with Multiselect to allow easier selection of alarm
+  [#1701](https://github.com/nextcloud/calendar/pull/1701)
+
+## 2.0.0 beta2 - 2019-11-04
+### Added
+- Consider categories for illustrations if title doesn't match any illustration
+  [#1509](https://github.com/nextcloud/calendar/issues/1509)
+- Update Today in calendar-view on day-change
+  [#678](https://github.com/nextcloud/calendar/issues/678)
+- Show warning when detected timezone is UTC
+  [#711](https://github.com/nextcloud/calendar/issues/711)
+- Allow to edit location and description in popover editor, if already set
+  [#680](https://github.com/nextcloud/calendar/issues/680)
+- Better default times when switching from all-day to timed event
+  [#532](https://github.com/nextcloud/calendar/issues/532)
+- Nicer integration of week-number into calendar-view
+  [#1571](https://github.com/nextcloud/calendar/issues/1571)
+- Simpler design for upper part of app navigation
+  [#1021](https://github.com/nextcloud/calendar/issues/1021)
+- Merged calendar-list and subscription list
+- Categories
+  [#107](https://github.com/nextcloud/calendar/issues/107)
+- Hide property info in read-only mode
+  [#1585](https://github.com/nextcloud/calendar/issues/1585)
+- Do not show all-day checkbox in read-only mode
+  [#1589](https://github.com/nextcloud/calendar/issues/1589)
+- Add timezone at creation of calendar
+  [#223](https://github.com/nextcloud/calendar/issues/223)
+- Allow to link to event
+  [#21](https://github.com/nextcloud/calendar/issues/21)
+
+### Fixed
+- Respect the user's locale
+  [#1569](https://github.com/nextcloud/calendar/issues/1569)
+- Mixup of locale and language
+  [#920](https://github.com/nextcloud/calendar/issues/920)
+- Error when selecting visibility in Editor
+  [#1591](https://github.com/nextcloud/calendar/issues/1591)
+- Show private calendars by default if no visibility is set
+  [#1588](https://github.com/nextcloud/calendar/issues/1588)
+- Remove title tag from illustration svg
+  [#1593](https://github.com/nextcloud/calendar/issues/1593)
+- Show more button in upper right corner in popover for read-only events
+  [#1592](https://github.com/nextcloud/calendar/issues/1592)
+- Event details are not transferred from popover to sidebar
+  [#1590](https://github.com/nextcloud/calendar/issues/1590)
+
+## 2.0.0 beta1 - 2019-10-21
+
+Version 2.0 of the calendar has been fully rewritten with a different technology, switching from the legacy AngularJS framework to Vue.js. Nextcloud is using more and more Vue.js throughout apps and server, which makes it easy to use common components everywhere. This allows faster development and a more coherent experience in all of Nextcloud.
+
+Even though all features present on the 1.x calendar app versions have been reimplemented, new bugs might have been introduced. Please report them if you find some.
+
+### Added
+- Improved compatibility with dark mode
+  [#1152](https://github.com/nextcloud/calendar/issues/1152)
+  [#985](https://github.com/nextcloud/calendar/issues/985)
+- Assign random UIDs on import if events don't have one
+  [#857](https://github.com/nextcloud/calendar/issues/857)
+- Use Popper.JS for more reliable positioning of event popover
+  [#18](https://github.com/nextcloud/calendar/issues/18)
+- New design for embedding shared calendars
+  [#741](https://github.com/nextcloud/calendar/issues/741)
+- Share multiple public calendars in one link
+  [#708](https://github.com/nextcloud/calendar/issues/708)
+- Completely rewritten interface for entering recurrence-rules
+  [#10](https://github.com/nextcloud/calendar/issues/10)
+- Improved discoverability of upper-left date-picker
+  [#881](https://github.com/nextcloud/calendar/issues/881)
+- Do not send invites on import
+  [#576](https://github.com/nextcloud/calendar/issues/576)
+- Automatically adjust the start time when user picks new end earlier than start
+  [#497](https://github.com/nextcloud/calendar/issues/497)
+- Prioritize user-addressbook over system users when inviting attendees
+  [#168](https://github.com/nextcloud/calendar/issues/168)
+- Add option to mark user as non-participant
+  [#570](https://github.com/nextcloud/calendar/issues/570)
+- Add subscribe and download button to public sharing menu
+  [#1263](https://github.com/nextcloud/calendar/issues/1263)
+- Make embedded public calendars stylable
+  [#318](https://github.com/nextcloud/calendar/issues/318)
+- Send email notifications on change of location, summary, or description
+  [#848](https://github.com/nextcloud/calendar/issues/848)
+- Add checkbox for birthday calendar in settings, allowing to restore it
+  [#277](https://github.com/nextcloud/calendar/issues/277)
+- Allow to edit only this or this and all future occurrences of an event
+  [#7](https://github.com/nextcloud/calendar/issues/7)
+- Add next/previous month button in top-left datepicker
+  [#554](https://github.com/nextcloud/calendar/issues/554)
+- Show invitation response of attendee
+  [#879](https://github.com/nextcloud/calendar/issues/879)
+- Top-left datepicker allows navigating between years
+  [#703](https://github.com/nextcloud/calendar/issues/703)
+- Limit number of concurrent requests while import
+  [#445](https://github.com/nextcloud/calendar/issues/445)
+- Cleanup VTimezones after editing events
+  [#37](https://github.com/nextcloud/calendar/issues/37)
+- Improved validation of attendee field
+  [#569](https://github.com/nextcloud/calendar/issues/560)
+- Show organizer of event
+  [#486](https://github.com/nextcloud/calendar/issues/486)
+- Improved legibility in read-only mode of editor
+  [#555](https://github.com/nextcloud/calendar/issues/555)
+- Allow to disable weekends
+  [#536](https://github.com/nextcloud/calendar/issues/536)
+- Add button to copy caldav link to clipboard
+  [#22](https://github.com/nextcloud/calendar/issues/22)
+- Show the current date in the browser title
+  [#280](https://github.com/nextcloud/calendar/issues/280)
+- Updated design of sharing mechanism for calendars
+  [#377](https://github.com/nextcloud/calendar/issues/377)
+- Ability to handle multiple VCALENDAR blocks in one ics
+  [#336](https://github.com/nextcloud/calendar/issues/336)
+- Allow to change color of contact birthdays calendar
+  [#313](https://github.com/nextcloud/calendar/issues/313)
+- Use webcals when accessing calendar via https
+  [#748](https://github.com/nextcloud/calendar/issues/748)
+- Use illustrations for events
+  [#968](https://github.com/nextcloud/calendar/issues/968)
+
+### Fixed
+- User session expiration exceptions
+  [#1215](https://github.com/nextcloud/calendar/issues/1215)
+- Files_sharing app is required as dependency for Sharing
+  [#608](https://github.com/nextcloud/calendar/issues/608)
+- Show original color of publicly shared calendars
+  [#619](https://github.com/nextcloud/calendar/issues/619)
+- Allow events with start time equal to end time
+  [#790](https://github.com/nextcloud/calendar/issues/790)
+- Missing interaction of import-button
+  [#1374](https://github.com/nextcloud/calendar/issues/1374)
+- Sharing list takes too long to show
+  [#1297](https://github.com/nextcloud/calendar/issues/1297)
+- Wrong profile picture when searching for user in share dialog
+  [#861](https://github.com/nextcloud/calendar/issues/861)
+- Properly update LAST-MODIFIED and SEQUENCE on update of calendar
+  [#976](https://github.com/nextcloud/calendar/issues/976)
+- Drag and Drop failed after viewing event details
+  [#914](https://github.com/nextcloud/calendar/issues/914)
+- Selected view was not sticky
+  [#809](https://github.com/nextcloud/calendar/issues/809)
+- Non-unique Id in HTML
+  [#860](https://github.com/nextcloud/calendar/issues/860)
+- X-NC-GROUP-ID was not properly removed 
+  [#342](https://github.com/nextcloud/calendar/issues/342)
+- Fields in repeat area are not disabled in read-only in Edge
+  [#420](https://github.com/nextcloud/calendar/issues/420)
+- Store CREATED, DTSTAMP, and LAST-MODIFIED as UTC
+  [#33](https://github.com/nextcloud/calendar/issues/33)
+- Same attendee could be added multiple times
+  [#575](https://github.com/nextcloud/calendar/issues/575)
+- Impossible to scroll down to save event on certain mobile devices
+  [#1079](https://github.com/nextcloud/calendar/issues/1079)
+
+### Changes
+- New calendars only support VEvent from now on
+  [#1316](https://github.com/nextcloud/calendar/issues/1316)
+
+
+## 1.7.1 - 2019-09-05
+### Fixed
+- Falses positives for local access rules [#1277](https://github.com/nextcloud/calendar/issues/1277)
+- Always show border on calendar item [#1298](https://github.com/nextcloud/calendar/pull/1298)
+- Update link to documentation [#1409](https://github.com/nextcloud/calendar/pull/1409)
+- Don’t ship special build for IE anymore [#1447](https://github.com/nextcloud/calendar/pull/1447)
+
+## 1.7.0 - 2019-03-25
+### Added
+- Share calendars with circles
+  [#602](https://github.com/nextcloud/calendar/pull/602)
+
+### Fixed
+- compatibility with Nextcloud 16
+- Buttons not visible in dark theme
+  [#1042](https://github.com/nextcloud/calendar/issues/1042)
+- Fix datepicker alignment
+  [#1085](https://github.com/nextcloud/calendar/pull/1085)
+
+## 1.6.4 - 2018-11-23
+### Fixed
+- Use clearer color to easier locate today
+  [#850](https://github.com/nextcloud/calendar/pull/850)
+- Styling broken with Nextcloud 14 using Dark theme
+  [#938](https://github.com/nextcloud/calendar/issues/938)
+- Missing name when using the dropdown for location -> contacts
+  [#776](https://github.com/nextcloud/calendar/issues/776)
+- Public calendar iframe has issues on some browser (requires Nextcloud 15+)
+  [#169](https://github.com/nextcloud/calendar/issues/169)
+- Broken positioning of New calendar button in Internet explorer 11
+  [#949](https://github.com/nextcloud/calendar/pull/949)
+- Provide autocompletion addresses as a single line
+  [#933](https://github.com/nextcloud/calendar/issues/933)
+
+## 1.6.3 - 2018-10-16
+### Fixed
+- Incorrect creation of attendees that led to duplicate entries after invitation response
+- updated translations
+
+## 1.6.2 - 2018-09-05
+### Fixed
+- compatibility with Nextcloud 14
+- updated translations
+
+## 1.6.1 - 2018-03-06
+### Fixed
+- Double the height of the description textarea
+  [#675](https://github.com/nextcloud/calendar/issues/675)
+- Fix parsing for all-day VEvents that 
+  [#692](https://github.com/nextcloud/calendar/issues/692)
+- Manual override for timezone
+  [#586](https://github.com/nextcloud/calendar/issues/586)
+- Improved error handling for parsing of events when importing
+  [#598](https://github.com/nextcloud/calendar/issues/598)
+- Fix correct highlighting of today on weekends
+  [#726](https://github.com/nextcloud/calendar/issues/726)
+- Fix handling of VEvents that contain only Recurrence-IDs
+  [#722](https://github.com/nextcloud/calendar/issues/722)
+
+## 1.6.0 - 2018-02-05
+### Fixed
+- Compatibility with 13
+- Enter in new attendee field closes sidebar
+  [#502](https://github.com/nextcloud/calendar/issues/502)
+- Displayname is missing on public sharing site
+  [#596](https://github.com/nextcloud/calendar/issues/596)
+- Small / short dates not usable in any agenda view
+  [#221](https://github.com/nextcloud/calendar/issues/221)
+- Missing 'Nextcloud' logo when accessing shared calendar
+  [#571](https://github.com/nextcloud/calendar/issues/571)
+
+### Informational:
+- Shortcut changed: The events editor can be closed with CTRL / CMD + Enter now
+- 1.6.0 does not support Nextcloud 12 and below, the 1.5 tree will be maintained till Nextcloud 12 is end of life
+
+## 1.5.7 - 2017-12-08
+### Fixed
+- Issue with displaying wrong year in upper left corner for certain cases
+  [#434](https://github.com/nextcloud/calendar/issues/434)
+- Don't allow importing events with the same UID in a calendar
+  [#589](https://github.com/nextcloud/calendar/issues/589)
+- Show warning about email reminders not being implemented in the server yet
+  [#676](https://github.com/nextcloud/calendar/pull/676)
+- Double escaping of alarm types in the event editor
+  [#269](https://github.com/nextcloud/calendar/issues/269)
+
+## 1.5.6 - 2017-10-18
+### Fixed
+- Issue with sharing read-write with users
+  [#606](https://github.com/nextcloud/calendar/issues/606)
+
+## 1.5.5 - 2017-09-19
+### Fixed
+- Remove invalid signed signature from release 
+
+## 1.5.4 - 2017-09-12
+### Fixed
+- Wrong timezone for Europe/Moscow
+  [#82](https://github.com/nextcloud/calendar/issues/82)
+- Double scrollbar in advanced event editor
+  [#468](https://github.com/nextcloud/calendar/pull/468)
+- Show displayname when creating a new calendar share
+  [#459](https://github.com/nextcloud/calendar/issues/459)
+- Better looking public-share notification emails on Nextcloud 12
+  [#427](https://github.com/nextcloud/calendar/issues/427)
+- Readable public sharing links
+  [#239](https://github.com/nextcloud/calendar/issues/239)
+- Today button overlapped with new calendar button in some localizations
+  [#312](https://github.com/nextcloud/calendar/issues/312)
+- Respect admin option to disable public sharing
+  [#525](https://github.com/nextcloud/calendar/issues/525)
+- Highlight current day in left sidebar datepicker
+  [#513](https://github.com/nextcloud/calendar/issues/513)
+- mispositioned buttons on public sharing site (only affected Nextcloud 11)
+  [#509](https://github.com/nextcloud/calendar/issues/509)
+- Fix checkbox style for attendee input
+  [#580](https://github.com/nextcloud/calendar/pull/580)
+- Spelling fixes
+  [#469](https://github.com/nextcloud/calendar/pull/469)
+  [#473](https://github.com/nextcloud/calendar/pull/473)
+  [#474](https://github.com/nextcloud/calendar/pull/474)
+
+## 1.5.3 - 2017-05-21
+### Added
+- allow editing props of shared calendars (Nextcloud 12 and above only)
+  [#406](https://github.com/nextcloud/calendar/issues/406)
+- add avatar to sharing list
+  [#207](https://github.com/nextcloud/calendar/issues/207)
+- effort to get rid of adblocker issues
+  [#417](https://github.com/nextcloud/calendar/pull/417)
+- color weekends slightly darker
+  [#430](https://github.com/nextcloud/calendar/pull/430)
+
+### Fixed
+- fix visual deletion of user shares
+  [#378](https://github.com/nextcloud/calendar/issues/378)
+- make sure the user can not set the end to something earlier than the start
+  [#11](https://github.com/nextcloud/calendar/issues/11)
+- increased font-size of calendar-view
+  [#166](https://github.com/nextcloud/calendar/issues/166)
+- sanitize missing VALUE=DATE when parsing ics data
+  [#376](https://github.com/nextcloud/calendar/issues/376)
+- fix visibility of import progressbar
+  [#423](https://github.com/nextcloud/calendar/issues/423)
+- properly display errors when querying events failed
+  [#359](https://github.com/nextcloud/calendar/issues/359)
+- increase ending time by an hour also when clicking on disabled time-input
+  [#438](https://github.com/nextcloud/calendar/issues/438)
+- improve visibility of vertical calendar grid
+  [#314](https://github.com/nextcloud/calendar/issues/314)
+- hide sharing actions for sharees (Nextcloud 12 and above only)
+  [#432](https://github.com/nextcloud/calendar/issues/432)
+- allow clicking on disabled time-input in sidebar (only affected Firefox)
+  [#388](https://github.com/nextcloud/calendar/issues/388)
+- fixed issue with chinese characters showing up in estonian language
+  [#264](https://github.com/nextcloud/calendar/issues/264)
+- fixed handling of Recurrence-ID
+  [#142](https://github.com/nextcloud/calendar/issues/142)
+- fixed and unified timepicker layout in editor popover and editor sidebar
+  [#72](https://github.com/nextcloud/calendar/issues/72)
+- improved visibility of current-day color
+  [#395](https://github.com/nextcloud/calendar/pull/395)
+- fix issue with too long webcal urls
+  [#325](https://github.com/nextcloud/calendar/issues/325)
+- show proper empty content view for non-existing public calendar links
+  [#240](https://github.com/nextcloud/calendar/issues/240)
+- refactored public calendar links page
+  [#243](https://github.com/nextcloud/calendar/issues/243)
+- fixed position of mobile menu on public calendar link page
+  [#248](https://github.com/nextcloud/calendar/issues/248)
+
+## 1.5.2 - 2017-03-21
+### Fixed
+- fixed issue with "three-part-timezone" like America/Argentina/Buenos_Aires
+  [#358](https://github.com/nextcloud/calendar/issues/358)
+
+## 1.5.1 - 2017-02-28
+### Added
+- advanced color-picker
+  [#4](https://github.com/nextcloud/calendar/issues/4)
+- support for Internet Explorer 11
+  [#329](https://github.com/nextcloud/calendar/pull/329)
+- added second step for deleting calendars
+  [#341](https://github.com/nextcloud/calendar/issues/341)
+
+### Fixed
+- debounce vertical window resize
+  [#23](https://github.com/nextcloud/calendar/issues/23)
+- fix phrasing on public sharing site
+  [#233](https://github.com/nextcloud/calendar/issues/233)
+- fix missing am/pm label in timepicker
+  [#345](https://github.com/nextcloud/calendar/issues/345)
+
+## 1.5.0 - 2017-01-17
+### Added
+- enable calendar when selecting it in editor
+  [#24](https://github.com/nextcloud/calendar/issues/24)
+- autoresize input for title, description and location
+  [#72](https://github.com/nextcloud/calendar/issues/72)
+- disable all-day when clicking on time-input
+  [#72](https://github.com/nextcloud/calendar/issues/72)
+- save 301 responses from webcal subscriptions
+  [#42](https://github.com/nextcloud/calendar/issues/42)
+- add web-based protocol handlers for WebCAL
+  [#41](https://github.com/nextcloud/calendar/issues/41)
+- better tabindex for event editors
+  [#25](https://github.com/nextcloud/calendar/issues/25)
+- lazy load timezones when rendering events
+  [#14](https://github.com/nextcloud/calendar/issues/14)
+- hide sidepanel on print view
+- replace TRIGGER:P with TRIGGER:P0D
+  [#251](https://github.com/nextcloud/calendar/issues/251)
+
+### Fixed
+- Require sharing api for creating new shares
+  [#205](https://github.com/nextcloud/calendar/issues/205)
+- Importing empty calendars
+  [#194](https://github.com/nextcloud/calendar/issues/194)
+- List app in office category
+- fix sending the RSVP parameter for attendees
+  [#102](https://github.com/nextcloud/calendar/issues/102)
+- fix styling issue with too long group names / too long translations
+  [#99](https://github.com/nextcloud/calendar/issues/99)
+- fix capitalization of Settings & import
+- fix icon share padding
+- fix glitchy looking whitespace in event details
+  [#242](https://github.com/nextcloud/calendar/issues/242)
+
+## 1.4.1 - 2016-11-22
+### Fixed
+- more consistent styles with Nextcloud
+- fixed scrolling of calendar-list
+- added details tab in sidebar
+- improved ARIA support
+- publishing calendars (requires Nextcloud 11)
+- removed eventLimit, all events will be displayed in month view
+- better border styles for calendar grid to enhance usability
+- fixed drag and drop between grid and allday area
+- fixed issue that prevented users from creating events in UTC
+- fixed issue with expanding repeating events on first day of week
+- expand settings area on first run
+- sanitize malformed dates, fixes compatibility with FB birthday webcal
+- attendee: show email address when user has multiple email addresses
+
+## 1.4.0 - 2016-09-19
+### Added
+- WebCal
+- Random color picker
+- Display week numbers
+
+### Fixed
+- Delete alarms from events
+- Adjusted colors to Nextcloud
+- Properly display line breaks in agenda views

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -23,7 +23,7 @@
 * 📎 **Attachments!** Add, upload and view event attachments
 * 🙈 **We’re not reinventing the wheel!** Based on the great [c-dav library](https://github.com/nextcloud/cdav-library), [ical.js](https://github.com/mozilla-comm/ical.js) and [fullcalendar](https://github.com/fullcalendar/fullcalendar) libraries.
 	]]></description>
-	<version>6.3.0-beta.0</version>
+	<version>6.2.0-beta.0</version>
 	<licence>agpl</licence>
 	<author homepage="https://github.com/GVodyanov">Grigory Vodyanov</author>
 	<author homepage="https://github.com/SebastianKrupinski">Sebastian Krupinski </author>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "calendar",
-  "version": "6.3.0-beta.0",
+  "version": "6.2.0-beta.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "calendar",
   "description": "A calendar app for Nextcloud. Easily sync events from various devices, share and edit them online.",
-  "version": "6.3.0-beta.0",
+  "version": "6.2.0-beta.0",
   "keywords": [
     "nextcloud",
     "calendars",


### PR DESCRIPTION
### Summary
This reverts commit bed5c14534aa41de05f8e35d5c2e9d70fc85ca60.

Release bot bumped the version incorrectly.