### PR TITLE
fix(InviteesListItem): attendee name wrapping

### DIFF
--- a/src/components/Editor/AvatarParticipationStatus.vue
+++ b/src/components/Editor/AvatarParticipationStatus.vue
@@ -288,9 +288,10 @@ export default {
 		bottom: 21px;
 		white-space: nowrap;
 		position: relative;
-		min-width: 420px;
 		text-overflow: ellipsis;
 		overflow: hidden;
+		max-width: 420px;
+		min-width: 420px;
 	}
 }
 </style>

--- a/src/components/Editor/Invitees/InviteesListItem.vue
+++ b/src/components/Editor/Invitees/InviteesListItem.vue
@@ -310,6 +310,11 @@ export default {
 	margin-top: 5px;
 }
 
+.attendee-display {
+	flex: 1;
+	min-width: 0;
+}
+
 .invitees-list-item__member-count {
 	color: var(--color-text-maxcontrast);
 	font-weight: 300;


### PR DESCRIPTION
| Before | After | 
| - | - | 
| <img width="481" height="211" alt="image" src="https://github.com/user-attachments/assets/5fb7d2cc-2550-4535-8e60-3f705800a85c" /> | <img width="479" height="207" alt="swappy-20260408_183004" src="https://github.com/user-attachments/assets/f37aaec7-8e85-4959-9363-39cd8d377672" /> |

