### PR TITLE
fix: adding circles to events (#6023)

### DIFF
--- a/lib/Controller/ContactController.php
+++ b/lib/Controller/ContactController.php
@@ -11,6 +11,7 @@ use Exception;
 use OCA\Calendar\Service\ContactsService;
 use OCA\Calendar\Service\ServiceException;
 use OCA\Circles\Exceptions\CircleNotFoundException;
+use OCA\Circles\Model\Member;
 use OCP\App\IAppManager;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http;
@@ -222,21 +223,43 @@ class ContactController extends Controller {
 		$circleMembers = $circle->getInheritedMembers();
 
 		foreach ($circleMembers as $circleMember) {
+			$email = "";
 			if ($circleMember->isLocal()) {
 
 				$circleMemberUserId = $circleMember->getUserId();
 
-				$user = $this->userManager->get($circleMemberUserId);
+				switch ($circleMember->getUserType()) {
+					case Member::TYPE_USER:
+						$user = $this->userManager->get($circleMemberUserId);
+						$email = $user ? $user->getEMailAddress() : "";
+						break;
 
-				if ($user === null) {
-					throw new ServiceException('Could not find organizer');
+					case Member::TYPE_GROUP:
+						// Ignored, as `getInheritedMembers` already fetches all members
+						continue 2;
+
+					case Member::TYPE_MAIL:
+						$email = $circleMemberUserId;
+						break;
+
+					case Member::TYPE_CONTACT:
+						// Currently you can't add contacts to circles, just mails of contacts
+						continue 2;
+
+					case Member::TYPE_CIRCLE:
+						// Ignored, as `getInheritedMembers` already fetches all members
+						continue 2;
+
+					default:
+						$this->logger->warning("Unknown usertype for circle member with ID: {$circleMemberUserId}");
+						continue 2;
 				}
 
 				$contacts[] = [
 					'commonName' => $circleMember->getDisplayName(),
 					'calendarUserType' => 'INDIVIDUAL',
-					'email' => $user->getEMailAddress(),
-					'isUser' => true,
+					'email' => $email,
+					'isUser' => $circleMember->getUserType() === 1,
 					'avatar' => $circleMemberUserId,
 					'hasMultipleEMails' => false,
 					'dropdownName' => $circleMember->getDisplayName(),


### PR DESCRIPTION
[ContactController::getCircleMembers](https://github.com/nextcloud/calendar/blob/main/lib/Controller/ContactController.php) is used to fetch all members of a circle, when adding that circle to an event.

Currently the function assumes members to be a nextcloud user:
https://github.com/nextcloud/calendar/blob/04e8e493108bfce34d3800b74be19ba2dea22480/lib/Controller/ContactController.php#L227-L229

This results in empty return values, which in turn causes an error and results in no member of the circle being added
https://github.com/nextcloud/calendar/blob/0a0dc2382fbc6eb0ac871b7273adee15316c3ae4/lib/Controller/ContactController.php#L231-L233

The PR changes the code to handle all types separately. Whilst this is not perfect and problems like federation or auto-updating memberlists are not solved by this it at least provides a short term fix for #6023 #6485 and one aspect of https://github.com/nextcloud/circles/issues/1690 if I'm not mistaken.