### PR TITLE
fix: meeting proposal public view position

### DIFF
--- a/src/views/Proposal/ProposalPublic.vue
+++ b/src/views/Proposal/ProposalPublic.vue
@@ -193,7 +193,7 @@ export default {
 
 .proposal-public__content {
   display: flex;
-  width: 100%;
+  width: 100vw;
   height: 100vh;
   flex-direction: column;
   justify-content: center;


### PR DESCRIPTION
### Summary
- Fixed the proposal voting view positioning (Vue 3 migration regression)

### Now
<img width="1920" height="1032" alt="image" src="https://github.com/user-attachments/assets/53a2faf2-d30e-4783-b0e3-6120d194c221" />

### Before
<img width="1920" height="1032" alt="image" src="https://github.com/user-attachments/assets/5f1cbd96-0c6c-4b68-b09c-13dd99f47d26" />
