### PR TITLE
fix(talk-integration): make sure talk is enabled for user

### DIFF
--- a/lib/Service/CalendarInitialStateService.php
+++ b/lib/Service/CalendarInitialStateService.php
@@ -16,6 +16,8 @@ use OCP\Calendar\Resource\IManager as IResourceManager;
 use OCP\Calendar\Room\IManager as IRoomManager;
 use OCP\IAppConfig;
 use OCP\IConfig;
+use OCP\IGroupManager;
+use OCP\IUserManager;
 use function in_array;
 
 class CalendarInitialStateService {
@@ -32,6 +34,8 @@ class CalendarInitialStateService {
 		private IResourceManager $resourceManager,
 		private IRoomManager $roomManager,
 		private ?IQueue $queue,
+		private IGroupManager $groupManager,
+		private IUserManager $userManager,
 	) {
 	}
 
@@ -70,7 +74,6 @@ class CalendarInitialStateService {
 		$showResources = $this->config->getAppValue($this->appName, 'showResources', 'yes') === 'yes';
 		$publicCalendars = $this->config->getAppValue($this->appName, 'publicCalendars', '');
 
-		$talkEnabled = $this->appManager->isEnabledForUser('spreed');
 		$talkApiVersion = version_compare($this->appManager->getAppVersion('spreed'), '12.0.0', '>=') ? 'v4' : 'v1';
 		$tasksEnabled = $this->appManager->isEnabledForUser('tasks');
 
@@ -95,7 +98,7 @@ class CalendarInitialStateService {
 		$this->initialStateService->provideInitialState('show_weekends', $showWeekends);
 		$this->initialStateService->provideInitialState('show_week_numbers', $showWeekNumbers);
 		$this->initialStateService->provideInitialState('skip_popover', $skipPopover);
-		$this->initialStateService->provideInitialState('talk_enabled', $talkEnabled);
+		$this->initialStateService->provideInitialState('talk_enabled', $this->isTalkEnabledForUser());
 		$this->initialStateService->provideInitialState('talk_api_version', $talkApiVersion);
 		$this->initialStateService->provideInitialState('timezone', $timezone);
 		$this->initialStateService->provideInitialState('attachments_folder', $attachmentsFolder);
@@ -146,4 +149,37 @@ class CalendarInitialStateService {
 				return $view;
 		}
 	}
+
+	private function isTalkEnabledForUser(): bool {
+		$userId = $this->userId;
+		if ($userId === null) {
+			return false;
+		}
+
+		$talkEnabled = $this->appManager->isEnabledForUser('spreed');
+		$user = $this->userManager->get($userId);
+
+		if ($user === null) {
+			return false;
+		}
+
+		$userGroups = $userGroups = $this->groupManager->getUserGroupIds($user);
+
+
+		//groups allowed to start a conversation
+		$startConversation = $this->config->getAppValue('spreed', 'start_conversations', '[]');
+		$startConversation = json_decode($startConversation, true);
+
+		$canStartConversation = !empty(array_intersect($startConversation, $userGroups));
+
+		//groups allowed to use talk
+		$allowedGroups = $this->config->getAppValue('spreed', 'allowed_groups', '[]');
+		$allowedGroups = json_decode($allowedGroups, true);
+
+		$canUseTalk = !empty(array_intersect($allowedGroups, $userGroups));
+
+		return $talkEnabled && $canStartConversation && $canUseTalk;
+	}
+
+
 }

--- a/tests/php/unit/Service/CalendarInitialStateServiceTest.php
+++ b/tests/php/unit/Service/CalendarInitialStateServiceTest.php
@@ -20,6 +20,8 @@ use OCP\Calendar\Room\IBackend as IRoomBackend;
 use OCP\Calendar\Room\IManager as IRoomManager;
 use OCP\IAppConfig;
 use OCP\IConfig;
+use OCP\IGroupManager;
+use OCP\IUserManager;
 use PHPUnit\Framework\MockObject\MockObject;
 
 class CalendarInitialStateServiceTest extends TestCase {
@@ -55,6 +57,9 @@ class CalendarInitialStateServiceTest extends TestCase {
 	/** @var (IQueue&MockObject)|null */
 	private $queue = null;
 
+	private IGroupManager&MockObject $groupManager;
+	private IUserManager&MockObject $userManager;
+
 	protected function setUp(): void {
 		$this->appName = 'calendar';
 		$this->appManager = $this->createMock(IAppManager::class);
@@ -70,6 +75,8 @@ class CalendarInitialStateServiceTest extends TestCase {
 		if (interface_exists(IQueue::class)) {
 			$this->queue = $this->createMock(IQueue::class);
 		}
+		$this->groupManager = $this->createMock(IGroupManager::class);
+		$this->userManager = $this->createMock(IUserManager::class);
 	}
 
 	public function testRun(): void {
@@ -85,6 +92,8 @@ class CalendarInitialStateServiceTest extends TestCase {
 			$this->resourceManager,
 			$this->roomManager,
 			$this->queue,
+			$this->groupManager,
+			$this->userManager,
 		);
 		$this->config->expects(self::exactly(17))
 			->method('getAppValue')
@@ -198,6 +207,8 @@ class CalendarInitialStateServiceTest extends TestCase {
 			$this->resourceManager,
 			$this->roomManager,
 			$this->queue,
+			$this->groupManager,
+			$this->userManager,
 		);
 		$this->config->expects(self::exactly(17))
 			->method('getAppValue')
@@ -242,10 +253,9 @@ class CalendarInitialStateServiceTest extends TestCase {
 				[null, 'calendar', 'showTasks', 'defaultShowTasks', '00:15:00'],
 				[null, 'calendar', 'tasksSidebar', 'defaultTasksSidebar', 'yes'],
 			]);
-		$this->appManager->expects(self::exactly(3))
+		$this->appManager->expects(self::exactly(2))
 			->method('isEnabledForUser')
 			->willReturnMap([
-				['spreed', null, true],
 				['tasks', null, true],
 				['circles', null, false],
 			]);
@@ -271,7 +281,7 @@ class CalendarInitialStateServiceTest extends TestCase {
 				['show_weekends', true],
 				['show_week_numbers', true],
 				['skip_popover', true],
-				['talk_enabled', true],
+				['talk_enabled', false],
 				['talk_api_version', 'v4'],
 				['timezone', 'Europe/Berlin'],
 				['attachments_folder', '/Calendar'],
@@ -314,6 +324,8 @@ class CalendarInitialStateServiceTest extends TestCase {
 			$this->resourceManager,
 			$this->roomManager,
 			$this->queue,
+			$this->groupManager,
+			$this->userManager,
 		);
 		$this->config->expects(self::exactly(17))
 			->method('getAppValue')


### PR DESCRIPTION
Talk app can be granularly enabled for specific user groups which is not respected by the integration in calendar. 
Introducing an OCP api for talk could also be a solution here or as a followup . 
We only use talk to create talk rooms afaik hence checking both configs. 

Admin settings -> talk 
<img width="1034" height="426" alt="image" src="https://github.com/user-attachments/assets/151bcfac-1ed1-4300-85c6-c99e88e1ab23" />
