### PR TITLE
fix: appointment booking room creation

### DIFF
--- a/lib/Service/Appointments/BookingCalendarWriter.php
+++ b/lib/Service/Appointments/BookingCalendarWriter.php
@@ -152,7 +152,9 @@ class BookingCalendarWriter {
 			);
 		}
 
-		if (!empty($config->getLocation())) {
+		if (!empty($booking->getTalkUrl())) {
+			$vEvent->add('LOCATION', $booking->getTalkUrl());
+		} elseif (!empty($config->getLocation())) {
 			$vEvent->add('LOCATION', $config->getLocation());
 		}
 


### PR DESCRIPTION
### Summary
- Fix issue with meeting room link not being added to calendar event

### Testing
- Create appointment configuration with "create a talk room" checked
- Book appointment
- Check event in calendar contains talk room link

<img width="513" height="263" alt="image" src="https://github.com/user-attachments/assets/0ebe6c8f-997b-4a28-962a-7f90b7f7ffba" />

