### PR TITLE
Fix: Inherit calendar transparency to new events

### DIFF
--- a/src/store/calendarObjectInstance.js
+++ b/src/store/calendarObjectInstance.js
@@ -1415,6 +1415,12 @@ export default defineStore('calendarObjectInstance', {
 			const calendarsStore = useCalendarsStore()
 			const calendar = calendarsStore.getCalendarById(calendarObject.calendarId)
 
+			// Inherit calendar transparency to new events (fix for "Never show me as busy")
+			if (calendar?.transparency === 'transparent') {
+				calendarObjectInstance.timeTransparency = 'transparent'
+				calendarObjectInstance.eventComponent.timeTransparency = 'transparent'
+			}
+
 			let defaultReminder = null
 			if (isAfterVersion(34) && calendar && calendar.defaultAlarm !== null) {
 				defaultReminder = parseInt(calendar.defaultAlarm)


### PR DESCRIPTION
When a calendar has 'Never show me as busy' enabled, newly created events on that calendar now inherit the transparent (free) setting instead of defaulting to busy (OPAQUE).

This fixes the issue where the calendar-level transparency setting was not being applied to newly created events.

Fixes: Events on 'Never show me as busy' calendar still default to busy