### PR TITLE
fix: blank date on manual input

### DIFF
--- a/src/components/Shared/DatePicker.vue
+++ b/src/components/Shared/DatePicker.vue
@@ -56,6 +56,8 @@ export default {
 		},
 	},
 
+	emits: ['change'],
+
 	data() {
 		return {
 			pendingDate: null,


### PR DESCRIPTION
### Summary
- Fixed date field becoming blank on manual input

### Before

https://github.com/user-attachments/assets/16f2cfa9-f46a-453b-82b5-a553527c18d4

### After

https://github.com/user-attachments/assets/cc289375-1e01-4d8b-97b1-c70b3ce70fe6

