### PR TITLE
fix(CalendarGrid): a small edge case with short events

### DIFF
--- a/src/components/CalendarGrid.vue
+++ b/src/components/CalendarGrid.vue
@@ -166,7 +166,7 @@ export default {
 				// Dropping Tasks
 				droppable: true,
 				eventReceive: this.handleEventReceive,
-				eventShortHeight: 40,
+				eventShortHeight: 38,
 			}
 		},
 


### PR DESCRIPTION
| Before | After |
| - | - |
| <img width="230" height="83" alt="Screenshot From 2026-02-17 12-06-46" src="https://github.com/user-attachments/assets/30e4e945-046e-4c24-bfd4-713bf6e238fd" /> |<img width="230" height="83" alt="image" src="https://github.com/user-attachments/assets/d3006ceb-7049-4ac8-a332-d30f413bc719" /> |
