### PR TITLE
fix: Proposal UTC time to user timezone when sending email

### DIFF
--- a/lib/Service/Proposal/ProposalService.php
+++ b/lib/Service/Proposal/ProposalService.php
@@ -31,6 +31,7 @@ use OCP\Calendar\ICalendar;
 use OCP\Calendar\ICalendarIsWritable;
 use OCP\Calendar\ICreateFromString;
 use OCP\Calendar\IManager;
+use OCP\Config\IUserConfig;
 use OCP\IAppConfig;
 use OCP\IL10N;
 use OCP\IURLGenerator;
@@ -56,6 +57,7 @@ class ProposalService {
 		private ProposalVoteMapper $proposalVoteMapper,
 		private IL10N $l10n,
 		private IURLGenerator $urlGenerator,
+		private IUserConfig $userConfig,
 		private IUserManager $userManager,
 		private IMailer $systemMailManager,
 		private IMailManager $userMailManager,
@@ -520,17 +522,26 @@ class ProposalService {
 			$template->addBodyListItem($this->l10n->t('%1$s minutes', [(string)$proposal->getDuration()]), $this->l10n->t('Duration:'));
 		}
 		// dates
+		$timezoneString = $this->userConfig->getValueString($user->getUID(), 'core', 'timezone', 'UTC') ?: 'UTC';
+		try {
+			$userTimezone = new \DateTimeZone($timezoneString);
+		} catch (\Exception $e) {
+			$userTimezone = new \DateTimeZone('UTC');
+		}
+
 		$temporaryText = '';
 		foreach ($proposal->getDates()->sortByDate() as $date) {
-			$dtStart = \DateTime::createFromImmutable($date->getDate());
+			$dtStart = \DateTime::createFromImmutable($date->getDate())->setTimezone($userTimezone);
 			$dtEnd = (clone $dtStart)->add(new \DateInterval("PT{$proposal->getDuration()}M"));
 			$textDate = $this->l10n->l('date', $dtStart, ['width' => 'long']);
 			$textStart = $this->l10n->l('time', $dtStart, ['width' => 'short']);
 			$textEnd = $this->l10n->l('time', $dtEnd, ['width' => 'short']);
 			$temporaryText .= $this->l10n->t('%1$s from %2$s to %3$s', [$textDate, $textStart, $textEnd]) . "\n";
 		}
-		$template->addBodyListItem($temporaryText, $this->l10n->t('Dates:'));
 
+		$temporaryText .= '(' . $userTimezone->getName() . ')';
+		$template->addBodyListItem($temporaryText, $this->l10n->t('Dates:'));
+		// buttons
 		$template->addBodyButton(
 			$this->l10n->t('Respond'),
 			$this->urlGenerator->linkToRouteAbsolute('Calendar.ProposalPublic.index', ['token' => $recipientToken])

--- a/tests/php/unit/Service/Proposal/ProposalServiceTest.php
+++ b/tests/php/unit/Service/Proposal/ProposalServiceTest.php
@@ -32,6 +32,7 @@ use OCA\Calendar\Objects\Proposal\ProposalResponseObject;
 use OCA\Calendar\Objects\Proposal\ProposalVoteCollection;
 use OCA\Calendar\Objects\Proposal\ProposalVoteObject;
 use OCP\Calendar\IManager;
+use OCP\Config\IUserConfig;
 use OCP\IAppConfig;
 use OCP\IL10N;
 use OCP\IURLGenerator;
@@ -52,6 +53,7 @@ class ProposalServiceTest extends TestCase {
 	protected ProposalVoteMapper|MockObject $proposalVoteMapper;
 	protected IL10N|MockObject $l10n;
 	protected IURLGenerator|MockObject $urlGenerator;
+	protected IUserConfig|MockObject $userConfig;
 	protected IUserManager|MockObject $userManager;
 	protected IMailer|MockObject $systemMailManager;
 	protected IMailManager|MockObject $userMailManager;
@@ -70,6 +72,7 @@ class ProposalServiceTest extends TestCase {
 		$this->proposalVoteMapper = $this->createMock(ProposalVoteMapper::class);
 		$this->l10n = $this->createMock(IL10N::class);
 		$this->urlGenerator = $this->createMock(IURLGenerator::class);
+		$this->userConfig = $this->createMock(IUserConfig::class);
 		$this->userManager = $this->createMock(IUserManager::class);
 		$this->systemMailManager = $this->createMock(IMailer::class);
 		$this->userMailManager = $this->createMock(IMailManager::class);
@@ -89,6 +92,7 @@ class ProposalServiceTest extends TestCase {
 			$this->proposalVoteMapper,
 			$this->l10n,
 			$this->urlGenerator,
+			$this->userConfig,
 			$this->userManager,
 			$this->systemMailManager,
 			$this->userMailManager,


### PR DESCRIPTION
At the moment the email sent with the proposed dates are in UTC so there can be a big gap with the proposed times and the user actual times. I had few comments at work.

=> This pr convert the dates to user timezone and put the user timezone at the end.

Tested 

With the following proposal
<img width="1235" height="408" alt="image" src="https://github.com/user-attachments/assets/c6e41545-c7eb-466e-bb6a-f329a7b3814d" />


Before PR Times in UTC
<img width="580" height="237" alt="image" src="https://github.com/user-attachments/assets/d87d3493-8fd9-43af-99db-dba75714000b" />





After PR Times in user timezone + timezone displayed
<img width="326" height="247" alt="image" src="https://github.com/user-attachments/assets/a046cd87-bf9c-42f2-af80-9ae1acf34306" />
