### PR TITLE
fix: NcSelect inner text overflowing in EditFull

### DIFF
--- a/css/app-full.scss
+++ b/css/app-full.scss
@@ -79,6 +79,10 @@
 	}
 }
 
+.vs__selected-options {
+	max-width: calc(100% - var(--default-clickable-area) - var(--default-grid-baseline));
+}
+
 .property-repeat__summary__content {
 	max-width: 300px;
 }


### PR DESCRIPTION
| Before | After |
| - | - |
|<img width="389" height="244" alt="image" src="https://github.com/user-attachments/assets/6cbe1ac9-f7d4-4722-a474-efee4397892f" /> | <img width="389" height="244" alt="image" src="https://github.com/user-attachments/assets/25adbe74-6d48-45f9-8696-bec3f3a6b344" /> |