### PR TITLE
fix: calendar name input

### DIFF
--- a/src/components/AppNavigation/CalendarList/CalendarListNew.vue
+++ b/src/components/AppNavigation/CalendarList/CalendarListNew.vue
@@ -262,10 +262,15 @@ export default {
 		 * @param {Event} event The submit event
 		 */
 		async createNewCalendar(event) {
+			const displayName = event.target.querySelector('input[type=text]').value
+
+			if (!displayName.trim()) {
+				showError(this.$t('calendar', 'Calendar name can not be blank'))
+				return
+			}
+
 			this.showCreateCalendarInput = false
 			this.showCreateCalendarSaving = true
-
-			const displayName = event.target.querySelector('input[type=text]').value
 
 			try {
 				await this.calendarsStore.appendCalendar({
@@ -289,10 +294,15 @@ export default {
 		 * @param {Event} event The submit event
 		 */
 		async createNewCalendarTaskList(event) {
+			const displayName = event.target.querySelector('input[type=text]').value
+
+			if (!displayName.trim()) {
+				showError(this.$t('calendar', 'Calendar name can not be blank'))
+				return
+			}
+
 			this.showCreateCalendarTaskListInput = false
 			this.showCreateCalendarTaskListSaving = true
-
-			const displayName = event.target.querySelector('input[type=text]').value
 
 			try {
 				await this.calendarsStore.appendCalendar({
@@ -317,10 +327,7 @@ export default {
 		 * @param {Event} event The submit event
 		 */
 		async createNewSubscription(event) {
-			this.showCreateSubscriptionInput = false
-			this.showCreateSubscriptionSaving = true
-
-			const link = event.target.querySelector('input[type=text]').value
+			const link = event.target.querySelector('input[type=text]')?.value.trim()
 			let url
 			let hostname
 			try {
@@ -331,6 +338,9 @@ export default {
 				showError(this.$t('calendar', 'Please enter a valid link (starting with http://, https://, webcal://, or webcals://)'))
 				return
 			}
+
+			this.showCreateSubscriptionInput = false
+			this.showCreateSubscriptionSaving = true
 
 			try {
 				await this.calendarsStore.appendSubscription({

--- a/src/components/AppNavigation/EditCalendarModal.vue
+++ b/src/components/AppNavigation/EditCalendarModal.vue
@@ -34,6 +34,8 @@
 					class="edit-calendar-modal__name-and-color__name"
 					:label="$t('calendar', 'Calendar name')"
 					:labelOutside="true"
+					:error="!isCalendarNameValid"
+					:helperText="!isCalendarNameValid ? $t('calendar', 'Calendar name can not be blank') : ''"
 					@update:modelValue="calendarNameChanged = true" />
 			</div>
 			<template v-if="canBeShared">
@@ -77,7 +79,7 @@
 					</template>
 					{{ $t('calendar', 'Export') }}
 				</NcButton>
-				<NcButton variant="secondary" @click="saveAndClose">
+				<NcButton variant="secondary" :disabled="!isCalendarNameValid" @click="saveAndClose">
 					<template #icon>
 						<CheckIcon :size="20" />
 					</template>
@@ -175,6 +177,15 @@ export default {
 		 */
 		downloadUrl() {
 			return this.calendar.url + '?export'
+		},
+
+		/**
+		 * Whether the calendar name is non-blank.
+		 *
+		 * @return {boolean}
+		 */
+		isCalendarNameValid() {
+			return !!this.calendarName?.trim()
 		},
 
 		/**
@@ -276,7 +287,7 @@ export default {
 			try {
 				await this.calendarsStore.renameCalendar({
 					calendar: this.calendar,
-					newName: this.calendarName,
+					newName: this.calendarName.trim(),
 				})
 			} catch (error) {
 				logger.error('Failed to save calendar name', {
@@ -293,6 +304,9 @@ export default {
 		 * @return {Promise<void>}
 		 */
 		async saveAndClose() {
+			if (!this.isCalendarNameValid) {
+				return
+			}
 			try {
 				if (this.calendarColorChanged) {
 					await this.saveColor()


### PR DESCRIPTION
### Summary
- resolves: https://github.com/nextcloud/calendar/issues/8037
- added logic to prevent calendar being created with a blank name
- added logic to prevent calendar name from being set to blank
- added logic to prevent calendar subscription from being submitted with invalid url