### PR TITLE
fix: add event link

### DIFF
--- a/lib/Controller/ObjectController.php
+++ b/lib/Controller/ObjectController.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+namespace OCA\Calendar\Controller;
+
+use OCA\Calendar\Service\ObjectResolverService;
+use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http\Attribute\FrontpageRoute;
+use OCP\AppFramework\Http\Attribute\NoAdminRequired;
+use OCP\AppFramework\Http\Attribute\NoCSRFRequired;
+use OCP\AppFramework\Http\RedirectResponse;
+use OCP\IRequest;
+use OCP\IURLGenerator;
+
+class ObjectController extends Controller {
+
+	public function __construct(
+		string $appName,
+		IRequest $request,
+		private ObjectResolverService $objectResolverService,
+		private IURLGenerator $urlGenerator,
+		private ?string $userId,
+	) {
+		parent::__construct($appName, $request);
+	}
+
+	/**
+	 * Resolve a permanent calendar object deep link.
+	 *
+	 * @param string $uid The iCalendar UID of the object
+	 * @param string|null $recurrenceId Unix timestamp of the recurrence instance, or null for 'next'
+	 */
+	#[NoAdminRequired]
+	#[NoCSRFRequired]
+	#[FrontpageRoute(verb: 'GET', url: '/object/{uid}', postfix: 'uid')]
+	#[FrontpageRoute(verb: 'GET', url: '/object/{uid}/{recurrenceId}', postfix: 'uid.recurrenceId')]
+	public function index(string $uid, ?string $recurrenceId = null): RedirectResponse {
+
+		$resolved = $this->userId !== null
+			? $this->objectResolverService->findByUid($this->userId, $uid)
+			: null;
+
+		if ($resolved !== null) {
+			$davPath = '/remote.php/dav/calendars/' . $this->userId . '/' . $resolved['calendarUri'] . '/' . $resolved['objectUri'];
+			$objectId = base64_encode($davPath);
+
+			return new RedirectResponse(
+				$this->urlGenerator->linkToRoute('calendar.view.indexdirect.edit.recurrenceId', [
+					'objectId' => $objectId,
+					'recurrenceId' => $recurrenceId ?? 'next',
+				])
+			);
+		}
+
+		// Object not found (no access or deleted) — redirect to a non-existent object so
+		// the frontend error handling displays "Event does not exist" instead of a blank page.
+		return new RedirectResponse(
+			$this->urlGenerator->linkToRoute('calendar.view.indexdirect.edit.recurrenceId', [
+				'objectId' => base64_encode("/object-not-found/$uid"),
+				'recurrenceId' => $recurrenceId ?? 'next',
+			])
+		);
+	}
+}

--- a/lib/Service/ObjectResolverService.php
+++ b/lib/Service/ObjectResolverService.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+namespace OCA\Calendar\Service;
+
+use OCP\Calendar\IManager;
+
+class ObjectResolverService {
+
+	public function __construct(
+		private IManager $calendarManager,
+	) {
+	}
+
+	/**
+	 * Locate a calendar object by UID across all calendars of the given user.
+	 *
+	 * @return array{calendarUri: string, objectUri: string}|null
+	 */
+	public function findByUid(string $userId, string $uid): ?array {
+		$principalUri = "principals/users/$userId";
+		$calendars = $this->calendarManager->getCalendarsForPrincipal($principalUri);
+
+		foreach ($calendars as $calendar) {
+			if ($calendar->isDeleted()) {
+				continue;
+			}
+
+			$results = $calendar->search('', [], ['uid' => $uid], 1);
+			if (!empty($results)) {
+				return [
+					'calendarUri' => $calendar->getUri(),
+					'objectUri' => $results[0]['uri'],
+				];
+			}
+		}
+
+		return null;
+	}
+}

--- a/src/mixins/EditorMixin.js
+++ b/src/mixins/EditorMixin.js
@@ -3,8 +3,9 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-import { showError } from '@nextcloud/dialogs'
+import { showError, showSuccess } from '@nextcloud/dialogs'
 import { translate as t } from '@nextcloud/l10n'
+import { generateUrl } from '@nextcloud/router'
 import { mapState, mapStores } from 'pinia'
 import { getRFCProperties } from '../models/rfcProps.js'
 import { containsRoomUrl } from '../services/talkService.ts'
@@ -368,6 +369,28 @@ export default {
 			return this.calendarObject.dav.url + '?export'
 		},
 		/**
+		 * Returns the permanent deep link URL for this event, or null if the event is new
+		 *
+		 * @return {string|null}
+		 */
+		eventLink() {
+			if (!this.calendarObject) {
+				return null
+			}
+
+			const uid = this.calendarObject.uid
+			if (!uid) {
+				return null
+			}
+
+			const recurrenceId = this.$route?.params?.recurrenceId
+			if (recurrenceId && recurrenceId !== 'next') {
+				return window.location.origin + generateUrl('/apps/calendar/object/{uid}/{recurrenceId}', { uid, recurrenceId })
+			}
+
+			return window.location.origin + generateUrl('/apps/calendar/object/{uid}', { uid })
+		},
+		/**
 		 * Returns whether or not this is a new event
 		 *
 		 * @return {boolean}
@@ -643,6 +666,25 @@ export default {
 		 */
 		async duplicateEvent() {
 			await this.calendarObjectInstanceStore.duplicateCalendarObjectInstance()
+		},
+
+		/**
+		 * Copies the permanent event deep link to the clipboard
+		 *
+		 * @return {Promise<void>}
+		 */
+		async copyEventLink() {
+			if (!this.eventLink) {
+				return
+			}
+
+			try {
+				await navigator.clipboard.writeText(this.eventLink)
+				showSuccess(t('calendar', 'Event link copied to clipboard'))
+			} catch (error) {
+				logger.error('Failed to copy event link to clipboard', { error })
+				showError(t('calendar', 'Failed to copy event link'))
+			}
 		},
 
 		/**

--- a/src/router.js
+++ b/src/router.js
@@ -91,11 +91,11 @@ const router = createRouter({
 		},
 		{
 			path: '/edit/:object',
-			redirect: () => `/${getInitialView()}/now/edit/${getPreferredEditorRoute()}/:object/next`,
+			redirect: (to) => `/${getInitialView()}/now/edit/${getPreferredEditorRoute()}/${to.params.object}/next`,
 		},
 		{
 			path: '/edit/:object/:recurrenceId',
-			redirect: () => `/${getInitialView()}/now/edit/${getPreferredEditorRoute()}/:object/:recurrenceId`,
+			redirect: (to) => `/${getInitialView()}/now/edit/${getPreferredEditorRoute()}/${to.params.object}/${to.params.recurrenceId}`,
 		},
 		/**
 		 * This is the main route that contains the current view and viewed day

--- a/src/views/EditFull.vue
+++ b/src/views/EditFull.vue
@@ -58,6 +58,12 @@
 							@saveThisAndAllFuture="prepareAccessForAttachments(true)" />
 						<div class="app-full__actions__inner" :class="[{ 'app-full__actions__inner__readonly': isReadOnly }]">
 							<NcActions>
+								<NcActionButton v-if="eventLink && !isNew" @click="copyEventLink()">
+									<template #icon>
+										<ContentCopy :size="20" decorative />
+									</template>
+									{{ $t('calendar', 'Copy link') }}
+								</NcActionButton>
 								<NcActionLink v-if="!hideEventExport && hasDownloadURL && !isNew" :href="downloadURL">
 									<template #icon>
 										<Download :size="20" decorative />
@@ -358,6 +364,7 @@ import {
 import { mapState, mapStores } from 'pinia'
 import CalendarBlank from 'vue-material-design-icons/CalendarBlank.vue'
 import Close from 'vue-material-design-icons/Close.vue'
+import ContentCopy from 'vue-material-design-icons/ContentCopy.vue'
 import ContentDuplicate from 'vue-material-design-icons/ContentDuplicate.vue'
 import HelpCircleIcon from 'vue-material-design-icons/HelpCircleOutline.vue'
 import Delete from 'vue-material-design-icons/TrashCanOutline.vue'
@@ -414,6 +421,7 @@ export default {
 		Delete,
 		Download,
 		ContentDuplicate,
+		ContentCopy,
 		InvitationResponseButtons,
 		AttachmentsList,
 		CalendarPickerHeader,

--- a/src/views/EditSimple.vue
+++ b/src/views/EditSimple.vue
@@ -70,6 +70,12 @@
 							</template>
 						</NcPopover>
 						<Actions v-if="!isLoading && !isError && !isNew" :forceMenu="true">
+							<ActionButton v-if="eventLink" @click="copyEventLink()">
+								<template #icon>
+									<ContentCopy :size="20" decorative />
+								</template>
+								{{ $t('calendar', 'Copy link') }}
+							</ActionButton>
 							<ActionLink
 								v-if="!hideEventExport && hasDownloadURL"
 								:href="downloadURL">
@@ -279,6 +285,7 @@ import { mapState, mapStores } from 'pinia'
 import Bell from 'vue-material-design-icons/BellOutline.vue'
 import CalendarBlank from 'vue-material-design-icons/CalendarBlankOutline.vue'
 import Close from 'vue-material-design-icons/Close.vue'
+import ContentCopy from 'vue-material-design-icons/ContentCopy.vue'
 import ContentDuplicate from 'vue-material-design-icons/ContentDuplicate.vue'
 import HelpCircleIcon from 'vue-material-design-icons/HelpCircleOutline.vue'
 import EditIcon from 'vue-material-design-icons/PencilOutline.vue'
@@ -322,6 +329,7 @@ export default {
 		Close,
 		Download,
 		ContentDuplicate,
+		ContentCopy,
 		Delete,
 		InvitationResponseButtons,
 		CalendarPickerHeader,


### PR DESCRIPTION
add a way to share a permanent link to an event 
<img width="573" height="371" alt="image" src="https://github.com/user-attachments/assets/c023f237-39b5-4477-8039-a779de44eb68" />

ps: Set as a fix intentionally so it can be backported

👇🏼 needs https://github.com/nextcloud/calendar/pull/8048
<img width="367" height="171" alt="image" src="https://github.com/user-attachments/assets/315d8ea5-cd52-4187-8db3-3e93350c198b" />
<img width="397" height="161" alt="image" src="https://github.com/user-attachments/assets/3a1b4723-ad73-42a8-924a-1b8f8dbf5211" />
