### PR TITLE
fix(EditFull): some styling issues after vue3 migration

### DIFF
--- a/css/app-full.scss
+++ b/css/app-full.scss
@@ -60,7 +60,7 @@
 	display: flex;
 	align-content: center;
 	align-items: center;
-	gap: calc(var(--default-grid-baseline) * 6);
+	gap: calc(var(--default-grid-baseline) * 4);
 	justify-content: flex-start;
 
 	&__input {
@@ -70,6 +70,11 @@
 		.v-select {
 			width: 100%;
 			margin: 0 !important;
+			overflow-x: hidden;
+
+			.vs__dropdown-toggle {
+				overflow-y: visible !important;
+			}
 		}
 	}
 }

--- a/src/views/EditFull.vue
+++ b/src/views/EditFull.vue
@@ -962,10 +962,6 @@ export default {
 		gap: calc(var(--default-grid-baseline) * 4);
 	}
 
-	.v-select.select {
-		min-width: unset !important;
-	}
-
 	.property-alarm-item {
 		margin-inline-start: calc(var(--default-grid-baseline) * 5);
 	}


### PR DESCRIPTION
| Before | After |
| - | - |
| <img width="1045" height="358" alt="image" src="https://github.com/user-attachments/assets/431e9d3f-d000-491a-bda5-7783fc39d4ee" /> | <img width="1098" height="295" alt="image" src="https://github.com/user-attachments/assets/1de20f70-c43e-4036-b6c0-c7bcd0418545" /> |