### PR TITLE
fix(appointments): Make scheduled appointments meeting conversations …

### DIFF
--- a/lib/Listener/AppointmentBookedListener.php
+++ b/lib/Listener/AppointmentBookedListener.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace OCA\Calendar\Listener;
 
 use OCA\Calendar\Events\BeforeAppointmentBookedEvent;
+use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;
 use OCP\IL10N;
@@ -27,16 +28,21 @@ class AppointmentBookedListener implements IEventListener {
 
 	private IL10N $l10n;
 
+	/** @var ITimeFactory $timeFactory , */
+	private $timeFactory;
+
 	/** @var LoggerInterface */
 	private $logger;
 
 	public function __construct(IBroker $broker,
 		IUserManager $userManager,
 		IL10N $l10n,
+		ITimeFactory $timeFactory,
 		LoggerInterface $logger) {
 		$this->broker = $broker;
 		$this->userManager = $userManager;
 		$this->l10n = $l10n;
+		$this->timeFactory = $timeFactory;
 		$this->logger = $logger;
 	}
 
@@ -73,10 +79,20 @@ class AppointmentBookedListener implements IEventListener {
 			$event->getConfig()->getName(),
 			$event->getBooking()->getDisplayName(),
 		]);
+
+		$options = $this->broker->newConversationOptions();
+		$options->setPublic();
+		if (method_exists($options, 'setMeeting')) {
+			$options->setMeeting(
+				$this->timeFactory->getDateTime('@' . $event->getBooking()->getStart()),
+				$this->timeFactory->getDateTime('@' . $event->getBooking()->getEnd()),
+			);
+		}
+
 		$conversation = $this->broker->createConversation(
 			$conversationName,
 			[$organizer],
-			$this->broker->newConversationOptions()->setPublic(),
+			$options,
 		);
 		$event->getBooking()->setTalkUrl(
 			$conversation->getAbsoluteUrl(),


### PR DESCRIPTION
…in Talk

- Server PR https://github.com/nextcloud/server/pull/59407
- Talk PR https://github.com/nextcloud/spreed/pull/17604

## Steps
1. Create an "Appointments schedule" with Talk conversation option
2. Book a meeting and confirm it

Before | After
---|---
Conversation is always visible | Conversation is only visible when the meeting is close or list is filtered for meetings
<img width="471" height="482" alt="Bildschirmfoto vom 2026-04-02 17-22-45" src="https://github.com/user-attachments/assets/d8d44b69-b33b-4bb3-bf33-42de2f5adf8b" /> | <img width="462" height="330" alt="Bildschirmfoto vom 2026-04-02 17-23-07" src="https://github.com/user-attachments/assets/b9a37094-d22b-443c-aa62-bf8353c1a6ea" />
Conversation persists after the call | Conversation expires after 28 days
<img width="903" height="327" alt="Bildschirmfoto vom 2026-04-02 17-25-32" src="https://github.com/user-attachments/assets/5cb45a04-99f2-46cc-94c8-57b67269be5b" /> | <img width="903" height="327" alt="Bildschirmfoto vom 2026-04-02 17-25-22" src="https://github.com/user-attachments/assets/cd8ce483-235e-4d05-9474-3218e56ffb1c" />

