### PR TITLE
Feat/valarm suppression shared calendars

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -43,6 +43,9 @@ return [
 		['name' => 'contact#getContactGroupMembers', 'url' => '/v1/autocompletion/groupmembers', 'verb' => 'POST'],
 		// Settings
 		['name' => 'settings#setConfig', 'url' => '/v1/config/{key}', 'verb' => 'POST'],
+		// Share alarm suppression
+		['name' => 'shareAlarm#get', 'url' => '/v1/share-alarm', 'verb' => 'GET'],
+		['name' => 'shareAlarm#toggle', 'url' => '/v1/share-alarm', 'verb' => 'POST'],
 		// Tools
 		['name' => 'email#sendEmailPublicLink', 'url' => '/v1/public/sendmail', 'verb' => 'POST'],
 	],

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -12,11 +12,13 @@ use OCA\Calendar\Events\BeforeAppointmentBookedEvent;
 use OCA\Calendar\Listener\AppointmentBookedListener;
 use OCA\Calendar\Listener\CalendarReferenceListener;
 use OCA\Calendar\Listener\NotifyPushListener;
+use OCA\Calendar\Listener\SabrePluginAddListener;
 use OCA\Calendar\Listener\UserDeletedListener;
 use OCA\Calendar\Notification\Notifier;
 use OCA\Calendar\Profile\AppointmentsAction;
 use OCA\Calendar\Reference\ReferenceProvider;
 use OCA\Calendar\UserMigration\Migrator;
+use OCA\DAV\Events\SabrePluginAddEvent;
 use OCP\AppFramework\App;
 use OCP\AppFramework\Bootstrap\IBootContext;
 use OCP\AppFramework\Bootstrap\IBootstrap;
@@ -62,6 +64,8 @@ class Application extends App implements IBootstrap {
 		$context->registerEventListener(CalendarObjectCreatedEvent::class, NotifyPushListener::class);
 		$context->registerEventListener(CalendarObjectUpdatedEvent::class, NotifyPushListener::class);
 		$context->registerEventListener(CalendarObjectDeletedEvent::class, NotifyPushListener::class);
+
+		$context->registerEventListener(SabrePluginAddEvent::class, SabrePluginAddListener::class);
 
 		$context->registerNotifierService(Notifier::class);
 

--- a/lib/Controller/ShareAlarmController.php
+++ b/lib/Controller/ShareAlarmController.php
@@ -1,0 +1,145 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Calendar\Controller;
+
+use OCA\Calendar\AppInfo\Application;
+use OCA\Calendar\Db\ShareAlarmSetting;
+use OCA\Calendar\Db\ShareAlarmSettingMapper;
+use OCA\Calendar\Http\JsonResponse;
+use OCA\DAV\CalDAV\CalDavBackend;
+use OCP\AppFramework\Controller;
+use OCP\AppFramework\Db\DoesNotExistException;
+use OCP\AppFramework\Http;
+use OCP\IRequest;
+use Psr\Log\LoggerInterface;
+
+class ShareAlarmController extends Controller {
+
+	public function __construct(
+		IRequest $request,
+		private readonly ShareAlarmSettingMapper $mapper,
+		private readonly CalDavBackend $calDavBackend,
+		private readonly LoggerInterface $logger,
+		private readonly ?string $userId,
+	) {
+		parent::__construct(Application::APP_ID, $request);
+	}
+
+	/**
+	 * Get alarm suppression settings for all shares of a calendar
+	 *
+	 * @NoAdminRequired
+	 *
+	 * @param string $calendarUrl The owner's calendar DAV URL
+	 * @return JsonResponse
+	 */
+	public function get(string $calendarUrl): JsonResponse {
+		if ($this->userId === null) {
+			return JsonResponse::fail(null, Http::STATUS_UNAUTHORIZED);
+		}
+
+		$calendarId = $this->resolveCalendarId($calendarUrl);
+		if ($calendarId === null) {
+			return JsonResponse::fail('Calendar not found', Http::STATUS_NOT_FOUND);
+		}
+
+		$settings = $this->mapper->findAllByCalendarId($calendarId);
+		$result = [];
+		foreach ($settings as $setting) {
+			$result[$setting->getPrincipalUri()] = $setting->getSuppressAlarms();
+		}
+
+		return JsonResponse::success($result);
+	}
+
+	/**
+	 * Toggle alarm suppression for a specific share
+	 *
+	 * @NoAdminRequired
+	 *
+	 * @param string $calendarUrl The owner's calendar DAV URL
+	 * @param string $principalUri The sharee's principal URI
+	 * @param bool $suppressAlarms Whether to suppress alarms
+	 * @return JsonResponse
+	 */
+	public function toggle(string $calendarUrl, string $principalUri, bool $suppressAlarms): JsonResponse {
+		if ($this->userId === null) {
+			return JsonResponse::fail(null, Http::STATUS_UNAUTHORIZED);
+		}
+
+		$calendarId = $this->resolveCalendarId($calendarUrl);
+		if ($calendarId === null) {
+			return JsonResponse::fail('Calendar not found', Http::STATUS_NOT_FOUND);
+		}
+
+		try {
+			$setting = $this->mapper->findByCalendarAndPrincipal($calendarId, $principalUri);
+			$setting->setSuppressAlarms($suppressAlarms);
+			$this->mapper->update($setting);
+		} catch (DoesNotExistException) {
+			$setting = new ShareAlarmSetting();
+			$setting->setCalendarId($calendarId);
+			$setting->setPrincipalUri($principalUri);
+			$setting->setSuppressAlarms($suppressAlarms);
+			$this->mapper->insert($setting);
+		} catch (\Exception $e) {
+			$this->logger->error('Failed to toggle alarm suppression', [
+				'exception' => $e,
+				'calendarUrl' => $calendarUrl,
+				'principalUri' => $principalUri,
+			]);
+			return JsonResponse::fail(null, Http::STATUS_INTERNAL_SERVER_ERROR);
+		}
+
+		return JsonResponse::success(['suppressAlarms' => $suppressAlarms]);
+	}
+
+	/**
+	 * Resolve a calendar DAV URL to its internal integer ID
+	 *
+	 * Parses the URL to extract the owner and calendar URI, then looks up
+	 * the calendar in the CalDAV backend. Also verifies the current user
+	 * owns the calendar.
+	 *
+	 * @param string $calendarUrl The calendar DAV URL (e.g. /remote.php/dav/calendars/owner/calname/)
+	 * @return int|null The internal calendar ID, or null if not found or not owned
+	 */
+	private function resolveCalendarId(string $calendarUrl): ?int {
+		// Extract owner and calendar URI from the URL
+		// Expected format: .../calendars/{owner}/{calendarUri}/...
+		if (!preg_match('#/calendars/([^/]+)/([^/]+)#', $calendarUrl, $matches)) {
+			$this->logger->warning('Could not parse calendar URL', ['calendarUrl' => $calendarUrl]);
+			return null;
+		}
+
+		$ownerName = $matches[1];
+		$calendarUri = $matches[2];
+
+		// Verify the current user is the calendar owner
+		if ($ownerName !== $this->userId) {
+			$this->logger->warning('User attempted to modify alarm settings for a calendar they do not own', [
+				'userId' => $this->userId,
+				'ownerName' => $ownerName,
+			]);
+			return null;
+		}
+
+		$principalUri = 'principals/users/' . $ownerName;
+		$calendars = $this->calDavBackend->getCalendarsForUser($principalUri);
+
+		foreach ($calendars as $calendar) {
+			if ($calendar['uri'] === $calendarUri) {
+				return (int)$calendar['id'];
+			}
+		}
+
+		return null;
+	}
+}

--- a/lib/Dav/StripAlarmsPlugin.php
+++ b/lib/Dav/StripAlarmsPlugin.php
@@ -1,0 +1,235 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Calendar\Dav;
+
+use OCA\Calendar\Db\ShareAlarmSettingMapper;
+use Sabre\CalDAV\ICalendarObject;
+use Sabre\DAV\INode;
+use Sabre\DAV\PropFind;
+use Sabre\DAV\Server;
+use Sabre\DAV\ServerPlugin;
+use Sabre\HTTP\RequestInterface;
+use Sabre\HTTP\ResponseInterface;
+use Sabre\VObject\Reader;
+use Psr\Log\LoggerInterface;
+
+/**
+ * SabreDAV plugin that strips VALARM components from CalDAV responses
+ * for shared calendars where the owner has enabled alarm suppression.
+ */
+class StripAlarmsPlugin extends ServerPlugin {
+
+	private ?Server $server = null;
+
+	/** @var array<string, bool> In-memory cache for suppression lookups per request */
+	private array $suppressionCache = [];
+
+	public function __construct(
+		private readonly ShareAlarmSettingMapper $mapper,
+		private readonly LoggerInterface $logger,
+	) {
+	}
+
+	/**
+	 * Returns the plugin name
+	 *
+	 * @return string
+	 */
+	public function getPluginName(): string {
+		return 'nc-calendar-strip-alarms';
+	}
+
+	/**
+	 * Register event handlers on the SabreDAV server
+	 *
+	 * @param Server $server The SabreDAV server instance
+	 */
+	public function initialize(Server $server): void {
+		$this->server = $server;
+		// Priority 600: runs after CalDAV plugin's propFind handlers (150-550)
+		// so that calendar-data is already populated
+		$server->on('propFind', [$this, 'handlePropFind'], 600);
+		// Handle direct GET requests on calendar objects
+		$server->on('afterMethod:GET', [$this, 'handleAfterGet']);
+	}
+
+	/**
+	 * Handle propFind events for REPORT responses (calendar-multiget, calendar-query)
+	 *
+	 * Checks if the calendar-data property contains VALARM components that
+	 * should be stripped for this sharee, and removes them.
+	 *
+	 * @param PropFind $propFind The PropFind object
+	 * @param INode $node The node being queried
+	 */
+	public function handlePropFind(PropFind $propFind, INode $node): void {
+		if (!($node instanceof ICalendarObject)) {
+			return;
+		}
+
+		if (!$this->shouldStripAlarms($node)) {
+			return;
+		}
+
+		$calendarData = $propFind->get('{urn:ietf:params:xml:ns:caldav}calendar-data');
+		if ($calendarData === null) {
+			return;
+		}
+
+		$stripped = $this->stripVAlarms($calendarData);
+		if ($stripped !== null) {
+			$propFind->set('{urn:ietf:params:xml:ns:caldav}calendar-data', $stripped);
+		}
+	}
+
+	/**
+	 * Handle afterMethod:GET events for direct GET requests on calendar objects
+	 *
+	 * @param RequestInterface $request The HTTP request
+	 * @param ResponseInterface $response The HTTP response
+	 */
+	public function handleAfterGet(RequestInterface $request, ResponseInterface $response): void {
+		$path = $request->getPath();
+
+		try {
+			$node = $this->server->tree->getNodeForPath($path);
+		} catch (\Exception) {
+			return;
+		}
+
+		if (!($node instanceof ICalendarObject)) {
+			return;
+		}
+
+		if (!$this->shouldStripAlarms($node)) {
+			return;
+		}
+
+		$body = $response->getBodyAsString();
+		if (empty($body)) {
+			return;
+		}
+
+		$stripped = $this->stripVAlarms($body);
+		if ($stripped !== null) {
+			$response->setBody($stripped);
+		}
+	}
+
+	/**
+	 * Determine whether VALARM components should be stripped from this node
+	 *
+	 * Checks if the node belongs to a shared calendar where the owner
+	 * has enabled alarm suppression for the current sharee.
+	 *
+	 * @param ICalendarObject $node The calendar object node
+	 * @return bool True if alarms should be stripped
+	 */
+	private function shouldStripAlarms(ICalendarObject $node): bool {
+		$calendarInfo = $this->getCalendarInfo($node);
+		if ($calendarInfo === null) {
+			return false;
+		}
+
+		$ownerPrincipal = $calendarInfo['{http://owncloud.org/ns}owner-principal'] ?? null;
+		$principalUri = $calendarInfo['principaluri'] ?? null;
+
+		// Not a shared calendar if owner matches current principal
+		if ($ownerPrincipal === null || $principalUri === null || $ownerPrincipal === $principalUri) {
+			return false;
+		}
+
+		$calendarId = $calendarInfo['id'] ?? null;
+		if ($calendarId === null) {
+			return false;
+		}
+
+		$cacheKey = $calendarId . ':' . $principalUri;
+		if (isset($this->suppressionCache[$cacheKey])) {
+			return $this->suppressionCache[$cacheKey];
+		}
+
+		$result = $this->mapper->isSuppressed((int)$calendarId, $principalUri);
+		$this->suppressionCache[$cacheKey] = $result;
+		return $result;
+	}
+
+	/**
+	 * Extract calendarInfo from a CalendarObject node
+	 *
+	 * Tries direct method access first, then falls back to looking up
+	 * the parent Calendar node from the server tree.
+	 *
+	 * @param ICalendarObject $node The calendar object node
+	 * @return array|null The calendarInfo array, or null if unavailable
+	 */
+	private function getCalendarInfo(ICalendarObject $node): ?array {
+		// Nextcloud's CalendarObject extends Sabre's CalendarObject which
+		// stores calendarInfo as a protected property. Try reflection to
+		// access it if no public method is available.
+		if (method_exists($node, 'getCalendarInfo')) {
+			return $node->getCalendarInfo();
+		}
+
+		// Fallback: use reflection to access the protected calendarInfo property
+		try {
+			$reflection = new \ReflectionClass($node);
+			$property = $reflection->getProperty('calendarInfo');
+			return $property->getValue($node);
+		} catch (\ReflectionException) {
+			// Reflection failed, try parent node lookup
+		}
+
+		// Last resort: look up the parent Calendar node from the server tree
+		try {
+			$path = $this->server->getRequestUri();
+			$parentPath = dirname($path);
+			$parent = $this->server->tree->getNodeForPath($parentPath);
+			if (method_exists($parent, 'getCalendarInfo')) {
+				return $parent->getCalendarInfo();
+			}
+		} catch (\Exception $e) {
+			$this->logger->debug('Could not determine calendar info for alarm stripping', [
+				'exception' => $e,
+			]);
+		}
+
+		return null;
+	}
+
+	/**
+	 * Strip all VALARM components from ICS data
+	 *
+	 * Follows the same pattern as CalendarObject::removeVAlarms() in the
+	 * Nextcloud server's apps/dav/lib/CalDAV/CalendarObject.php.
+	 *
+	 * @param string $calendarData Raw ICS data
+	 * @return string|null Modified ICS data with VALARMs removed, or null on error
+	 */
+	private function stripVAlarms(string $calendarData): ?string {
+		try {
+			$vObject = Reader::read($calendarData);
+			$subcomponents = $vObject->getComponents();
+
+			foreach ($subcomponents as $subcomponent) {
+				unset($subcomponent->VALARM);
+			}
+
+			$result = $vObject->serialize();
+			$vObject->destroy();
+			return $result;
+		} catch (\Exception $e) {
+			$this->logger->warning('Failed to strip VALARM from calendar data', [
+				'exception' => $e,
+			]);
+			return null;
+		}
+	}
+}

--- a/lib/Db/ShareAlarmSetting.php
+++ b/lib/Db/ShareAlarmSetting.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Calendar\Db;
+
+use OCP\AppFramework\Db\Entity;
+use OCP\DB\Types;
+
+/**
+ * @method int getCalendarId()
+ * @method void setCalendarId(int $calendarId)
+ * @method string getPrincipalUri()
+ * @method void setPrincipalUri(string $principalUri)
+ * @method bool getSuppressAlarms()
+ * @method void setSuppressAlarms(bool $suppressAlarms)
+ */
+class ShareAlarmSetting extends Entity {
+	/** @var int */
+	protected $calendarId;
+
+	/** @var string */
+	protected $principalUri;
+
+	/** @var bool */
+	protected $suppressAlarms = false;
+
+	public function __construct() {
+		$this->addType('calendarId', Types::INTEGER);
+		$this->addType('suppressAlarms', Types::BOOLEAN);
+	}
+}

--- a/lib/Db/ShareAlarmSettingMapper.php
+++ b/lib/Db/ShareAlarmSettingMapper.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Calendar\Db;
+
+use OCP\AppFramework\Db\DoesNotExistException;
+use OCP\AppFramework\Db\QBMapper;
+use OCP\DB\QueryBuilder\IQueryBuilder;
+use OCP\IDBConnection;
+
+/**
+ * @template-extends QBMapper<ShareAlarmSetting>
+ */
+class ShareAlarmSettingMapper extends QBMapper {
+
+	public function __construct(IDBConnection $db) {
+		parent::__construct($db, 'calendar_share_alarms');
+	}
+
+	/**
+	 * Find the alarm suppression setting for a specific calendar and sharee
+	 *
+	 * @param int $calendarId The internal calendar ID
+	 * @param string $principalUri The sharee's principal URI
+	 * @return ShareAlarmSetting
+	 * @throws DoesNotExistException When no setting exists
+	 */
+	public function findByCalendarAndPrincipal(int $calendarId, string $principalUri): ShareAlarmSetting {
+		$qb = $this->db->getQueryBuilder();
+		$qb->select('*')
+			->from($this->getTableName())
+			->where($qb->expr()->eq('calendar_id', $qb->createNamedParameter($calendarId, IQueryBuilder::PARAM_INT)))
+			->andWhere($qb->expr()->eq('principal_uri', $qb->createNamedParameter($principalUri)));
+		return $this->findEntity($qb);
+	}
+
+	/**
+	 * Check whether alarms should be suppressed for a given calendar and sharee
+	 *
+	 * @param int $calendarId The internal calendar ID
+	 * @param string $principalUri The sharee's principal URI
+	 * @return bool True if alarms should be suppressed
+	 */
+	public function isSuppressed(int $calendarId, string $principalUri): bool {
+		try {
+			$setting = $this->findByCalendarAndPrincipal($calendarId, $principalUri);
+			return $setting->getSuppressAlarms();
+		} catch (DoesNotExistException) {
+			return false;
+		}
+	}
+
+	/**
+	 * Find all alarm settings for a given calendar
+	 *
+	 * @param int $calendarId The internal calendar ID
+	 * @return ShareAlarmSetting[]
+	 */
+	public function findAllByCalendarId(int $calendarId): array {
+		$qb = $this->db->getQueryBuilder();
+		$qb->select('*')
+			->from($this->getTableName())
+			->where($qb->expr()->eq('calendar_id', $qb->createNamedParameter($calendarId, IQueryBuilder::PARAM_INT)));
+		return $this->findEntities($qb);
+	}
+
+	/**
+	 * Delete all alarm settings for a calendar
+	 *
+	 * @param int $calendarId The internal calendar ID
+	 */
+	public function deleteByCalendarId(int $calendarId): void {
+		$qb = $this->db->getQueryBuilder();
+		$qb->delete($this->getTableName())
+			->where($qb->expr()->eq('calendar_id', $qb->createNamedParameter($calendarId, IQueryBuilder::PARAM_INT)));
+		$qb->executeStatement();
+	}
+
+	/**
+	 * Delete alarm setting for a specific share
+	 *
+	 * @param int $calendarId The internal calendar ID
+	 * @param string $principalUri The sharee's principal URI
+	 */
+	public function deleteByCalendarAndPrincipal(int $calendarId, string $principalUri): void {
+		$qb = $this->db->getQueryBuilder();
+		$qb->delete($this->getTableName())
+			->where($qb->expr()->eq('calendar_id', $qb->createNamedParameter($calendarId, IQueryBuilder::PARAM_INT)))
+			->andWhere($qb->expr()->eq('principal_uri', $qb->createNamedParameter($principalUri)));
+		$qb->executeStatement();
+	}
+}

--- a/lib/Listener/SabrePluginAddListener.php
+++ b/lib/Listener/SabrePluginAddListener.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Calendar\Listener;
+
+use OCA\Calendar\Dav\StripAlarmsPlugin;
+use OCA\DAV\Events\SabrePluginAddEvent;
+use OCP\EventDispatcher\Event;
+use OCP\EventDispatcher\IEventListener;
+
+/**
+ * Registers the StripAlarmsPlugin with the SabreDAV server
+ *
+ * @template-implements IEventListener<SabrePluginAddEvent>
+ */
+class SabrePluginAddListener implements IEventListener {
+
+	public function __construct(
+		private readonly StripAlarmsPlugin $plugin,
+	) {
+	}
+
+	/**
+	 * Handle the SabrePluginAddEvent by registering the alarm stripping plugin
+	 *
+	 * @param Event $event The event to handle
+	 */
+	#[\Override]
+	public function handle(Event $event): void {
+		if (!($event instanceof SabrePluginAddEvent)) {
+			return;
+		}
+
+		$event->getServer()->addPlugin($this->plugin);
+	}
+}

--- a/lib/Migration/Version5050Date20250701000005.php
+++ b/lib/Migration/Version5050Date20250701000005.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Calendar\Migration;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\DB\Types;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+class Version5050Date20250701000005 extends SimpleMigrationStep {
+	/**
+	 * @param IOutput $output
+	 * @param Closure $schemaClosure The `\Closure` returns a `ISchemaWrapper`
+	 * @param array $options
+	 * @return null|ISchemaWrapper
+	 */
+	#[\Override]
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
+		$schema = $schemaClosure();
+
+		if ($schema->hasTable('calendar_share_alarms')) {
+			return $schema;
+		}
+
+		$table = $schema->createTable('calendar_share_alarms');
+		$table->addColumn('id', Types::BIGINT, [
+			'autoincrement' => true,
+			'notnull' => true,
+			'unsigned' => true,
+		]);
+		$table->addColumn('calendar_id', Types::BIGINT, [
+			'notnull' => true,
+			'unsigned' => true,
+		]);
+		$table->addColumn('principal_uri', Types::STRING, [
+			'notnull' => true,
+			'length' => 255,
+		]);
+		$table->addColumn('suppress_alarms', Types::BOOLEAN, [
+			'notnull' => false,
+			'default' => false,
+		]);
+
+		$table->setPrimaryKey(['id']);
+		$table->addUniqueIndex(['calendar_id', 'principal_uri'], 'cal_share_alarm_unique');
+
+		return $schema;
+	}
+}

--- a/src/components/AppNavigation/EditCalendarModal.vue
+++ b/src/components/AppNavigation/EditCalendarModal.vue
@@ -6,7 +6,7 @@
 <template>
 	<NcModal
 		v-if="!!calendarsStore.editCalendarModal && calendar"
-		size="normal"
+		size="large"
 		:name="$t('calendar', 'Edit calendar')"
 		@close="closeModal">
 		<div class="edit-calendar-modal">
@@ -222,6 +222,11 @@ export default {
 			this.calendarNameChanged = false
 			this.calendarColorChanged = false
 			this.isTransparent = calendar.transparency === 'transparent'
+
+			// Load alarm suppression settings for shares when modal opens
+			if (!calendar.isSharedWithMe && calendar.shares.length > 0) {
+				this.calendarsStore.loadShareAlarmSettings({ calendar })
+			}
 		},
 	},
 

--- a/src/components/AppNavigation/EditCalendarModal/ShareItem.vue
+++ b/src/components/AppNavigation/EditCalendarModal/ShareItem.vue
@@ -16,13 +16,22 @@
 			</p>
 		</div>
 
-		<NcCheckboxRadioSwitch
-			v-if="canBeSharedWritable"
-			v-model="isWriteable"
-			:disabled="updatingSharee"
-			@update:checked="updatePermission">
-			{{ $t('calendar', 'can edit and see confidential events') }}
-		</NcCheckboxRadioSwitch>
+		<div class="share-item__options">
+			<NcCheckboxRadioSwitch
+				v-if="canBeSharedWritable"
+				v-model="isWriteable"
+				:disabled="updatingSharee"
+				@update:modelValue="updatePermission">
+				{{ $t('calendar', 'can edit and see confidential events') }}
+			</NcCheckboxRadioSwitch>
+
+			<NcCheckboxRadioSwitch
+				v-model="isSuppressAlarms"
+				:disabled="updatingSharee"
+				@update:modelValue="updateAlarmSuppression">
+				{{ $t('calendar', 'suppress alarms') }}
+			</NcCheckboxRadioSwitch>
+		</div>
 
 		<NcActions>
 			<NcActionButton
@@ -80,6 +89,7 @@ export default {
 			updatingSharee: false,
 			shareeEmail: '',
 			isWriteable: false,
+			isSuppressAlarms: false,
 		}
 	},
 
@@ -118,13 +128,14 @@ export default {
 	},
 
 	watch: {
-		isWriteable() {
-			this.updatePermission()
+		'sharee.suppressAlarms'(newVal) {
+			this.isSuppressAlarms = newVal
 		},
 	},
 
 	mounted() {
 		this.isWriteable = this.initialIsWriteable
+		this.isSuppressAlarms = this.sharee.suppressAlarms || false
 		this.updateShareeEmail()
 	},
 
@@ -171,6 +182,26 @@ export default {
 			}
 		},
 
+		/**
+		 * Toggles alarm suppression for this sharee
+		 *
+		 * @return {Promise<void>}
+		 */
+		async updateAlarmSuppression() {
+			this.updatingSharee = true
+			try {
+				await this.calendarsStore.toggleShareAlarmSuppression({
+					calendar: this.calendar,
+					uri: this.sharee.uri,
+				})
+				this.updatingSharee = false
+			} catch (error) {
+				console.error(error)
+				showInfo(this.$t('calendar', 'An error occurred, unable to change the alarm suppression setting.'))
+				this.updatingSharee = false
+			}
+		},
+
 		async updateShareeEmail() {
 			if (this.sharee.isGroup || this.sharee.isCircle) {
 				return
@@ -213,11 +244,22 @@ export default {
 	&__label {
 		flex: 1 auto;
 		flex-direction: column;
+		min-width: 0;
+		overflow: hidden;
+		text-overflow: ellipsis;
 
 		p {
 			color: var(--color-text-lighter);
 			line-height: 1;
 		}
+	}
+
+	&__options {
+		display: flex;
+		gap: 4px;
+		margin-inline-start: auto;
+		white-space: nowrap;
+		flex-shrink: 0;
 	}
 }
 </style>

--- a/src/models/calendarShare.js
+++ b/src/models/calendarShare.js
@@ -32,6 +32,8 @@ function getDefaultCalendarShareObject(props = {}) {
 		isRemoteUser: false,
 		// Uri necessary for deleting / updating share
 		uri: null,
+		// Whether alarms are suppressed for this sharee
+		suppressAlarms: false,
 		...props,
 	}
 }

--- a/src/services/shareAlarmService.js
+++ b/src/services/shareAlarmService.js
@@ -1,0 +1,43 @@
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import axios from '@nextcloud/axios'
+import { generateUrl } from '@nextcloud/router'
+import logger from '../utils/logger.js'
+
+/**
+ * Fetch alarm suppression settings for all shares of a calendar
+ *
+ * @param {string} calendarUrl The owner's calendar DAV URL
+ * @return {Promise<object>} Map of principalUri to suppressAlarms boolean
+ */
+export async function getShareAlarmSettings(calendarUrl) {
+	logger.debug('Fetching share alarm settings', { calendarUrl })
+	const url = generateUrl('/apps/calendar/v1/share-alarm')
+
+	const response = await axios.get(url, {
+		params: { calendarUrl },
+	})
+	return response.data.data ?? {}
+}
+
+/**
+ * Toggle alarm suppression for a specific share
+ *
+ * @param {string} calendarUrl The owner's calendar DAV URL
+ * @param {string} principalUri The sharee's principal URI (without 'principal:' prefix)
+ * @param {boolean} suppressAlarms Whether to suppress alarms
+ * @return {Promise<void>}
+ */
+export async function toggleShareAlarmSuppression(calendarUrl, principalUri, suppressAlarms) {
+	logger.debug('Toggling share alarm suppression', { calendarUrl, principalUri, suppressAlarms })
+	const url = generateUrl('/apps/calendar/v1/share-alarm')
+
+	await axios.post(url, {
+		calendarUrl,
+		principalUri,
+		suppressAlarms,
+	})
+}

--- a/src/store/calendars.js
+++ b/src/store/calendars.js
@@ -23,6 +23,7 @@ import {
 	findAllDeletedCalendars,
 	findPublicCalendarsByTokens,
 } from '../services/caldavService.js'
+import { getShareAlarmSettings, toggleShareAlarmSuppression } from '../services/shareAlarmService.js'
 import getTimezoneManager from '../services/timezoneDataProviderService.js'
 import { uidToHexColor } from '../utils/color.js'
 import { dateFactory, getUnixTimestampFromDate } from '../utils/date.js'
@@ -626,6 +627,44 @@ export default defineStore('calendars', {
 			/// TODO test this not sure what it does
 			calendar = this.calendars.find((search) => search.id === calendar.id)
 			sharee.writeable = !sharee.writeable
+		},
+
+		/**
+		 * Load alarm suppression settings for all shares of a calendar
+		 *
+		 * @param {object} data destructuring object
+		 * @param {object} data.calendar the calendar
+		 * @return {Promise<void>}
+		 */
+		async loadShareAlarmSettings({ calendar }) {
+			try {
+				const settings = await getShareAlarmSettings(calendar.url)
+				for (const sharee of calendar.shares) {
+					const principalUri = sharee.uri.replace('principal:', '')
+					sharee.suppressAlarms = settings[principalUri] ?? false
+				}
+			} catch (error) {
+				logger.error('Failed to load share alarm settings', { error })
+			}
+		},
+
+		/**
+		 * Toggle alarm suppression for a specific share
+		 *
+		 * @param {object} data destructuring object
+		 * @param {object} data.calendar the calendar to change
+		 * @param {string} data.uri the sharing principalScheme uri
+		 * @return {Promise<void>}
+		 */
+		async toggleShareAlarmSuppression({ calendar, uri }) {
+			const sharee = calendar.shares.find((s) => s.uri === uri)
+			const principalUri = uri.replace('principal:', '')
+			const newValue = !sharee.suppressAlarms
+
+			await toggleShareAlarmSuppression(calendar.url, principalUri, newValue)
+
+			calendar = this.calendars.find((search) => search.id === calendar.id)
+			sharee.suppressAlarms = newValue
 		},
 
 		/**


### PR DESCRIPTION
# Owner-Controlled VALARM Suppression for Shared Calendars

## Problem

When a Nextcloud calendar is shared with read-write access, VALARM (alarm/reminder) components from the owner's events are transmitted to the sharee via CalDAV. Android calendar apps synced via DAVx5 have no per-calendar notification suppression, causing unwanted alerts on the sharee's device.

**Existing behavior**: Nextcloud server's `CalendarObject::get()` (in `apps/dav`) already strips VALARM for **read-only** shared calendars. For **read-write** shares, VALARM is preserved.

**Reference**: [Issue #7498](https://github.com/nextcloud/calendar/issues/7498)

## Solution

Register a SabreDAV plugin from the calendar app via the `SabrePluginAddEvent` mechanism (NC 28+; this app targets NC 32+). The plugin intercepts CalDAV responses and strips VALARM when the owner has enabled suppression for that share. A new database table stores the per-share preference, and the sharing UI exposes the toggle.

The owner controls the setting: in the calendar edit/share modal, each sharee row has a "suppress alarms" checkbox alongside the existing "can edit" checkbox.

---

## Plan

### Architecture

```
┌─────────────────────────────────────────────────────────────────┐
│  Frontend (Vue/JS)                                              │
│                                                                 │
│  EditCalendarModal.vue                                          │
│    └─ ShareItem.vue  ←── "suppress alarms" checkbox per sharee  │
│         └─ calendars.js store                                   │
│              └─ shareAlarmService.js  ←── axios API calls        │
└─────────────────────┬───────────────────────────────────────────┘
                      │  POST/GET /v1/share-alarm
                      ▼
┌─────────────────────────────────────────────────────────────────┐
│  Backend (PHP)                                                  │
│                                                                 │
│  ShareAlarmController.php  ←── resolves calendar URL to ID,     │
│    │                           verifies ownership               │
│    └─ ShareAlarmSettingMapper.php  ←── reads/writes DB          │
│         └─ calendar_share_alarms table                          │
│                                                                 │
│  StripAlarmsPlugin.php  ←── SabreDAV plugin (registered via     │
│    │                        SabrePluginAddEvent)                 │
│    ├─ propFind handler (priority 600) for REPORT responses      │
│    ├─ afterMethod:GET handler for direct GET requests            │
│    └─ ShareAlarmSettingMapper.isSuppressed() with in-mem cache  │
└─────────────────────────────────────────────────────────────────┘
```

### Data Flow

1. **Owner** opens EditCalendarModal, sees "suppress alarms" checkbox per sharee
2. Toggling calls `POST /v1/share-alarm` → upserts record in `calendar_share_alarms`
3. **Sharee's** CalDAV client (DAVx5) fetches events via REPORT or GET
4. `StripAlarmsPlugin` intercepts, checks DB (cached), strips VALARM from ICS data
5. Sharee receives clean ICS without alarm components → no unwanted notifications

---

## Files Created

| File | Purpose |
|------|---------|
| `lib/Migration/Version5050Date20250701000005.php` | DB migration: `calendar_share_alarms` table with `calendar_id`, `principal_uri`, `suppress_alarms` |
| `lib/Db/ShareAlarmSetting.php` | Entity class for alarm suppression setting |
| `lib/Db/ShareAlarmSettingMapper.php` | QBMapper with `isSuppressed()`, `findAllByCalendarId()`, and cleanup methods |
| `lib/Dav/StripAlarmsPlugin.php` | SabreDAV plugin: `propFind` (priority 600) + `afterMethod:GET` hooks, in-memory cache, VALARM stripping via `Sabre\VObject\Reader` |
| `lib/Listener/SabrePluginAddListener.php` | Registers `StripAlarmsPlugin` via `SabrePluginAddEvent` |
| `lib/Controller/ShareAlarmController.php` | API controller: `GET /v1/share-alarm` and `POST /v1/share-alarm`, ownership verification, calendar URL→ID resolution via `CalDavBackend` |
| `src/services/shareAlarmService.js` | Frontend API service using `@nextcloud/axios` |

## Files Modified

| File | Change |
|------|--------|
| `lib/AppInfo/Application.php` | Registered `SabrePluginAddListener` for `SabrePluginAddEvent` |
| `appinfo/routes.php` | Added `GET` and `POST /v1/share-alarm` routes |
| `src/models/calendarShare.js` | Added `suppressAlarms: false` to default share object |
| `src/store/calendars.js` | Added `loadShareAlarmSettings` and `toggleShareAlarmSuppression` actions |
| `src/components/AppNavigation/EditCalendarModal/ShareItem.vue` | Added "suppress alarms" `NcCheckboxRadioSwitch`, watcher, and `updateAlarmSuppression()` method |
| `src/components/AppNavigation/EditCalendarModal.vue` | Loads alarm settings when modal opens for owned calendars with shares |

---

## Database Schema

```sql
CREATE TABLE calendar_share_alarms (
    id          BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
    calendar_id BIGINT UNSIGNED NOT NULL,   -- internal calendar ID
    principal_uri VARCHAR(255) NOT NULL,     -- e.g. 'principals/users/alice'
    suppress_alarms BOOLEAN NOT NULL DEFAULT FALSE,
    UNIQUE INDEX cal_share_alarm_unique (calendar_id, principal_uri)
);
```

## API Endpoints

### `GET /apps/calendar/v1/share-alarm?calendarUrl=...`

Returns suppression state for all shares of a calendar.

```json
{
    "status": "success",
    "data": {
        "principals/users/alice": true,
        "principals/users/bob": false
    }
}
```

### `POST /apps/calendar/v1/share-alarm`

Toggles suppression for one share.

```json
{
    "calendarUrl": "/remote.php/dav/calendars/owner/calname/",
    "principalUri": "principals/users/alice",
    "suppressAlarms": true
}
```

---

## SabreDAV Plugin Details

`StripAlarmsPlugin` hooks into two interception points:

1. **`propFind` (priority 600)** — For REPORT requests (calendar-multiget, calendar-query). Runs after the CalDAV plugin (priority 150-550) has populated `{urn:ietf:params:xml:ns:caldav}calendar-data`. Calls `propFind->get()` to read the ICS, strips VALARM, calls `propFind->set()` to replace.

2. **`afterMethod:GET`** — For direct GET on `.ics` files. Reads `response->getBodyAsString()`, strips VALARM, calls `response->setBody()`.

**VALARM stripping** follows the same pattern as the server's `CalendarObject::removeVAlarms()`:
```php
$vObject = Reader::read($calendarData);
foreach ($vObject->getComponents() as $subcomponent) {
    unset($subcomponent->VALARM);
}
return $vObject->serialize();
```

**Performance**: An in-memory `$suppressionCache` array (keyed by `calendarId:principalUri`) avoids repeated DB lookups for objects in the same calendar during a single REPORT response.

**CalendarInfo access**: Uses reflection as fallback to access the protected `calendarInfo` property on Sabre's `CalendarObject`, with a last-resort parent node lookup via the server tree.

---

## Known Caveats

1. **`calendarInfo` access**: The plugin uses reflection to access the protected `calendarInfo` property on `CalendarObject`. This should be tested against the actual Nextcloud server version. If `getCalendarInfo()` becomes public in a future NC version, the reflection fallback becomes unnecessary.

2. **Calendar ID resolution**: The controller resolves the calendar URL to an internal ID via `CalDavBackend::getCalendarsForUser()`. This adds a dependency on the DAV app's backend class (`OCA\DAV\CalDAV\CalDavBackend`).

3. **Principal URI format mismatch**: Frontend uses `principal:principals/users/alice` (cdav-library format), backend uses `principals/users/alice`. The store actions strip the `principal:` prefix before API calls.

4. **`propFind->set()` after lazy eval**: The `PropFind::set()` behavior after `get()` triggers lazy evaluation needs verification against the SabreDAV version bundled with NC 32+.

---

## Verification

### Unit Tests
- `ShareAlarmSettingMapper`: CRUD operations, `isSuppressed()` returns false for missing records
- `StripAlarmsPlugin`: Mock `CalendarObject` node with `calendarInfo`, verify VALARM stripping when enabled and no-op when disabled

### Manual End-to-End
1. Owner creates calendar with events containing VALARM
2. Owner shares calendar with read-write access to another user
3. Owner opens EditCalendarModal, enables "suppress alarms" for the sharee
4. Sharee syncs via DAVx5 or fetches via:
   ```bash
   curl -u sharee:pass https://cloud.example.com/remote.php/dav/calendars/sharee/shared-cal/event.ics
   ```
5. Verify the ICS response contains no VALARM components
6. Toggle off, re-sync, verify VALARM is present again
