### PR TITLE
Fix: Calendar embedding not works after migration to Vue 3

### DIFF
--- a/src/reference.js
+++ b/src/reference.js
@@ -14,27 +14,31 @@ __webpack_public_path__ = linkTo('calendar', 'js/') // eslint-disable-line
 
 // eslint-disable-next-line no-unused-vars
 registerWidget('calendar_widget', async (el, { richObjectType, richObject, accessible, interactive }) => {
-	const { default: Vue } = await import('vue')
+	const { createApp } = await import('vue')
 	const { default: Calendar } = await import('./views/Calendar.vue')
-	const { createPinia, PiniaVuePlugin } = await import('pinia')
+	const { createPinia } = await import('pinia')
 
-	Vue.use(PiniaVuePlugin)
 	const pinia = createPinia()
 
-	Vue.prototype.$t = translate
-	Vue.prototype.$n = translatePlural
-	Vue.mixin({ methods: { t, n } })
+	const app = createApp(Calendar, {
+		isWidget: true,
+		isPublic: richObject.isPublic,
+		referenceToken: richObject?.token,
+		url: richObject.url,
+	})
 
-	const Widget = Vue.extend(Calendar)
-	const vueElement = new Widget({
-		pinia,
-		propsData: {
-			isWidget: true,
-			isPublic: richObject.isPublic,
-			referenceToken: richObject?.token,
-			url: richObject.url,
+	app.use(pinia)
+	app.config.globalProperties.$t = translate
+	app.config.globalProperties.$n = translatePlural
+
+	app.mixin({
+		methods: {
+			t: translate,
+			n: translatePlural,
 		},
-	}).$mount(el)
+	})
+
+	const vueElement = app.mount(el)
 	return new NcCustomPickerRenderResult(vueElement.$el, vueElement)
 }, (el, renderResult) => {
 	renderResult.object.$destroy()


### PR DESCRIPTION
Hey mates!

It seems like you had migrated to Vue 3 recently and now calendar embedding completely broken :see_no_evil: . This PR aims to fix that

#### 🖼️ Screenshots

🏚️ Before | 🏡 After
---|---
<img width="300" alt="image" src="https://github.com/user-attachments/assets/29b59813-2761-4d7f-91d2-6c1ffca7d962" /> | <img width="300" alt="image" src="https://github.com/user-attachments/assets/1ecbd74a-b6fd-4896-bf84-8b4327ec04c9" />
