### PR TITLE
fix(A11y): make focused input borders have default styling

### DIFF
--- a/css/app-full.scss
+++ b/css/app-full.scss
@@ -371,23 +371,6 @@
 	}
 }
 
-// Override outdated server styling
-input:not(
-	[type='range'],
-	.input-field__input,
-	[type='submit'],
-	[type='button'],
-	[type='reset'],
-	.multiselect__input,
-	.select2-input,
-	.action-input__input,
-	[class^="vs__"]
-),
-select,
-div[contenteditable=true],
-textarea {
-	border: var(--border-width-input) solid var(--color-border-maxcontrast);
-}
 
 textarea {
 	padding: 5px 12px !important;

--- a/src/components/Appointments/AppointmentDetails.vue
+++ b/src/components/Appointments/AppointmentDetails.vue
@@ -303,11 +303,6 @@ h3 {
 		border-radius: var(--border-radius);
 		background-color: var(--color-main-background);
 		cursor: text;
-
-		&:hover {
-			border-color: var(--color-primary-element) !important;
-			outline: none !important;
-		}
 	}
 }
 </style>


### PR DESCRIPTION
Fix https://github.com/nextcloud/calendar/issues/7931

After:
<img width="542" height="236" alt="swappy-20260420_143245" src="https://github.com/user-attachments/assets/8ee66b21-0930-4a09-beb8-9e9ecc157440" />

(They previously weren't thick enough)