### PR TITLE
Replace "Calendars" with "My" calendars in to be consistent with "Shared" calendars

### DIFF
--- a/src/components/AppNavigation/CalendarList/CalendarListNew.vue
+++ b/src/components/AppNavigation/CalendarList/CalendarListNew.vue
@@ -8,7 +8,7 @@
 		<NcAppNavigationCaption
 			class="app-navigation-entry-new-calendar"
 			:class="{ 'app-navigation-entry-new-calendar--open': isOpen }"
-			:name="$t('calendar', 'Calendars')"
+			:name="$t('calendar', 'My calendars')"
 			:menuOpen="isOpen"
 			@update:menuOpen="setMenuOpen"
 			@click.prevent.stop="toggleDialog">


### PR DESCRIPTION
Currently, the “Calendars” section does not actually contain all calendars, but only mine, so not the “Shared calendars”. 

To clarify things, I suggest replacing "Calendars" with "My calendars" in order to make a clearer ownership distinction.

Here is what the PR is supposed to change (⚠️ I request tests from reviewers) : 

<img width="309" height="884" alt="2026-03-06_09-22" src="https://github.com/user-attachments/assets/99b4df15-931f-4e44-8ee9-588e51b6338f" />
