### PR TITLE
test: eliminate unit tests relying on order

### DIFF
--- a/tests/javascript/unit/store/contacts.test.js
+++ b/tests/javascript/unit/store/contacts.test.js
@@ -7,9 +7,12 @@ import { setActivePinia, createPinia } from 'pinia'
 
 describe('store/contacts test suite', () => {
 
-	setActivePinia(createPinia())
+	let contactsStore
 
-	const contactsStore = useContactsStore()
+	beforeEach(() => {
+		setActivePinia(createPinia())
+		contactsStore = useContactsStore()
+	})
 
 	it('should provide a default state', () => {
 		expect(contactsStore.contacts).toEqual([])
@@ -62,23 +65,11 @@ describe('store/contacts test suite', () => {
 			name: 'Jane Doe',
 			emails: ['jane.doe@example.com'],
 		}
-
-		const state = {
-			contacts: [
-				contact1,
-				contact2,
-			],
-			contactByEmail: {
-				'john.doe@example.com': contact1,
-				'jane.doe@example.com': contact2,
-			},
-		}
-
-		contactsStore.contacts = state.contacts
-		contactsStore.contactByEmail = state.contactByEmail
+		contactsStore.appendContact({ contact: contact1 })
+		contactsStore.appendContact({ contact: contact2 })
 
 		contactsStore.removeContact({ contact: contact1 })
-
+		
 		expect(contactsStore.contacts).toEqual([
 			contact2,
 		])
@@ -97,17 +88,8 @@ describe('store/contacts test suite', () => {
 			name: 'Jane Doe',
 			emails: ['jane.doe@example.com'],
 		}
-
-		const state = {
-			contacts: [
-				contact1,
-				contact2,
-			],
-			contactByEmail: {
-				'john.doe@example.com': contact1,
-				'jane.doe@example.com': contact2,
-			},
-		}
+		contactsStore.appendContact({ contact: contact1 })
+		contactsStore.appendContact({ contact: contact2 })
 
 		const unknownContact = {
 			name: 'Foo Bar',
@@ -116,12 +98,12 @@ describe('store/contacts test suite', () => {
 
 		contactsStore.removeContact({ contact: unknownContact })
 
-		expect(state.contacts).toEqual([
+		expect(contactsStore.contacts).toEqual([
 			contact1,
 			contact2,
 		])
 
-		expect(state.contactByEmail).toEqual({
+		expect(contactsStore.contactByEmail).toEqual({
 			'john.doe@example.com': contact1,
 			'jane.doe@example.com': contact2,
 		})

--- a/tests/javascript/unit/store/tasks.test.js
+++ b/tests/javascript/unit/store/tasks.test.js
@@ -7,24 +7,27 @@ import { setActivePinia, createPinia } from 'pinia'
 
 describe('store/tasks test suite', () => {
 
-    setActivePinia(createPinia())
+	let tasksStore
 
-    const tasksStore = useTasksStore()
+	beforeEach(() => {
+		setActivePinia(createPinia())
+		tasksStore = useTasksStore()
+	})
 
     it('should provide a default state', () => {
         expect(tasksStore.map).toEqual({})
     })
 
     const task1 = {
-        id: "1-1",
+        id: "1",
         title: "Task 1",
     }
     const task2 = {
-        id: "1-2",
+        id: "2",
         title: "Task 2",
     }
     const task3 = {
-        id: "1-3",
+        id: "3",
         title: "Task 3",
     }
 
@@ -54,57 +57,17 @@ describe('store/tasks test suite', () => {
         ])
     })
 
-    const task4 = {
-        id: "1-4",
-        title: "Task 4"
-    }
-    const task5 = {
-        id: "1-5",
-        title: "Task 5"
-    }
-
     it('should provide a mutation to remove a task - existing', () => {
+        tasksStore.appendTask(1, task1)
+        tasksStore.removeTask(1, task1)
 
-
-        tasksStore.appendTask(1, task4)
-        tasksStore.appendTask(2, task5)
-
-        tasksStore.removeTask(1, task4)
-
-        expect(tasksStore.map[1]).toEqual([
-                task1,
-                task2,
-                task3
-             ])
-
-        expect(tasksStore.map[2]).toEqual([
-           task2,
-           task5])
+        expect(tasksStore.map[1]).toEqual([])
     })
 
-
-    const task6 = {
-        id: "1-6",
-        title: "Task 6"
-    }
-    const task7 = {
-        id: "1-7",
-        title: "Task 7"
-    }
-    const task8 = {
-        id: "1-8",
-        title: "Task 8"
-    }
-
     it('should provide a mutation to remove a task - non-existing', () => {
+        tasksStore.appendTask(1, task1)
+        tasksStore.removeTask(1, task2)
 
-
-        tasksStore.appendTask(1, task6)
-        tasksStore.appendTask(1, task7)
-
-        tasksStore.removeTask(1, task8)
-
-        expect(tasksStore.map[1]).toEqual([task1, task2, task3, task6, task7])
-
+        expect(tasksStore.map[1]).toEqual([task1])
     })
 })


### PR DESCRIPTION
In tests, some stores were not recreated before each test. They broke when running them in a random order.
This could be achieved by running `npx vitest --run  --sequence.shuffle`.

Properly recreating stores also allowed refactoring the tests to make them more clear.