### PR TITLE
fix: cannot edit calendar event with external attendees (#8050)

### DIFF
--- a/src/components/Editor/Invitees/InviteesListSearch.vue
+++ b/src/components/Editor/Invitees/InviteesListSearch.vue
@@ -145,6 +145,7 @@ export default {
 							timezoneId: null,
 							hasMultipleEMails: false,
 							dropdownName: query,
+							scheduleAgent: 'CLIENT',
 						})
 					}
 				}

--- a/src/models/attendee.js
+++ b/src/models/attendee.js
@@ -31,6 +31,8 @@ function getDefaultAttendeeObject(props = {}) {
 		uri: null,
 		// Member address of the attendee
 		member: null,
+		// The SCHEDULE-AGENT parameter value for the attendee ('CLIENT' for external attendees)
+		scheduleAgent: null,
 		...props,
 	}
 }
@@ -51,6 +53,7 @@ function mapAttendeePropertyToAttendeeObject(attendeeProperty) {
 		rsvp: attendeeProperty.rsvp,
 		uri: attendeeProperty.email,
 		member: attendeeProperty.member,
+		scheduleAgent: attendeeProperty.getParameterFirstValue('SCHEDULE-AGENT') ?? null,
 	})
 }
 

--- a/src/store/calendarObjectInstance.js
+++ b/src/store/calendarObjectInstance.js
@@ -430,6 +430,7 @@ export default defineStore('calendarObjectInstance', {
 		 * @param {string=} data.timezoneId Preferred timezone of the attendee
 		 * @param {object=} data.organizer Principal of the organizer to be set if not present
 		 * @param {string | Array} data.member Group membership(s)
+		 * @param {string=} data.scheduleAgent Optional SCHEDULE-AGENT parameter value ('CLIENT'- for external attendees or null for server handled scheduling)
 		 */
 		addAttendee({
 			calendarObjectInstance,
@@ -443,6 +444,7 @@ export default defineStore('calendarObjectInstance', {
 			timezoneId = null,
 			organizer = null,
 			member = null,
+			scheduleAgent = null,
 		}) {
 			const attendee = AttendeeProperty.fromNameAndEMail(commonName, uri)
 			if (calendarUserType !== null) {
@@ -466,6 +468,9 @@ export default defineStore('calendarObjectInstance', {
 			if (member !== null) {
 				attendee.updateParameterIfExist('MEMBER', member)
 			}
+			if (scheduleAgent !== null) {
+				attendee.setParameter(new Parameter('SCHEDULE-AGENT', scheduleAgent))
+			}
 
 			// TODO - use real addAttendeeFrom method
 			calendarObjectInstance.eventComponent.addProperty(attendee)
@@ -476,6 +481,7 @@ export default defineStore('calendarObjectInstance', {
 				rsvp,
 				uri,
 				attendeeProperty: attendee,
+				scheduleAgent,
 			})
 
 			if (!calendarObjectInstance.organizer && organizer) {

--- a/src/store/calendarObjects.js
+++ b/src/store/calendarObjects.js
@@ -96,7 +96,7 @@ export default defineStore('calendarObjects', {
 		 * Updates a calendar-object
 		 *
 		 * @param {object} data destructuring object
-		 * @param {CalendarObject} data.calendarObject Calendar-object to delete
+		 * @param {CalendarObject} data.calendarObject Calendar-object to update
 		 * @return {Promise<void>}
 		 */
 		async updateCalendarObject({ calendarObject }) {
@@ -105,7 +105,19 @@ export default defineStore('calendarObjects', {
 
 			if (calendarObject.existsOnServer) {
 				calendarObject.dav.data = calendarObject.calendarComponent.toICS()
-				await calendarObject.dav.update()
+				try {
+					await calendarObject.dav.update()
+				} catch (error) {
+					logger.error('Could not update calendar object', { error })
+					this.resetCalendarObjectToDavMutation({ calendarObject })
+					throw error
+				}
+
+				if (!calendarObject.dav.etag) {
+					calendarObject.dav.fetchCompleteData(true).catch((error) => {
+						logger.warn('Could not refetch calendar object ETag after update', { error })
+					})
+				}
 
 				fetchedTimeRangesStore.addCalendarObjectIdToAllTimeRangesOfCalendar({
 					calendarId: calendarObject.calendarId,
@@ -119,7 +131,12 @@ export default defineStore('calendarObjects', {
 			}
 
 			const calendar = calendarsStore.getCalendarById(calendarObject.calendarId)
-			calendarObject.dav = await calendar.dav.createVObject(calendarObject.calendarComponent.toICS())
+			try {
+				calendarObject.dav = await calendar.dav.createVObject(calendarObject.calendarComponent.toICS())
+			} catch (error) {
+				logger.error('Could not create calendar object', { error })
+				throw error
+			}
 			calendarObject.existsOnServer = true
 			this.updateCalendarObjectIdMutation({ calendarObject })
 

--- a/tests/javascript/unit/models/attendee.test.js
+++ b/tests/javascript/unit/models/attendee.test.js
@@ -3,8 +3,8 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-import {getDefaultAttendeeObject, mapAttendeePropertyToAttendeeObject, mapPrincipalObjectToAttendeeObject} from "../../../../src/models/attendee.js";
 import { AttendeeProperty } from '@nextcloud/calendar-js'
+import { getDefaultAttendeeObject, mapAttendeePropertyToAttendeeObject, mapPrincipalObjectToAttendeeObject } from '../../../../src/models/attendee.js'
 
 describe('Test suite: Attendee model (models/attendee.js)', () => {
 
@@ -18,6 +18,7 @@ describe('Test suite: Attendee model (models/attendee.js)', () => {
 			role: 'REQ-PARTICIPANT',
 			rsvp: false,
 			uri: null,
+			scheduleAgent: null,
 		})
 	})
 
@@ -35,6 +36,7 @@ describe('Test suite: Attendee model (models/attendee.js)', () => {
 			rsvp: false,
 			uri: null,
 			otherProp: 'foo',
+			scheduleAgent: null,
 		})
 	})
 
@@ -51,6 +53,7 @@ describe('Test suite: Attendee model (models/attendee.js)', () => {
 			role: 'REQ-PARTICIPANT',
 			rsvp: true,
 			uri: 'mailto:jsmith@example.com',
+			scheduleAgent: null,
 		})
 	})
 
@@ -67,6 +70,7 @@ describe('Test suite: Attendee model (models/attendee.js)', () => {
 			role: 'REQ-PARTICIPANT',
 			rsvp: false,
 			uri: 'mailto:ietf-calsch@example.org',
+			scheduleAgent: null,
 		})
 	})
 
@@ -83,6 +87,7 @@ describe('Test suite: Attendee model (models/attendee.js)', () => {
 			role: 'REQ-PARTICIPANT',
 			rsvp: false,
 			uri: 'mailto:jsmith@example.com',
+			scheduleAgent: null,
 		})
 	})
 
@@ -99,6 +104,7 @@ describe('Test suite: Attendee model (models/attendee.js)', () => {
 			role: 'CHAIR',
 			rsvp: false,
 			uri: 'mailto:mrbig@example.com',
+			scheduleAgent: null,
 		})
 	})
 
@@ -115,6 +121,7 @@ describe('Test suite: Attendee model (models/attendee.js)', () => {
 			role: 'REQ-PARTICIPANT',
 			rsvp: false,
 			uri: 'mailto:hcabot@example.com',
+			scheduleAgent: null,
 		})
 	})
 
@@ -131,6 +138,7 @@ describe('Test suite: Attendee model (models/attendee.js)', () => {
 			role: 'NON-PARTICIPANT',
 			rsvp: false,
 			uri: 'mailto:iamboss@example.com',
+			scheduleAgent: null,
 		})
 	})
 
@@ -147,6 +155,7 @@ describe('Test suite: Attendee model (models/attendee.js)', () => {
 			role: 'REQ-PARTICIPANT',
 			rsvp: false,
 			uri: 'mailto:jdoe@example.com',
+			scheduleAgent: null,
 		})
 	})
 

--- a/tests/javascript/unit/store/calendarObjectInstance.test.js
+++ b/tests/javascript/unit/store/calendarObjectInstance.test.js
@@ -1,0 +1,191 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { AttendeeProperty } from '@nextcloud/calendar-js'
+import { createPinia, setActivePinia } from 'pinia'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import useCalendarObjectInstanceStore from '../../../../src/store/calendarObjectInstance.js'
+
+// Mock the talkService
+vi.mock('@/services/talkService', () => ({
+	updateRoomParticipantsFromEvent: vi.fn(),
+}))
+
+// Mock the timezone provider used internally by the store.
+vi.mock('../../../../src/services/timezoneDataProviderService.js', () => ({
+	default: vi.fn(() => ({
+		getTimezoneForId: vi.fn((id) => ({ timezoneId: id })),
+	})),
+}))
+
+/**
+ * Builds a minimal calendarObjectInstance
+ *
+ * @return {object}
+ */
+function createMinimalCalendarObjectInstance() {
+	return {
+		eventComponent: {
+			addProperty: vi.fn(),
+			// setOrganizerFromNameAndEMail is called when organizer is passed
+			setOrganizerFromNameAndEMail: vi.fn(),
+			getFirstProperty: vi.fn(() => null),
+		},
+		attendees: [],
+		organizer: null,
+	}
+}
+
+describe('store/calendarObjects test suite', () => {
+	it('should be true', () => {
+		expect(true).toEqual(true)
+	})
+})
+
+describe('store/calendarObjectInstance — addAttendee', () => {
+	beforeEach(() => {
+		// Create and activate a fresh Pinia instance before each test
+		setActivePinia(createPinia())
+	})
+
+	it('should add an external attendee with SCHEDULE-AGENT=CLIENT on the AttendeeProperty', () => {
+		const store = useCalendarObjectInstanceStore()
+		const calendarObjectInstance = createMinimalCalendarObjectInstance()
+
+		store.addAttendee({
+			calendarObjectInstance,
+			commonName: 'External User',
+			uri: 'external@gmail.com',
+			scheduleAgent: 'CLIENT',
+		})
+
+		expect(calendarObjectInstance.attendees).toHaveLength(1)
+
+		const attendee = calendarObjectInstance.attendees[0]
+
+		// The store object itself must carry the flag so other parts of the
+		// UI (e.g. free/busy requests) can check it without re-reading the ICS.
+		expect(attendee.scheduleAgent).toBe('CLIENT')
+
+		// The SCHEDULE-AGENT=CLIENT, which tells the CalDAV server not to attempt
+		// server-side iTIP scheduling for this address. Without this the PUT request is rejected for external users.
+		expect(attendee.attendeeProperty.getParameterFirstValue('SCHEDULE-AGENT')).toBe('CLIENT')
+	})
+
+	it('should add an internal attendee WITHOUT setting SCHEDULE-AGENT', () => {
+		const store = useCalendarObjectInstanceStore()
+		const calendarObjectInstance = createMinimalCalendarObjectInstance()
+
+		store.addAttendee({
+			calendarObjectInstance,
+			commonName: 'Internal User',
+			uri: 'internal@mynextcloud.org',
+			// scheduleAgent intentionally omitted — must default to null so
+			// the server retains control of iTIP scheduling for local users.
+		})
+
+		expect(calendarObjectInstance.attendees).toHaveLength(1)
+
+		const attendee = calendarObjectInstance.attendees[0]
+
+		expect(attendee.scheduleAgent).toBeNull()
+		// The parameter must be absent from the AttendeeProperty entirely so
+		// the server applies its default (SERVER) scheduling behaviour.
+		expect(attendee.attendeeProperty.getParameterFirstValue('SCHEDULE-AGENT')).toBeNull()
+	})
+
+	it('should add the attendee to eventComponent.addProperty', () => {
+		const store = useCalendarObjectInstanceStore()
+		const calendarObjectInstance = createMinimalCalendarObjectInstance()
+
+		store.addAttendee({
+			calendarObjectInstance,
+			commonName: 'External User',
+			uri: 'external@gmail.com',
+			scheduleAgent: 'CLIENT',
+		})
+
+		// addProperty must be called exactly once with an AttendeeProperty
+		expect(calendarObjectInstance.eventComponent.addProperty).toHaveBeenCalledOnce()
+		const [passedProperty] = calendarObjectInstance.eventComponent.addProperty.mock.calls[0]
+		expect(passedProperty).toBeInstanceOf(AttendeeProperty)
+	})
+
+	it('should set the organizer when one is passed and no organizer exists yet', () => {
+		const store = useCalendarObjectInstanceStore()
+		const calendarObjectInstance = createMinimalCalendarObjectInstance()
+
+		const organizer = {
+			displayname: 'Organizer Name',
+			emailAddress: 'organizer@mynextcloud.org',
+		}
+
+		store.addAttendee({
+			calendarObjectInstance,
+			commonName: 'External User',
+			uri: 'external@gmail.com',
+			scheduleAgent: 'CLIENT',
+			organizer,
+		})
+
+		expect(calendarObjectInstance.eventComponent.setOrganizerFromNameAndEMail)
+			.toHaveBeenCalledWith('Organizer Name', 'organizer@mynextcloud.org')
+	})
+
+	it('should NOT override an existing organizer when one is already set', () => {
+		const store = useCalendarObjectInstanceStore()
+		const calendarObjectInstance = createMinimalCalendarObjectInstance()
+
+		// Pre-set an organizer to simulate an existing event
+		calendarObjectInstance.organizer = {
+			commonName: 'Existing Organizer',
+			uri: 'existing@mynextcloud.org',
+		}
+
+		store.addAttendee({
+			calendarObjectInstance,
+			commonName: 'External User',
+			uri: 'external@gmail.com',
+			scheduleAgent: 'CLIENT',
+			organizer: {
+				displayname: 'New Organizer',
+				emailAddress: 'new@mynextcloud.org',
+			},
+		})
+
+		// setOrganizerFromNameAndEMail must NOT have been called because an
+		// organizer was already present
+		expect(calendarObjectInstance.eventComponent.setOrganizerFromNameAndEMail)
+			.not.toHaveBeenCalled()
+	})
+
+	it('should support adding multiple attendees independently', () => {
+		const store = useCalendarObjectInstanceStore()
+		const calendarObjectInstance = createMinimalCalendarObjectInstance()
+
+		store.addAttendee({
+			calendarObjectInstance,
+			commonName: 'Internal User',
+			uri: 'internal@mynextcloud.org',
+		})
+
+		store.addAttendee({
+			calendarObjectInstance,
+			commonName: 'External User',
+			uri: 'external@gmail.com',
+			scheduleAgent: 'CLIENT',
+		})
+
+		expect(calendarObjectInstance.attendees).toHaveLength(2)
+
+		const [internalAttendee, externalAttendee] = calendarObjectInstance.attendees
+
+		expect(internalAttendee.scheduleAgent).toBeNull()
+		expect(internalAttendee.attendeeProperty.getParameterFirstValue('SCHEDULE-AGENT')).toBeNull()
+
+		expect(externalAttendee.scheduleAgent).toBe('CLIENT')
+		expect(externalAttendee.attendeeProperty.getParameterFirstValue('SCHEDULE-AGENT')).toBe('CLIENT')
+	})
+})

--- a/tests/javascript/unit/store/calendarObjects.test.js
+++ b/tests/javascript/unit/store/calendarObjects.test.js
@@ -3,10 +3,94 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-describe('store/calendarObjects test suite', () => {
+import { createPinia, setActivePinia } from 'pinia'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import useCalendarObjectsStore from '../../../../src/store/calendarObjects.js'
 
+vi.mock('@nextcloud/calendar-js', async (importOriginal) => {
+	const actual = await importOriginal()
+	return {
+		...actual,
+		getParserManager: vi.fn(() => ({
+			getParserForFileType: vi.fn(() => ({
+				parse: vi.fn(),
+				getItemIterator: vi.fn(() => ({ next: vi.fn(() => ({ value: null })) })),
+			})),
+		})),
+	}
+})
+
+vi.mock('@nextcloud/timezones', () => ({
+	getTimezoneManager: vi.fn(() => ({
+		getTimezoneForId: vi.fn((id) => ({ timezoneId: id })),
+	})),
+}))
+
+function createMinimalCalendarObject(etagAfterUpdate = '"valid-etag"') {
+	const dav = {
+		data: null,
+		etag: '"old-etag"',
+		url: '/remote.php/dav/calendars/admin/personal/event.ics',
+		update: vi.fn(async function() {
+			this.etag = etagAfterUpdate
+		}),
+		fetchCompleteData: vi.fn(async function() {
+			this.etag = '"new-etag-from-propfind"'
+		}),
+	}
+	return {
+		id: btoa('/remote.php/dav/calendars/admin/personal/event.ics'),
+		calendarId: btoa('/remote.php/dav/calendars/admin/personal/'),
+		existsOnServer: true,
+		dav,
+		calendarComponent: {
+			toICS: vi.fn(() => 'BEGIN:VCALENDAR\r\nEND:VCALENDAR'),
+		},
+	}
+}
+
+describe('store/calendarObjects test suite', () => {
 	it('should be true', () => {
 		expect(true).toEqual(true)
 	})
+})
 
+describe('store/calendarObjects — updateCalendarObject ETag fix', () => {
+	beforeEach(() => {
+		setActivePinia(createPinia())
+	})
+
+	it('should NOT call fetchCompleteData when server returns a valid ETag', async () => {
+		const store = useCalendarObjectsStore()
+		const calendarObject = createMinimalCalendarObject('"valid-etag"')
+		store.calendarObjects[calendarObject.id] = calendarObject
+
+		await store.updateCalendarObject({ calendarObject })
+
+		expect(calendarObject.dav.fetchCompleteData).not.toHaveBeenCalled()
+	})
+
+	it('should call fetchCompleteData(true) when server returns null ETag', async () => {
+		const store = useCalendarObjectsStore()
+		const calendarObject = createMinimalCalendarObject(null)
+		store.calendarObjects[calendarObject.id] = calendarObject
+
+		await store.updateCalendarObject({ calendarObject })
+
+		expect(calendarObject.dav.fetchCompleteData).toHaveBeenCalledOnce()
+		expect(calendarObject.dav.fetchCompleteData).toHaveBeenCalledWith(true)
+		expect(calendarObject.dav.etag).toBe('"new-etag-from-propfind"')
+	})
+
+	it('should continue normally if fetchCompleteData throws', async () => {
+		const store = useCalendarObjectsStore()
+		const calendarObject = createMinimalCalendarObject(null)
+		store.calendarObjects[calendarObject.id] = calendarObject
+
+		calendarObject.dav.fetchCompleteData = vi.fn(async () => {
+			throw new Error('PROPFIND failed')
+		})
+
+		await expect(store.updateCalendarObject({ calendarObject })).resolves.toBeUndefined()
+	})
 })


### PR DESCRIPTION
fixes: #8050

@GretaD 
When an event has external attendees (e.g. user@gmail.com), the CalDAV server rejects the save because it tries to resolve those email addresses as local users and fails.

The fix adds SCHEDULE-AGENT=CLIENT to external attendee properties so the server knows not to handle scheduling for addresses it cannot resolve locally (RFC 6638 Section 7.1).

Also fixed the calendar grid not updating instantly after saving. The server does not return an ETag on 204 responses, which caused an unnecessary extra request before the UI could refresh. A background PROPFIND now restores the ETag immediately after saving, so the grid updates instantly.