### PR TITLE
fix: put default calendar selector back

### DIFF
--- a/src/components/AppNavigation/Settings.vue
+++ b/src/components/AppNavigation/Settings.vue
@@ -27,6 +27,13 @@
 					:name="t('calendar', 'General')">
 					<SettingsTimezoneSelect
 						:isDisabled="loadingCalendars" />
+					<CalendarPicker
+						:value="defaultCalendar"
+						:calendars="defaultCalendarOptions"
+						:disabled="savingDefaultCalendarId"
+						:inputLabel="$t('calendar', 'Default calendar for incoming invitations')"
+						:clearable="false"
+						@selectCalendar="changeDefaultCalendar" />
 					<NcFormBox>
 						<NcFormBoxButton
 							target="_blank"
@@ -147,6 +154,7 @@ import {
 } from '@nextcloud/vue'
 import { mapState, mapStores } from 'pinia'
 import CogIcon from 'vue-material-design-icons/CogOutline.vue'
+import CalendarPicker from '../Shared/CalendarPicker.vue'
 import SettingsAttachmentsFolder from './Settings/SettingsAttachmentsFolder.vue'
 import SettingsImportSection from './Settings/SettingsImportSection.vue'
 import SettingsTimezoneSelect from './Settings/SettingsTimezoneSelect.vue'
@@ -171,6 +179,7 @@ export default {
 		NcAppSettingsDialog,
 		NcAppSettingsSection,
 		NcSelect,
+		CalendarPicker,
 		SettingsImportSection,
 		SettingsTimezoneSelect,
 		SettingsAttachmentsFolder,


### PR DESCRIPTION
### Summary
- added the calendar picker component back to the settings modal

<img width="945" height="444" alt="image" src="https://github.com/user-attachments/assets/28def357-3b66-4936-a903-3b918262e4fd" />
