### PR TITLE
Fix: adjust color contrast of avatar participation status

### DIFF
--- a/src/components/Editor/AvatarParticipationStatus.vue
+++ b/src/components/Editor/AvatarParticipationStatus.vue
@@ -119,15 +119,23 @@ export default {
 		status() {
 			const acceptedIcon = {
 				icon: IconAccepted,
-				fillColor: '#32CD32',
+				fillColor: 'var(--color-success-text)',
 			}
 			const declinedIcon = {
 				icon: IconDeclined,
-				fillColor: '#ff4402',
+				fillColor: 'var(--color-error-text)',
 			}
 			const tentativeIcon = {
 				icon: IconTentative,
-				fillColor: '#ffc107',
+				fillColor: 'var(--color-element-warning)',
+			}
+			const delegatedIcon = {
+				icon: IconDelegated,
+				fillColor: 'vat(--color-text-maxcontrast)',
+			}
+			const noResponseIcon = {
+				icon: IconNoResponse,
+				fillColor: 'vat(--color-text-maxcontrast)',
 			}
 
 			if (this.isSuggestion) {
@@ -274,25 +282,8 @@ export default {
 		justify-self: unset !important;
 	}
 
-	&__indicator.accepted {
-		background-color: #2fb130;
-	}
-
-	&__indicator.declined {
-		background-color: #ff0000;
-	}
-
-	&__indicator.tentative {
-		background-color: #ffa704;
-	}
-
-	&__indicator.delegated,
-	&__indicator.no-response {
-		background-color: grey;
-	}
-
 	&__text {
-		opacity: .45;
+		color: var(--color-text-maxcontrast);
 		inset-inline-start: 58px;
 		bottom: 21px;
 		white-space: nowrap;


### PR DESCRIPTION
Related to [Issue 7929](https://github.com/nextcloud/calendar/issues/7929)

- Bumps opacity for avatar participation status text for minimum AAA contrast (checked with [WebAIM contrast checker](https://webaim.org/resources/contrastchecker/))
- Creates variables for status colors for easier future refactor
- Update colors for equivalent ones with more contrast. Checked with [WebAIM contrast checker](https://webaim.org/resources/contrastchecker/) using the Graphical Objects and User Interface Components result as reference.
- Clean up unused styles.