### PR TITLE
fix: all day events order

### DIFF
--- a/src/components/CalendarGrid.vue
+++ b/src/components/CalendarGrid.vue
@@ -42,9 +42,9 @@ import dayCellDidMount from '../fullcalendar/rendering/dayCellDidMount.js'
 import dayHeaderDidMount from '../fullcalendar/rendering/dayHeaderDidMount.js'
 import eventDidMount from '../fullcalendar/rendering/eventDidMount.js'
 import {
-	eventDurationOrderDesc,
-	eventOrder,
-	eventStartOrder,
+	allDayFirst,
+	allDayOrder,
+	partDayOrder,
 } from '../fullcalendar/rendering/eventOrder.js'
 import noEventsDidMount from '../fullcalendar/rendering/noEventsDidMount.js'
 // Import timezone plugins
@@ -145,7 +145,7 @@ export default {
 				dayHeaderDidMount,
 				eventDidMount,
 				noEventsDidMount,
-				eventOrder: [eventStartOrder, eventDurationOrderDesc, 'allDay', eventOrder],
+				eventOrder: [allDayFirst, allDayOrder, partDayOrder],
 				forceEventDuration: false,
 				headerToolbar: false,
 				height: '100%',

--- a/src/fullcalendar/rendering/eventOrder.js
+++ b/src/fullcalendar/rendering/eventOrder.js
@@ -2,16 +2,15 @@
  * SPDX-FileCopyrightText: 2019 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
-import { errorCatch } from '../utils/errors.js'
 
 /**
- * This sorts events by their start date and time and skips all-day events.
+ * Sorts part-day events by start date and time and skips all-day events.
  *
  * @param {EventApi} first The first full-calendar event
  * @param {EventApi} second The second full-calendar event
  * @return {number}
  */
-export function eventStartOrder(first, second) {
+export function partDayOrder(first, second) {
 	if (first.allDay && second.allDay) {
 		return 0
 	}
@@ -20,46 +19,42 @@ export function eventStartOrder(first, second) {
 }
 
 /**
- * This sorts events by their duration in descending order and skips all-day events.
+ * Sorts all-day events before timed events explicitly.
  *
  * @param {EventApi} first The first full-calendar event
  * @param {EventApi} second The second full-calendar event
  * @return {number}
  */
-export function eventDurationOrderDesc(first, second) {
-	if (first.allDay && second.allDay) {
+export function allDayFirst(first, second) {
+	if (first.allDay === second.allDay) {
 		return 0
 	}
-
-	return second.duration - first.duration
+	return first.allDay ? -1 : 1
 }
 
 /**
- * This sorts events when they occur at the same time, have the same duration
- * and the same all-day property
+ * Sorts all-day events by calendarOrder, then duration desc, then title.
  *
- * @param {EventApi} firstEvent The first full-calendar event
- * @param {EventApi} secondEvent The second full-calendar event
+ * @param {EventApi} first The first full-calendar event
+ * @param {EventApi} second The second full-calendar event
  * @return {number}
  */
-export function eventOrder(firstEvent, secondEvent) {
-	if (firstEvent.extendedProps.calendarOrder !== secondEvent.extendedProps.calendarOrder) {
-		return (firstEvent.extendedProps.calendarOrder - secondEvent.extendedProps.calendarOrder) < 0 ? -1 : 1
+export function allDayOrder(first, second) {
+	if (!first.allDay || !second.allDay) {
+		return 0
 	}
 
-	if (firstEvent.extendedProps.calendarName !== secondEvent.extendedProps.calendarName) {
-		return (firstEvent.extendedProps.calendarName < secondEvent.extendedProps.calendarName) ? -1 : 1
+	if (first.extendedProps.calendarOrder !== second.extendedProps.calendarOrder) {
+		return (first.extendedProps.calendarOrder - second.extendedProps.calendarOrder) < 0 ? -1 : 1
 	}
 
-	if (firstEvent.extendedProps.calendarId !== secondEvent.extendedProps.calendarId) {
-		return (firstEvent.extendedProps.calendarId < secondEvent.extendedProps.calendarId) ? -1 : 1
+	if (second.duration !== first.duration) {
+		return second.duration - first.duration
 	}
 
-	if (firstEvent.title !== secondEvent.title) {
-		return (firstEvent.title < secondEvent.title) ? -1 : 1
+	if (first.title !== second.title) {
+		return (first.title < second.title) ? -1 : 1
 	}
 
 	return 0
 }
-
-export default errorCatch(eventOrder, 'eventOrder')

--- a/tests/javascript/unit/fullcalendar/rendering/eventOrder.test.js
+++ b/tests/javascript/unit/fullcalendar/rendering/eventOrder.test.js
@@ -3,182 +3,153 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 import {
-	eventOrder,
-	eventStartOrder,
-	eventDurationOrderDesc,
+	allDayFirst,
+	allDayOrder,
+	partDayOrder,
 } from '../../../../../src/fullcalendar/rendering/eventOrder.js'
 
-describe('fullcalendar/eventOrder test suite', () => {
+describe('fullcalendar/eventOrder - allDayFirst', () => {
 
-	it('should sort events by the underlying calendar-order', () => {
-		const firstEvent = {
-			extendedProps: {
-				calendarOrder: 0,
-				calendarName: 'AACCEE',
-				calendarId: 'ID:AABBCC',
-			},
-			title: 'Title 123',
-		}
-		const secondEvent = {
-			extendedProps: {
-				calendarOrder: 5,
-				calendarName: 'AABBCC',
-				calendarId: 'ID:AACCEE',
-			},
-			title: 'Title 123',
-		}
+	it('should sort all-day events before timed events', () => {
+		const allDayEvent = { allDay: true }
+		const timedEvent = { allDay: false }
 
-		expect(eventOrder(firstEvent, secondEvent)).toEqual(-1)
-		expect(eventOrder(secondEvent, firstEvent)).toEqual(1)
+		expect(allDayFirst(allDayEvent, timedEvent)).toEqual(-1)
+		expect(allDayFirst(timedEvent, allDayEvent)).toEqual(1)
 	})
 
-	it('should sort events by calendar-name if calendar-order is equal', () => {
-		const firstEvent = {
-			extendedProps: {
-				calendarOrder: 42,
-				calendarName: 'AABBCC',
-				calendarId: 'ID:AACCEE',
-			},
-			title: 'Title 123',
-		}
-		const secondEvent = {
-			extendedProps: {
-				calendarOrder: 42,
-				calendarName: 'AACCEE',
-				calendarId: 'ID:AABBCC',
-			},
-			title: 'Title 123',
-		}
+	it('should return zero when both events are all-day', () => {
+		const first = { allDay: true }
+		const second = { allDay: true }
 
-		expect(eventOrder(firstEvent, secondEvent)).toEqual(-1)
-		expect(eventOrder(secondEvent, firstEvent)).toEqual(1)
+		expect(allDayFirst(first, second)).toEqual(0)
 	})
 
-	it('should sort events by calendar-id if calendar-name and calendar-order is equal', () => {
-		const firstEvent = {
-			extendedProps: {
-				calendarOrder: 42,
-				calendarName: 'AABBCC',
-				calendarId: 'ID:AABBCC',
-			},
-			title: 'Title 123',
-		}
-		const secondEvent = {
-			extendedProps: {
-				calendarOrder: 42,
-				calendarName: 'AABBCC',
-				calendarId: 'ID:AACCEE',
-			},
-			title: 'Title 123',
-		}
+	it('should return zero when both events are timed', () => {
+		const first = { allDay: false }
+		const second = { allDay: false }
 
-		expect(eventOrder(firstEvent, secondEvent)).toEqual(-1)
-		expect(eventOrder(secondEvent, firstEvent)).toEqual(1)
+		expect(allDayFirst(first, second)).toEqual(0)
+	})
+})
+
+describe('fullcalendar/eventOrder - allDayOrder', () => {
+
+	it('should return zero when either event is not all-day', () => {
+		const allDayEvent = { allDay: true, extendedProps: { calendarOrder: 0 }, duration: 1000, title: 'A' }
+		const timedEvent = { allDay: false, extendedProps: { calendarOrder: 5 }, duration: 500, title: 'B' }
+
+		expect(allDayOrder(allDayEvent, timedEvent)).toEqual(0)
+		expect(allDayOrder(timedEvent, allDayEvent)).toEqual(0)
+		expect(allDayOrder(timedEvent, timedEvent)).toEqual(0)
 	})
 
-	it('should sort events by title as a fallback', () => {
-		const firstEvent = {
-			extendedProps: {
-				calendarOrder: 42,
-				calendarName: 'AABBCC',
-				calendarId: 'ID:AABBCC',
-			},
+	it('should sort all-day events by calendarOrder ascending', () => {
+		const first = {
+			allDay: true,
+			extendedProps: { calendarOrder: 0 },
+			duration: 1000,
 			title: 'Title 123',
 		}
-		const secondEvent = {
-			extendedProps: {
-				calendarOrder: 42,
-				calendarName: 'AABBCC',
-				calendarId: 'ID:AABBCC',
-			},
-			title: 'Title 456',
+		const second = {
+			allDay: true,
+			extendedProps: { calendarOrder: 5 },
+			duration: 1000,
+			title: 'Title 123',
 		}
 
-		expect(eventOrder(firstEvent, secondEvent)).toEqual(-1)
-		expect(eventOrder(secondEvent, firstEvent)).toEqual(1)
+		expect(allDayOrder(first, second)).toEqual(-1)
+		expect(allDayOrder(second, first)).toEqual(1)
 	})
 
-	it('should return zero if all properties are equal', () => {
-		const firstEvent = {
-			extendedProps: {
-				calendarOrder: 42,
-				calendarName: 'AABBCC',
-				calendarId: 'ID:AABBCC',
-			},
+	it('should sort all-day events by duration descending when calendarOrder is equal', () => {
+		const first = {
+			allDay: true,
+			extendedProps: { calendarOrder: 1 },
+			duration: 2000,
 			title: 'Title 123',
 		}
-		const secondEvent = {
-			extendedProps: {
-				calendarOrder: 42,
-				calendarName: 'AABBCC',
-				calendarId: 'ID:AABBCC',
-			},
+		const second = {
+			allDay: true,
+			extendedProps: { calendarOrder: 1 },
+			duration: 1000,
 			title: 'Title 123',
 		}
 
-		expect(eventOrder(firstEvent, secondEvent)).toEqual(0)
-		expect(eventOrder(secondEvent, firstEvent)).toEqual(0)
+		// first has longer duration, so it should come first
+		expect(allDayOrder(first, second)).toBeLessThan(0)
+		expect(allDayOrder(second, first)).toBeGreaterThan(0)
 	})
 
-	it('should sort events by start (ascending)', () => {
+	it('should sort all-day events by title when calendarOrder and duration are equal', () => {
+		const first = {
+			allDay: true,
+			extendedProps: { calendarOrder: 1 },
+			duration: 1000,
+			title: 'AAA',
+		}
+		const second = {
+			allDay: true,
+			extendedProps: { calendarOrder: 1 },
+			duration: 1000,
+			title: 'BBB',
+		}
+
+		expect(allDayOrder(first, second)).toEqual(-1)
+		expect(allDayOrder(second, first)).toEqual(1)
+	})
+
+	it('should return zero when all properties are equal', () => {
+		const first = {
+			allDay: true,
+			extendedProps: { calendarOrder: 1 },
+			duration: 1000,
+			title: 'Title 123',
+		}
+		const second = {
+			allDay: true,
+			extendedProps: { calendarOrder: 1 },
+			duration: 1000,
+			title: 'Title 123',
+		}
+
+		expect(allDayOrder(first, second)).toEqual(0)
+		expect(allDayOrder(second, first)).toEqual(0)
+	})
+})
+
+describe('fullcalendar/eventOrder - partDayOrder', () => {
+
+	it('should sort timed events by start time ascending', () => {
 		const firstEvent = {
 			title: 'Title 123',
+			allDay: false,
 			start: 1000,
 		}
 		const secondEvent = {
 			title: 'Title 123',
+			allDay: false,
 			start: 1001,
 		}
 
-		expect(eventStartOrder(firstEvent, secondEvent)).toBeLessThan(0)
-		expect(eventStartOrder(secondEvent, firstEvent)).toBeGreaterThan(0)
-		expect(eventStartOrder(firstEvent, firstEvent)).toBe(0)
+		expect(partDayOrder(firstEvent, secondEvent)).toBeLessThan(0)
+		expect(partDayOrder(secondEvent, firstEvent)).toBeGreaterThan(0)
+		expect(partDayOrder(firstEvent, firstEvent)).toBe(0)
 	})
 
-	it('should sort events by start - skip all-day', () => {
+	it('should return zero when both events are all-day', () => {
 		const firstEvent = {
 			title: 'Title 123',
 			start: 1000,
-			allDay: 1,
+			allDay: true,
 		}
 		const secondEvent = {
 			title: 'Title 123',
 			start: 1001,
-			allDay: 1,
+			allDay: true,
 		}
 
-		expect(eventStartOrder(firstEvent, secondEvent)).toBe(0)
-		expect(eventStartOrder(secondEvent, firstEvent)).toBe(0)
-	})
-
-	it('should sort events by duration (descending)', () => {
-		const firstEvent = {
-			title: 'Title 123',
-			duration: 1000,
-		}
-		const secondEvent = {
-			title: 'Title 123',
-			duration: 1001,
-		}
-
-		expect(eventDurationOrderDesc(firstEvent, secondEvent)).toBeGreaterThan(0)
-		expect(eventDurationOrderDesc(secondEvent, firstEvent)).toBeLessThan(0)
-		expect(eventDurationOrderDesc(firstEvent, firstEvent)).toBe(0)
-	})
-
-	it('should sort events by duration - skip all-day', () => {
-		const firstEvent = {
-			title: 'Title 123',
-			duration: 1000,
-			allDay: 1,
-		}
-		const secondEvent = {
-			title: 'Title 123',
-			duration: 1001,
-			allDay: 1,
-		}
-
-		expect(eventDurationOrderDesc(firstEvent, secondEvent)).toBe(0)
-		expect(eventDurationOrderDesc(secondEvent, firstEvent)).toBe(0)
+		expect(partDayOrder(firstEvent, secondEvent)).toBe(0)
+		expect(partDayOrder(secondEvent, firstEvent)).toBe(0)
 	})
 })


### PR DESCRIPTION
### Summary
- Resolves: https://github.com/nextcloud/calendar/issues/7978
- Resolves: internal ticket
- Modified sort logic to be more consistent in sorting

### Logic 
- All day events first
- All day order -> calendar order -> event duration -> event title
- Part day order -> start time

Can't share screen shots was using internal private data