### PR TITLE
fix: appointment booking overview page styling

### DIFF
--- a/src/views/Appointments/Overview.vue
+++ b/src/views/Appointments/Overview.vue
@@ -93,9 +93,11 @@ export default {
 .overview-info {
 	display: flex;
 	align-items: center;
+	justify-content: center;
 	flex-direction: column;
+	width: 100%;
 	max-width: 900px;
-	margin: 50px auto;
+	margin: 0 auto;
 	padding: 8px 25px var(--footer-height) 25px;
 
 	.title {
@@ -177,6 +179,14 @@ export default {
 </style>
 
 <style lang="scss">
+#appointments-overview {
+	display: flex;
+	justify-content: center;
+	align-items: center;
+	width: 100%;
+	min-height: 100%;
+}
+
 #content.app-calendar {
   // Enable scrolling
   overflow: auto;


### PR DESCRIPTION
### Summary
- resolves: https://github.com/nextcloud/calendar/issues/8174
- fixed appointment booking overview page styling

### Before
<img width="2560" height="1385" alt="Screenshot 2026-04-20 175444" src="https://github.com/user-attachments/assets/b71529c0-ee5c-4467-b939-c0954beaa879" />

### After
<img width="2560" height="1385" alt="Screenshot 2026-04-20 175407" src="https://github.com/user-attachments/assets/08cf0c86-1dc3-4551-b67c-90b9814023f1" />
