### PR TITLE
fix: modifying a proposal

### DIFF
--- a/lib/Objects/Proposal/ProposalDateCollection.php
+++ b/lib/Objects/Proposal/ProposalDateCollection.php
@@ -84,7 +84,7 @@ class ProposalDateCollection extends BaseCollection {
 		foreach ($otherDates as $key => $date) {
 			if (isset($currentDates[$key])) {
 				if ($date->getDate()->getTimestamp() !== $currentDates[$key]->getDate()->getTimestamp()) {
-					$modified[] = $currentDates[$key];
+					$modified[] = $date;
 				}
 				unset($currentDates[$key]);
 			} else {


### PR DESCRIPTION
Current code is wrong because:

    $currentDates[$key] = the old date from the database

    $date = the new mutated date from the client

So when we detect a modification, we are returning the old object instead of the new one.

On main
create a proposal. (save)
exit
re-enter Try to modify it => nothing happens (fail silently)

With pull request
create a proposal (save)
exit
Modify it => proposal is modified accurately