### PR TITLE
Feat Proposal email generation sent dates converted with user  timezone

### DIFF
--- a/lib/Service/Proposal/ProposalService.php
+++ b/lib/Service/Proposal/ProposalService.php
@@ -61,7 +61,7 @@ class ProposalService {
 		private IMailer $systemMailManager,
 		private IMailManager $userMailManager,
 		private IManager $calendarManager,
-		private CalendarManager $appCalendarManager;
+		private CalendarManager $appCalendarManager,
 	) {
 	}
 


### PR DESCRIPTION
At the moment the email sent with the proposed dates are in UTC so there can be a big gap with the proposed times and the user actual times. I had few comments at work.

=> This pr convert the dates to user timezone and put the user timezone add the end.

Tested 

With the following proposal
<img width="1235" height="408" alt="image" src="https://github.com/user-attachments/assets/c6e41545-c7eb-466e-bb6a-f329a7b3814d" />


Before PR Times in UTC
<img width="580" height="237" alt="image" src="https://github.com/user-attachments/assets/d87d3493-8fd9-43af-99db-dba75714000b" />





After PR Times in user timezone + timezone displayed
<img width="326" height="247" alt="image" src="https://github.com/user-attachments/assets/a046cd87-bf9c-42f2-af80-9ae1acf34306" />
