### PR TITLE
New accessible event style in calendar grid

### DIFF
--- a/css/fullcalendar.scss
+++ b/css/fullcalendar.scss
@@ -14,8 +14,8 @@
 	--fc-daygrid-event-dot-width: 10px !important;
 
 	--fc-event-bg-color: var(--color-primary-element);
-	--fc-event-border-color: var(--color-primary-element-text);
-	--fc-event-text-color: var(--color-primary-element-text);
+	--fc-event-border-color: var(--color-primary-element);
+	--fc-event-text-color: var(--color-main-text);
 	--fc-event-selected-overlay-color: var(--color-box-shadow);
 
 	--fc-event-resizer-thickness: 8px;
@@ -131,13 +131,60 @@
 // ### FullCalendar Event adjustments
 .fc-event {
 	padding-inline-start: 3px;
-	border-width: 2px;
+
+	// Only show the left border, thick and full-opacity (dot events and list events are excluded)
+	&:not(.fc-daygrid-dot-event):not(.fc-list-event) {
+		border-block-start-width: 0 !important;
+		border-block-end-width: 0 !important;
+		border-inline-end-width: 0 !important;
+		border-inline-start-width: var(--default-grid-baseline) !important;
+		border-inline-start-style: solid !important;
+	}
+
+	// Free (TRANSP:TRANSPARENT) events: hollow left strip — 1px accent | page-bg | 1px accent
+	&.fc-event-nc-free {
+		&:not(.fc-daygrid-dot-event):not(.fc-list-event) {
+			position: relative;
+			// Hide the solid left border; the ::before pseudo-element takes its place
+			border-inline-start-color: transparent !important;
+
+			&::before {
+				content: '';
+				position: absolute;
+				// Offset into the (transparent) border area so we start at the true left edge
+				inset-inline-start: calc(-1 * var(--default-grid-baseline));
+				top: 0;
+				bottom: 0;
+				width: var(--default-grid-baseline);
+				background: var(--fc-page-bg-color);
+				border-inline-start: 1px solid var(--nc-event-color, currentColor);
+				border-inline-end: 1px solid var(--nc-event-color, currentColor);
+				border-start-start-radius: inherit;
+				border-end-start-radius: inherit;
+				box-sizing: border-box;
+			}
+		}
+	}
 
 	&.fc-event-nc-task-completed,
 	&.fc-event-nc-cancelled {
 		.fc-event-title,
 		.fc-list-event-title {
 			text-decoration: line-through !important;
+		}
+	}
+
+
+	// Participation-state events with no fill keep the thick left stripe plus a 1px frame.
+	&.fc-event-nc-all-declined,
+	&.fc-event-nc-needs-action,
+	&.fc-event-nc-declined {
+		&:not(.fc-daygrid-dot-event):not(.fc-list-event) {
+			background-color: transparent !important;
+			border-block-start-width: 1px !important;
+			border-block-end-width: 1px !important;
+			border-inline-end-width: 1px !important;
+			border-inline-start-width: var(--default-grid-baseline) !important;
 		}
 	}
 
@@ -305,3 +352,33 @@
 		margin-inline-end: 2vw;
 	}
 }
+
+// High-contrast mode: events use plain page background so the coloured left
+// border is the sole colour indicator (no transparency, no stripe patterns).
+// Two triggers:
+//   1. OS/browser prefers-contrast: more media feature.
+//   2. Nextcloud in-app Accessibility theme, which writes
+//      data-themes="light-highcontrast" (or dark-highcontrast) on <body>
+//      without necessarily setting the OS media feature.
+@mixin _fc-high-contrast-events {
+	.fc-event:not(.fc-daygrid-dot-event):not(.fc-list-event) {
+		background-color: var(--fc-page-bg-color) !important;
+		background-image: none !important;
+
+		.fc-event-title,
+		.fc-event-time {
+			color: var(--color-main-text) !important;
+		}
+	}
+}
+
+@media (prefers-contrast: more) {
+	@include _fc-high-contrast-events;
+}
+
+[data-theme-light-highcontrast],
+[data-theme-dark-highcontrast],
+[data-themes*="highcontrast"] {
+	@include _fc-high-contrast-events;
+}
+

--- a/src/fullcalendar/eventSources/eventSource.js
+++ b/src/fullcalendar/eventSources/eventSource.js
@@ -5,9 +5,6 @@ import useFetchedTimeRangesStore from '../../store/fetchedTimeRanges.js'
  * SPDX-FileCopyrightText: 2019 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
-import {
-	generateTextColorForHex,
-} from '../../utils/color.js'
 import { getUnixTimestampFromDate } from '../../utils/date.js'
 import logger from '../../utils/logger.js'
 import { eventSourceFunction } from './eventSourceFunction.js'
@@ -27,7 +24,6 @@ export default function() {
 			// coloring
 			backgroundColor: calendar.color,
 			borderColor: calendar.color,
-			textColor: generateTextColorForHex(calendar.color),
 			// html foo
 			events: async ({ start, end, timeZone }, successCallback, failureCallback) => {
 				let timezoneObject = getTimezoneManager().getTimezoneForId(timeZone)

--- a/src/fullcalendar/eventSources/eventSourceFunction.js
+++ b/src/fullcalendar/eventSources/eventSourceFunction.js
@@ -7,7 +7,6 @@ import usePrincipalsStore from '../../store/principals.js'
 import useTasksStore from '../../store/unscheduledTasks.js'
 import { getAllObjectsInTimeRange } from '../../utils/calendarObject.js'
 import {
-	generateTextColorForHex,
 	getHexForColorName,
 	hexToRGB,
 	isLight,
@@ -81,6 +80,10 @@ export function eventSourceFunction(calendarObjects, calendar, start, end, timez
 				classNames.push('fc-event-nc-alarms')
 			}
 
+			if (object.name === 'VEVENT' && object.getFirstPropertyFirstValue('TRANSP') === 'TRANSPARENT') {
+				classNames.push('fc-event-nc-free')
+			}
+
 			let jsStart, jsEnd
 			if (object.name === 'VEVENT') {
 				jsStart = object.startDate.getInTimezone(timezone).jsDate
@@ -140,6 +143,10 @@ export function eventSourceFunction(calendarObjects, calendar, start, end, timez
 				}
 			}
 
+			const attendeeCount = object.hasComponent('ATTENDEE')
+				? [...object.getPropertyIterator('ATTENDEE')].length
+				: 0
+
 			const fcEvent = {
 				id: [calendarObject.id, object.id].join('###'),
 				title,
@@ -165,6 +172,7 @@ export function eventSourceFunction(calendarObjects, calendar, start, end, timez
 					davUrl: calendarObject.dav.url,
 					location: object.location,
 					description: object.description,
+					attendeeCount,
 				},
 			}
 
@@ -173,7 +181,6 @@ export function eventSourceFunction(calendarObjects, calendar, start, end, timez
 				if (customColor) {
 					fcEvent.backgroundColor = customColor
 					fcEvent.borderColor = customColor
-					fcEvent.textColor = generateTextColorForHex(customColor)
 				}
 			}
 			if (object.name === 'VTODO' && object.endDate === null && object.percent !== 100 && object.status !== 'COMPLETED') {

--- a/src/fullcalendar/rendering/eventDidMount.js
+++ b/src/fullcalendar/rendering/eventDidMount.js
@@ -64,6 +64,14 @@ export default errorCatch(function({ event, el }) {
 		}
 	}
 
+	if (
+		el.classList.contains('fc-event-nc-free')
+		&& !el.classList.contains('fc-list-event')
+		&& !el.classList.contains('fc-daygrid-dot-event')
+	) {
+		el.style.setProperty('--nc-event-color', el.style.borderColor)
+	}
+
 	if (event.source === null) {
 		el.dataset.isNew = 'yes'
 	} else {
@@ -93,6 +101,27 @@ export default errorCatch(function({ event, el }) {
 		}
 	}
 
+	// Apply semi-transparent background for grid events (not dot or list events).
+	// The full-opacity color remains on the left border (set by FullCalendar's inline border-color).
+	// Past events get a stronger fill to keep them visually distinct.
+	// Skipped in high-contrast mode — CSS will force the plain page background instead.
+	if (
+		!el.classList.contains('fc-list-event')
+		&& !el.classList.contains('fc-daygrid-dot-event')
+		&& !isHighContrast()
+	) {
+		const bgColor = el.style.backgroundColor
+		if (bgColor) {
+			const rgb = extractRGB(bgColor)
+			if (rgb) {
+				const now = new Date()
+				const isPast = event.end ? event.end < now : (event.start ? event.start < now : false)
+				const opacity = isPast ? 0.05 : 0.35
+				el.style.backgroundColor = `rgba(${rgb.r}, ${rgb.g}, ${rgb.b}, ${opacity})`
+			}
+		}
+	}
+
 	if (
 		el.classList.contains('fc-event-nc-all-declined')
 		|| el.classList.contains('fc-event-nc-needs-action')
@@ -108,7 +137,19 @@ export default errorCatch(function({ event, el }) {
 			dotElement.style.minWidth = '10px'
 			dotElement.style.minHeight = '10px'
 		} else {
-			el.style.background = 'var(--fc-page-bg-color)'
+			el.style.background = 'transparent'
+
+			if (!isHighContrast()) {
+				const now = new Date()
+				const isPast = event.end ? event.end < now : (event.start ? event.start < now : false)
+				const borderRgb = extractRGB(el.style.borderColor)
+				if (isPast && borderRgb) {
+					const fadedBorderColor = `rgba(${borderRgb.r}, ${borderRgb.g}, ${borderRgb.b}, 0.35)`
+					el.style.borderTopColor = fadedBorderColor
+					el.style.borderRightColor = fadedBorderColor
+					el.style.borderBottomColor = fadedBorderColor
+				}
+			}
 		}
 
 		if (titleElement) {
@@ -133,43 +174,44 @@ export default errorCatch(function({ event, el }) {
 		}
 	}
 
+	if (
+		event.extendedProps.attendeeCount >= 1
+		&& !el.classList.contains('fc-event-nc-task')
+	) {
+		prependTitleIcon(el, 'M40-160v-112q0-34 17.5-62.5T104-378q62-31 126-46.5T360-440q66 0 130 15.5T616-378q29 15 46.5 43.5T680-272v112H40Zm640 0v-112q0-51-26-95.5T586-441q51 6 98 20.5t84 35.5q36 20 57 44.5t21 52.5v112H680ZM360-480q-66 0-113-47t-47-113q0-66 47-113t113-47q66 0 113 47t47 113q0 66-47 113t-113 47Zm400-160q0 66-47 113t-113 47q-11 0-28-2.5t-28-5.5q27-32 41.5-71t14.5-81q0-42-14.5-81T544-792q14-5 28-6.5t28-1.5q66 0 113 47t47 113Z')
+	}
+
 	if (el.classList.contains('fc-event-nc-all-declined')) {
-		const titleElement = el.querySelector('.fc-event-title')
-
-		if (titleElement) {
-			const svgString = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 -960 960 960"><path d="m40-120 440-760 440 760H40Zm440-120q17 0 28.5-11.5T520-280q0-17-11.5-28.5T480-320q-17 0-28.5 11.5T440-280q0 17 11.5 28.5T480-240Zm-40-120h80v-200h-80v200Z"/></svg>'
-			titleElement.innerHTML = svgString + titleElement.innerHTML
-
-			const svgElement = titleElement.querySelector('svg')
-			if (svgElement) {
-				svgElement.style.fill = el.style.borderColor
-				svgElement.style.width = '1em'
-				svgElement.style.marginBottom = '0.2em'
-				svgElement.style.verticalAlign = 'middle'
-			}
-		}
+		prependTitleIcon(el, 'm40-120 440-760 440 760H40Zm440-120q17 0 28.5-11.5T520-280q0-17-11.5-28.5T480-320q-17 0-28.5 11.5T440-280q0 17 11.5 28.5T480-240Zm-40-120h80v-200h-80v200Z')
 	}
 
 	if (el.classList.contains('fc-event-nc-tentative')) {
 		const dotElement = el.querySelector('.fc-daygrid-event-dot')
 
-		// Get background color, with fallback to border color if dotElement doesn't exist
-		const bgColor = el.style.backgroundColor
-			? el.style.backgroundColor
-			: (dotElement ? dotElement.style.borderColor : el.style.borderColor)
-		const bgStripeColor = darkenColor(bgColor)
-
-		let backgroundStyling = `repeating-linear-gradient(45deg, ${bgStripeColor}, ${bgStripeColor} 1px, ${bgColor} 1px, ${bgColor} 10px)`
-
 		if (dotElement) {
+			// Dot events: keep the existing marker fill and overlay stripes only.
+			const dotColor = dotElement.style.borderColor || el.style.borderColor
+			const dotRgb = extractRGB(dotColor)
+			const stripeColor = dotRgb ? `rgba(${dotRgb.r}, ${dotRgb.g}, ${dotRgb.b}, 0.25)` : dotColor
 			dotElement.style.borderWidth = '2px'
-			backgroundStyling = `repeating-linear-gradient(45deg, ${bgColor}, ${bgColor} 1px, var(--fc-page-bg-color) 1px, var(--fc-page-bg-color) 3.5px)`
-
-			dotElement.style.background = backgroundStyling
+			if (!isHighContrast()) {
+				dotElement.style.backgroundImage = `repeating-linear-gradient(45deg, ${stripeColor}, ${stripeColor} 1px, transparent 1px, transparent 3.5px)`
+			}
 			dotElement.style.minWidth = '10px'
 			dotElement.style.minHeight = '10px'
-		} else {
-			el.style.background = backgroundStyling
+		} else if (!isHighContrast()) {
+			// Block/time events: keep the existing fill and overlay stripes only.
+			const eventColor = el.style.borderColor
+			const rgb = extractRGB(eventColor)
+			if (rgb) {
+				const stripeColor = `rgba(${rgb.r}, ${rgb.g}, ${rgb.b}, 0.25)`
+				el.style.backgroundImage = `repeating-linear-gradient(45deg, ${stripeColor}, ${stripeColor} 2px, transparent 2px, transparent 10px)`
+			} else {
+				// Fallback for when border color can't be parsed
+				const baseColor = el.style.backgroundColor
+				const stripeColor = darkenColor(baseColor)
+				el.style.backgroundImage = `repeating-linear-gradient(45deg, ${stripeColor}, ${stripeColor} 2px, transparent 2px, transparent 10px)`
+			}
 		}
 
 		el.title = t('calendar', 'Your participation is tentative')
@@ -177,15 +219,114 @@ export default errorCatch(function({ event, el }) {
 }, 'eventDidMount')
 
 /**
- * Create a slightly darker color for background stripes
+ * Prepend a Material Symbols SVG icon to an event's title element.
+ * The icon is coloured with the event's border colour and sized to match the text.
+ *
+ * @param {HTMLElement} el The root element of the fullcalendar event
+ * @param {string} svgPath The `d` attribute of the SVG path to render
+ */
+function prependTitleIcon(el, svgPath) {
+	const titleElement = el.querySelector('.fc-event-title')
+	if (!titleElement) {
+		return
+	}
+
+	// Avoid duplicating icons when eventDidMount is called again (e.g. after a click).
+	const existingSvgs = titleElement.querySelectorAll('svg')
+	for (const svg of existingSvgs) {
+		const path = svg.querySelector('path')
+		if (path && path.getAttribute('d') === svgPath) {
+			return
+		}
+	}
+
+	const svgNS = 'http://www.w3.org/2000/svg'
+	const svgElement = document.createElementNS(svgNS, 'svg')
+	svgElement.setAttribute('viewBox', '0 -960 960 960')
+	const pathElement = document.createElementNS(svgNS, 'path')
+	pathElement.setAttribute('d', svgPath)
+	svgElement.appendChild(pathElement)
+	svgElement.style.fill = el.style.borderColor
+	svgElement.style.width = '1em'
+	svgElement.style.marginBottom = '0.2em'
+	svgElement.style.verticalAlign = 'middle'
+	titleElement.insertBefore(svgElement, titleElement.firstChild)
+}
+
+/**
+ * Extract RGB components from a CSS color string.
+ * Supports rgb(), rgba(), #rrggbb, and #rgb formats.
+ *
+ * @param {string} color The color string to parse
+ * @return {{r: number, g: number, b: number}|null}
+ */
+function extractRGB(color) {
+	if (!color) {
+		return null
+	}
+
+	// rgb() or rgba() — browser-normalised inline style values
+	const rgbMatch = color.match(/^rgba?\((\d+),\s*(\d+),\s*(\d+)/)
+	if (rgbMatch) {
+		return { r: parseInt(rgbMatch[1]), g: parseInt(rgbMatch[2]), b: parseInt(rgbMatch[3]) }
+	}
+
+	// #rrggbb
+	const hexMatch = color.match(/^#([0-9a-f]{2})([0-9a-f]{2})([0-9a-f]{2})$/i)
+	if (hexMatch) {
+		return {
+			r: parseInt(hexMatch[1], 16),
+			g: parseInt(hexMatch[2], 16),
+			b: parseInt(hexMatch[3], 16),
+		}
+	}
+
+	// #rgb
+	const shortHexMatch = color.match(/^#([0-9a-f])([0-9a-f])([0-9a-f])$/i)
+	if (shortHexMatch) {
+		return {
+			r: parseInt(shortHexMatch[1] + shortHexMatch[1], 16),
+			g: parseInt(shortHexMatch[2] + shortHexMatch[2], 16),
+			b: parseInt(shortHexMatch[3] + shortHexMatch[3], 16),
+		}
+	}
+
+	return null
+}
+
+/**
+ * Create a slightly darker color for background stripes.
+ * Handles rgb(), rgba(), and hex color formats.
  *
  * @param {string} color The color to darken
+ * @return {string} The darkened color
  */
 function darkenColor(color) {
-	const rgb = color.match(/\d+/g)
-	if (!rgb) {
+	const match = color.match(/^rgba?\((\d+),\s*(\d+),\s*(\d+)(?:,\s*([\d.]+))?\)/)
+	if (!match) {
 		return color
 	}
-	const [r, g, b] = rgb.map((c) => Math.max(0, Math.min(255, c - (c * 0.3))))
+	const [r, g, b] = [match[1], match[2], match[3]].map((c) => Math.max(0, Math.min(255, parseInt(c) - (parseInt(c) * 0.3))))
+	if (match[4] !== undefined) {
+		return `rgba(${r}, ${g}, ${b}, ${match[4]})`
+	}
 	return `rgb(${r}, ${g}, ${b})`
+}
+
+/**
+ * Returns true when the user has requested a high-contrast experience.
+ *
+ * Nextcloud lets users pick a high-contrast theme from their Accessibility
+ * settings. That sets data-themes="light-highcontrast" (or dark-highcontrast)
+ * on <body> — it does NOT necessarily trigger the OS-level
+ * `prefers-contrast: more` media feature, so we check both.
+ *
+ * @return {boolean}
+ */
+function isHighContrast() {
+	if (window.matchMedia('(prefers-contrast: more)').matches) {
+		return true
+	}
+	const themes = document.body.getAttribute('data-themes') ?? ''
+	return themes.includes('highcontrast')
 }

--- a/tests/javascript/unit/fullcalendar/eventSources/eventSource.test.js
+++ b/tests/javascript/unit/fullcalendar/eventSources/eventSource.test.js
@@ -2,16 +2,13 @@
  * SPDX-FileCopyrightText: 2019 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
-import eventSource from "../../../../../src/fullcalendar/eventSources/eventSource.js";
-
-import { generateTextColorForHex } from '../../../../../src/utils/color.js'
-import getTimezoneManager from '../../../../../src/services/timezoneDataProviderService'
-import { getUnixTimestampFromDate } from '../../../../../src/utils/date.js'
+import eventSource from '../../../../../src/fullcalendar/eventSources/eventSource.js'
 import { eventSourceFunction } from '../../../../../src/fullcalendar/eventSources/eventSourceFunction.js'
-import useFetchedTimeRangesStore from '../../../../../src/store/fetchedTimeRanges.js'
+import getTimezoneManager from '../../../../../src/services/timezoneDataProviderService'
 import useCalendarsStore from '../../../../../src/store/calendars.js'
+import useFetchedTimeRangesStore from '../../../../../src/store/fetchedTimeRanges.js'
+import { getUnixTimestampFromDate } from '../../../../../src/utils/date.js'
 
-vi.mock('../../../../../src/utils/color.js')
 vi.mock('../../../../../src/services/timezoneDataProviderService')
 vi.mock('../../../../../src/utils/date.js')
 vi.mock('../../../../../src/fullcalendar/eventSources/eventSourceFunction.js')
@@ -19,9 +16,7 @@ vi.mock('../../../../../src/store/fetchedTimeRanges.js')
 vi.mock('../../../../../src/store/calendars.js')
 
 describe('fullcalendar/eventSource test suite', () => {
-
 	beforeEach(() => {
-		generateTextColorForHex.mockClear()
 		getTimezoneManager.mockClear()
 		getUnixTimestampFromDate.mockClear()
 		eventSourceFunction.mockClear()
@@ -37,23 +32,16 @@ describe('fullcalendar/eventSource test suite', () => {
 		const calendar = {
 			id: 'calendar-id-123',
 			color: '#ff00ff',
-			readOnly: false
+			readOnly: false,
 		}
-
-		generateTextColorForHex
-			.mockReturnValue('#00ff00')
 
 		const eventSourceFunction = eventSource()
 		expect(eventSourceFunction(calendar)).toEqual({
 			id: 'calendar-id-123',
 			backgroundColor: '#ff00ff',
 			borderColor: '#ff00ff',
-			textColor: '#00ff00',
-			events: expect.any(Function)
+			events: expect.any(Function),
 		})
-
-		expect(generateTextColorForHex).toHaveBeenCalledTimes(1)
-		expect(generateTextColorForHex).toHaveBeenNthCalledWith(1, '#ff00ff')
 	})
 
 	it('should provide an eventSource for a given read-only calendar', () => {
@@ -64,24 +52,17 @@ describe('fullcalendar/eventSource test suite', () => {
 		const calendar = {
 			id: 'calendar-id-123',
 			color: '#ff00ff',
-			readOnly: true
+			readOnly: true,
 		}
-
-		generateTextColorForHex
-			.mockReturnValue('#00ff00')
 
 		const eventSourceFunction = eventSource()
 		expect(eventSourceFunction(calendar)).toEqual({
 			id: 'calendar-id-123',
 			backgroundColor: '#ff00ff',
 			borderColor: '#ff00ff',
-			textColor: '#00ff00',
 			events: expect.any(Function),
-			editable: false
+			editable: false,
 		})
-
-		expect(generateTextColorForHex).toHaveBeenCalledTimes(1)
-		expect(generateTextColorForHex).toHaveBeenNthCalledWith(1, '#ff00ff')
 	})
 
 	it('should provide an eventSource function to provide events - fetch new timerange', async () => {
@@ -94,32 +75,29 @@ describe('fullcalendar/eventSource test suite', () => {
 			getTimeRangeForCalendarCoveringRange: vi.fn()
 				.mockReturnValueOnce(false),
 			getCalendarObjectsByTimeRangeId: vi.fn()
-				.mockReturnValueOnce([{ calendarObjectId: 1 }, { calendarObjectId: 2 }])
+				.mockReturnValueOnce([{ calendarObjectId: 1 }, { calendarObjectId: 2 }]),
 		}
 		useFetchedTimeRangesStore.mockReturnValue(fetchedTimeRangesStore)
 
 		const calendar = {
 			id: 'calendar-id-123',
 			color: '#ff00ff',
-			readOnly: true
+			readOnly: true,
 		}
 
 		const getTimezoneForId = vi.fn()
 			.mockReturnValueOnce({ calendarJsTimezone: true, tzid: 'America/New_York' })
 		getTimezoneManager
 			.mockReturnValue({
-				getTimezoneForId
+				getTimezoneForId,
 			})
 
 		getUnixTimestampFromDate
 			.mockReturnValueOnce(1234)
 			.mockReturnValueOnce(5678)
 
-		generateTextColorForHex
-			.mockReturnValue('#00ff00')
-
 		eventSourceFunction
-			.mockReturnValueOnce([{ fcEventId: 1 },  { fcEventId: 2 }])
+			.mockReturnValueOnce([{ fcEventId: 1 }, { fcEventId: 2 }])
 
 		const start = new Date(Date.UTC(2019, 0, 1, 0, 0, 0, 0))
 		const end = new Date(Date.UTC(2019, 0, 31, 59, 59, 59, 999))
@@ -139,7 +117,7 @@ describe('fullcalendar/eventSource test suite', () => {
 		expect(calendarsStore.getEventsFromCalendarInTimeRange).toHaveBeenNthCalledWith(1, {
 			calendar,
 			from: start,
-			to: end
+			to: end,
 		})
 
 		expect(fetchedTimeRangesStore.getCalendarObjectsByTimeRangeId).toHaveBeenCalledTimes(1)
@@ -149,7 +127,7 @@ describe('fullcalendar/eventSource test suite', () => {
 		expect(eventSourceFunction).toHaveBeenNthCalledWith(1, [{ calendarObjectId: 1 }, { calendarObjectId: 2 }], calendar, start, end, { calendarJsTimezone: true, tzid: 'America/New_York' })
 
 		expect(successCallback).toHaveBeenCalledTimes(1)
-		expect(successCallback).toHaveBeenNthCalledWith(1, [{ fcEventId: 1 },  { fcEventId: 2 }])
+		expect(successCallback).toHaveBeenNthCalledWith(1, [{ fcEventId: 1 }, { fcEventId: 2 }])
 
 		expect(failureCallback).toHaveBeenCalledTimes(0)
 	})
@@ -166,32 +144,29 @@ describe('fullcalendar/eventSource test suite', () => {
 					id: 42,
 				}),
 			getCalendarObjectsByTimeRangeId: vi.fn()
-				.mockReturnValueOnce([{ calendarObjectId: 1 }, { calendarObjectId: 2 }])
+				.mockReturnValueOnce([{ calendarObjectId: 1 }, { calendarObjectId: 2 }]),
 		}
 		useFetchedTimeRangesStore.mockReturnValue(fetchedTimeRangesStore)
 
 		const calendar = {
 			id: 'calendar-id-123',
 			color: '#ff00ff',
-			readOnly: true
+			readOnly: true,
 		}
 
 		const getTimezoneForId = vi.fn()
 			.mockReturnValueOnce({ calendarJsTimezone: true, tzid: 'America/New_York' })
 		getTimezoneManager
 			.mockReturnValue({
-				getTimezoneForId
+				getTimezoneForId,
 			})
 
 		getUnixTimestampFromDate
 			.mockReturnValueOnce(1234)
 			.mockReturnValueOnce(5678)
 
-		generateTextColorForHex
-			.mockReturnValue('#00ff00')
-
 		eventSourceFunction
-			.mockReturnValueOnce([{ fcEventId: 1 },  { fcEventId: 2 }])
+			.mockReturnValueOnce([{ fcEventId: 1 }, { fcEventId: 2 }])
 
 		const start = new Date(Date.UTC(2019, 0, 1, 0, 0, 0, 0))
 		const end = new Date(Date.UTC(2019, 0, 31, 59, 59, 59, 999))
@@ -216,7 +191,7 @@ describe('fullcalendar/eventSource test suite', () => {
 		expect(eventSourceFunction).toHaveBeenNthCalledWith(1, [{ calendarObjectId: 1 }, { calendarObjectId: 2 }], calendar, start, end, { calendarJsTimezone: true, tzid: 'America/New_York' })
 
 		expect(successCallback).toHaveBeenCalledTimes(1)
-		expect(successCallback).toHaveBeenNthCalledWith(1, [{ fcEventId: 1 },  { fcEventId: 2 }])
+		expect(successCallback).toHaveBeenNthCalledWith(1, [{ fcEventId: 1 }, { fcEventId: 2 }])
 
 		expect(failureCallback).toHaveBeenCalledTimes(0)
 	})
@@ -233,14 +208,14 @@ describe('fullcalendar/eventSource test suite', () => {
 					id: 42,
 				}),
 			getCalendarObjectsByTimeRangeId: vi.fn()
-				.mockReturnValueOnce([{ calendarObjectId: 1 }, { calendarObjectId: 2 }])
+				.mockReturnValueOnce([{ calendarObjectId: 1 }, { calendarObjectId: 2 }]),
 		}
 		useFetchedTimeRangesStore.mockReturnValue(fetchedTimeRangesStore)
 
 		const calendar = {
 			id: 'calendar-id-123',
 			color: '#ff00ff',
-			readOnly: true
+			readOnly: true,
 		}
 
 		const getTimezoneForId = vi.fn()
@@ -248,18 +223,15 @@ describe('fullcalendar/eventSource test suite', () => {
 			.mockReturnValueOnce({ calendarJsTimezone: true, tzid: 'UTC' })
 		getTimezoneManager
 			.mockReturnValue({
-				getTimezoneForId
+				getTimezoneForId,
 			})
 
 		getUnixTimestampFromDate
 			.mockReturnValueOnce(1234)
 			.mockReturnValueOnce(5678)
 
-		generateTextColorForHex
-			.mockReturnValue('#00ff00')
-
 		eventSourceFunction
-			.mockReturnValueOnce([{ fcEventId: 1 },  { fcEventId: 2 }])
+			.mockReturnValueOnce([{ fcEventId: 1 }, { fcEventId: 2 }])
 
 		const start = new Date(Date.UTC(2019, 0, 1, 0, 0, 0, 0))
 		const end = new Date(Date.UTC(2019, 0, 31, 59, 59, 59, 999))
@@ -288,7 +260,7 @@ describe('fullcalendar/eventSource test suite', () => {
 		expect(eventSourceFunction).toHaveBeenNthCalledWith(1, [{ calendarObjectId: 1 }, { calendarObjectId: 2 }], calendar, start, end, { calendarJsTimezone: true, tzid: 'UTC' })
 
 		expect(successCallback).toHaveBeenCalledTimes(1)
-		expect(successCallback).toHaveBeenNthCalledWith(1, [{ fcEventId: 1 },  { fcEventId: 2 }])
+		expect(successCallback).toHaveBeenNthCalledWith(1, [{ fcEventId: 1 }, { fcEventId: 2 }])
 
 		expect(failureCallback).toHaveBeenCalledTimes(0)
 	})
@@ -303,32 +275,29 @@ describe('fullcalendar/eventSource test suite', () => {
 			getTimeRangeForCalendarCoveringRange: vi.fn()
 				.mockReturnValueOnce(false),
 			getCalendarObjectsByTimeRangeId: vi.fn()
-				.mockReturnValueOnce([{ calendarObjectId: 1 }, { calendarObjectId: 2 }])
+				.mockReturnValueOnce([{ calendarObjectId: 1 }, { calendarObjectId: 2 }]),
 		}
 		useFetchedTimeRangesStore.mockReturnValue(fetchedTimeRangesStore)
 
 		const calendar = {
 			id: 'calendar-id-123',
 			color: '#ff00ff',
-			readOnly: true
+			readOnly: true,
 		}
 
 		const getTimezoneForId = vi.fn()
 			.mockReturnValueOnce({ calendarJsTimezone: true, tzid: 'America/New_York' })
 		getTimezoneManager
 			.mockReturnValue({
-				getTimezoneForId
+				getTimezoneForId,
 			})
 
 		getUnixTimestampFromDate
 			.mockReturnValueOnce(1234)
 			.mockReturnValueOnce(5678)
 
-		generateTextColorForHex
-			.mockReturnValue('#00ff00')
-
 		eventSourceFunction
-			.mockReturnValueOnce([{ fcEventId: 1 },  { fcEventId: 2 }])
+			.mockReturnValueOnce([{ fcEventId: 1 }, { fcEventId: 2 }])
 
 		const start = new Date(Date.UTC(2019, 0, 1, 0, 0, 0, 0))
 		const end = new Date(Date.UTC(2019, 0, 31, 59, 59, 59, 999))
@@ -348,7 +317,7 @@ describe('fullcalendar/eventSource test suite', () => {
 		expect(calendarsStore.getEventsFromCalendarInTimeRange).toHaveBeenNthCalledWith(1, {
 			calendar,
 			from: start,
-			to: end
+			to: end,
 		})
 
 		expect(fetchedTimeRangesStore.getCalendarObjectsByTimeRangeId).toHaveBeenCalledTimes(0)
@@ -358,5 +327,4 @@ describe('fullcalendar/eventSource test suite', () => {
 
 		expect(failureCallback).toHaveBeenCalledTimes(1)
 	})
-
 })

--- a/tests/javascript/unit/fullcalendar/eventSources/freeBusyResourceEventSourceFunction.test.js
+++ b/tests/javascript/unit/fullcalendar/eventSources/freeBusyResourceEventSourceFunction.test.js
@@ -217,6 +217,7 @@ describe('fullcalendar/freeBusyResourceEventSourceFunction test suite', () => {
 					percent: null,
 					description: undefined,
 					location: undefined,
+					attendeeCount: 0,
 				}
 			},
 			{
@@ -240,6 +241,7 @@ describe('fullcalendar/freeBusyResourceEventSourceFunction test suite', () => {
 					percent: null,
 					description: undefined,
 					location: undefined,
+					attendeeCount: 0,
 				}
 			},
 			{
@@ -263,6 +265,7 @@ describe('fullcalendar/freeBusyResourceEventSourceFunction test suite', () => {
 					percent: null,
 					description: undefined,
 					location: undefined,
+					attendeeCount: 0,
 				}
 			},
 			{
@@ -286,6 +289,7 @@ describe('fullcalendar/freeBusyResourceEventSourceFunction test suite', () => {
 					percent: null,
 					description: undefined,
 					location: undefined,
+					attendeeCount: 0,
 				}
 			},
 			{
@@ -309,11 +313,11 @@ describe('fullcalendar/freeBusyResourceEventSourceFunction test suite', () => {
 					percent: null,
 					description: undefined,
 					location: undefined,
+					attendeeCount: 0,
 				},
-				backgroundColor: '#ff0000',
-				borderColor: '#ff0000',
-				textColor: '#eeeeee',
-			}
+			backgroundColor: '#ff0000',
+			borderColor: '#ff0000',
+		}
 		])
 
 		expect(eventComponentSet1[0].startDate.getInTimezone).toHaveBeenCalledTimes(1)
@@ -356,8 +360,7 @@ describe('fullcalendar/freeBusyResourceEventSourceFunction test suite', () => {
 		expect(getHexForColorName).toHaveBeenCalledTimes(1)
 		expect(getHexForColorName).toHaveBeenNthCalledWith(1, 'red')
 
-		expect(generateTextColorForHex).toHaveBeenCalledTimes(1)
-		expect(generateTextColorForHex).toHaveBeenNthCalledWith(1, '#ff0000')
+		expect(generateTextColorForHex).toHaveBeenCalledTimes(0)
 
 		// Make sure the following dates have not been touched
 		expect(event11Start.getFullYear()).toEqual(2020)
@@ -615,6 +618,7 @@ describe('fullcalendar/freeBusyResourceEventSourceFunction test suite', () => {
 				recurrenceId: 123,
 				description: undefined,
 				location: undefined,
+				attendeeCount: 0,
 			},
 			id: '1###1',
 			start: event1End,
@@ -639,6 +643,7 @@ describe('fullcalendar/freeBusyResourceEventSourceFunction test suite', () => {
 				recurrenceId: 123,
 				description: undefined,
 				location: undefined,
+				attendeeCount: 0,
 			},
 			id: '1###2',
 			start: event2End,
@@ -663,6 +668,7 @@ describe('fullcalendar/freeBusyResourceEventSourceFunction test suite', () => {
 				recurrenceId: 123,
 				description: undefined,
 				location: undefined,
+				attendeeCount: 0,
 			},
 			id: '1###3',
 			start: event3End,
@@ -687,6 +693,7 @@ describe('fullcalendar/freeBusyResourceEventSourceFunction test suite', () => {
 				recurrenceId: 123,
 				description: undefined,
 				location: undefined,
+				attendeeCount: 0,
 			},
 			id: '1###4',
 			start: event4End,
@@ -711,6 +718,7 @@ describe('fullcalendar/freeBusyResourceEventSourceFunction test suite', () => {
 				recurrenceId: 123,
 				description: undefined,
 				location: undefined,
+				attendeeCount: 0,
 			},
 			id: '1###5',
 			start: event5End,


### PR DESCRIPTION
Fix https://github.com/nextcloud/calendar/issues/8022
Fix https://github.com/nextcloud/calendar/issues/2353

How do we like this? It passes WCAG AA with all colors ✅. Based on this design: https://github.com/nextcloud/calendar/issues/8022#issuecomment-4223154364

Here's what it looks like with some "normal" colors:

| | Yellow | Purple |
| - | - | - |
| Light mode | <img width="611" height="301" alt="image" src="https://github.com/user-attachments/assets/ef4df6ac-1b30-467f-b22f-c07e6fd5370c" /> | <img width="615" height="307" alt="image" src="https://github.com/user-attachments/assets/b4e15405-c490-466b-a662-0b34398fa806" />|
| Dark mode | <img width="617" height="303" alt="image" src="https://github.com/user-attachments/assets/05a6db12-007f-45ed-b1f2-a690e74c1b41" />| <img width="623" height="308" alt="image" src="https://github.com/user-attachments/assets/c64769b7-7bb2-4346-ab18-29c283c31ff6" /> |

Here's what it looks like with the most problematic colors, still passes WCAG:

| | White | Black |
| - | - | - | 
| Light mode | <img width="615" height="295" alt="image" src="https://github.com/user-attachments/assets/6728ae3f-4b92-4f1b-b577-28914ebd7e8d" />| <img width="616" height="305" alt="image" src="https://github.com/user-attachments/assets/338a4d2b-dbb7-4dbf-b795-fa04bc5905cb" /> |
| Dark mode | <img width="619" height="311" alt="image" src="https://github.com/user-attachments/assets/1cc19690-4a78-41a1-bac4-b0f281fa3a69" /> | <img width="617" height="307" alt="image" src="https://github.com/user-attachments/assets/a49a66d2-8011-43c3-b9bf-eb90d809f87a" /> |

Naturally this system doesn't look great with people choosing white for their white backgrounds, but who am I to stop them from doing that (also our current system doesn't really handle that either). It passes WCAG anyway.



