### PR TITLE
fix(EmailController): Use calendar name from database

### DIFF
--- a/lib/Controller/EmailController.php
+++ b/lib/Controller/EmailController.php
@@ -10,6 +10,7 @@ namespace OCA\Calendar\Controller;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\JSONResponse;
+use OCP\Calendar\IManager;
 use OCP\Defaults;
 use OCP\IConfig;
 use OCP\IL10N;
@@ -48,6 +49,9 @@ class EmailController extends Controller {
 	/** @var IUserManager */
 	private $userManager;
 
+	/** @var \OCP\Calendar\IManager */
+	private $calendarManager;
+
 	/**
 	 * EmailController constructor.
 	 *
@@ -60,6 +64,7 @@ class EmailController extends Controller {
 	 * @param Defaults $defaults
 	 * @param IURLGenerator $urlGenerator
 	 * @param IUserManager $userManager
+	 * @param IManager $calendarManager
 	 */
 	public function __construct(string $appName,
 		IRequest $request,
@@ -69,7 +74,8 @@ class EmailController extends Controller {
 		IL10N $l10N,
 		Defaults $defaults,
 		IURLGenerator $urlGenerator,
-		IUserManager $userManager) {
+		IUserManager $userManager,
+		IManager $calendarManager) {
 		parent::__construct($appName, $request);
 		$this->config = $config;
 		$this->userSession = $userSession;
@@ -78,12 +84,12 @@ class EmailController extends Controller {
 		$this->defaults = $defaults;
 		$this->urlGenerator = $urlGenerator;
 		$this->userManager = $userManager;
+		$this->calendarManager = $calendarManager;
 	}
 
 	/**
 	 * @param string $recipient
 	 * @param string $token
-	 * @param string $calendarName
 	 * @return JSONResponse
 	 *
 	 * @UserRateThrottle(limit=5, period=100)
@@ -91,8 +97,7 @@ class EmailController extends Controller {
 	 * @NoAdminRequired
 	 */
 	public function sendEmailPublicLink(string $recipient,
-		string $token,
-		string $calendarName):JSONResponse {
+		string $token):JSONResponse {
 		if (strlen($recipient) > 512) {
 			return new JSONResponse([
 				'message' => $this->l10n->t('Provided email-address is too long'),
@@ -112,11 +117,20 @@ class EmailController extends Controller {
 			], Http::STATUS_BAD_REQUEST);
 		}
 
-		$fromAddress = $this->getFromAddress();
-		$displayName = $this->userManager->getDisplayName($user->getUID());
-		$subject = $this->l10n->t('%s has published the calendar »%s«', [$displayName, $calendarName]);
+		$calendar = $this->findCalendarByToken($user, $token);
 
-		$template = $this->createTemplate($subject, $displayName, $calendarName, $token);
+		if ($calendar === null) {
+			return new JSONResponse([
+				'message' => $this->l10n->t('An error occured during sending email'),
+			], Http::STATUS_BAD_REQUEST);
+		}
+
+		$fromAddress = $this->getFromAddress();
+		$displayNameOfUser = $this->userManager->getDisplayName($user->getUID()) ?? $user->getUID();
+		$displayNameOfCalendar = $calendar->getDisplayName() ?? $calendar->getKey();
+		$subject = $this->l10n->t('%s has published the calendar »%s«', [$displayNameOfUser, $displayNameOfCalendar]);
+
+		$template = $this->createTemplate($subject, $displayNameOfUser, $displayNameOfCalendar, $token);
 		$message = $this->createMessage($fromAddress, [$recipient => $recipient], $template);
 
 		try {
@@ -206,5 +220,27 @@ class EmailController extends Controller {
 		return $this->urlGenerator->linkToRouteAbsolute('calendar.publicView.public_index_with_branding', [
 			'token' => $token,
 		]);
+	}
+
+	/**
+	 * Returns the calendar that matches
+	 * the given public sharing token.
+	 *
+	 * @param string $token
+	 * @return \OCA\DAV\CalDAV\CalendarImpl|null
+	 */
+	private function findCalendarByToken($user, string $token): mixed {
+		$userId = $user->getUID();
+		$userCalendars = $this->calendarManager->getCalendarsForPrincipal("principals/users/$userId");
+
+		$matchingCalendar = array_find($userCalendars, function ($calendar) use ($token) {
+			// TODO: Remove method_exists check once there is no risk
+			//  anymore the method isn't available.
+			if (method_exists($calendar, 'getPublicToken')) {
+				return $calendar->getPublicToken() === $token;
+			}
+		});
+
+		return $matchingCalendar;
 	}
 }

--- a/psalm.xml
+++ b/psalm.xml
@@ -71,6 +71,7 @@
 				<referencedClass name="OCA\Circles\Api\v1\Circles" />
 				<referencedClass name="OCA\DAV\CalDAV\Calendar" />
 				<referencedClass name="OCA\DAV\CalDAV\CalendarHome" />
+				<referencedClass name="OCA\DAV\CalDAV\CalendarImpl" />
 				<referencedClass name="OCA\DAV\CalDAV\InvitationResponse\InvitationResponseServer" />
 				<referencedClass name="Symfony\Component\Console\Output\OutputInterface" />
 			</errorLevel>

--- a/src/components/AppNavigation/EditCalendarModal/PublishCalendar.vue
+++ b/src/components/AppNavigation/EditCalendarModal/PublishCalendar.vue
@@ -244,7 +244,6 @@ export default {
 				await HttpClient.post(url, {
 					recipient: emailAddress,
 					token: this.calendar.publishURL.split('/').slice(-1)[0],
-					calendarName: this.calendar.displayName,
 				})
 			} catch (error) {
 				console.error(error)

--- a/tests/php/unit/Controller/EmailControllerTest.php
+++ b/tests/php/unit/Controller/EmailControllerTest.php
@@ -8,7 +8,10 @@ declare(strict_types=1);
 namespace OCA\Calendar\Controller;
 
 use ChristophWurst\Nextcloud\Testing\TestCase;
+use OCA\DAV\CalDAV\CalendarImpl;
+use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\JSONResponse;
+use OCP\Calendar\IManager;
 use OCP\Defaults;
 use OCP\IConfig;
 use OCP\IL10N;
@@ -57,6 +60,9 @@ class EmailControllerTest extends TestCase {
 	/** @var EmailController */
 	private $controller;
 
+	/** @var \OCP\Calendar\IManager|MockObject */
+	private $calendarManager;
+
 	protected function setUp():void {
 		parent::setUp();
 
@@ -69,6 +75,7 @@ class EmailControllerTest extends TestCase {
 		$this->userSession = $this->createMock(IUserSession::class);
 		$this->urlGenerator = $this->createMock(IURLGenerator::class);
 		$this->userManager = $this->createMock(IUserManager::class);
+		$this->calendarManager = $this->createMock(IManager::class);
 
 		$this->user = $this->createMock(IUser::class);
 		$this->user->method('getUID')->willReturn('123');
@@ -83,8 +90,8 @@ class EmailControllerTest extends TestCase {
 		$this->controller = new EmailController($this->appName,
 			$this->request, $this->userSession, $this->config,
 			$this->mailer, $this->l10n, $this->defaults,
-			$this->urlGenerator,
-			$this->userManager);
+			$this->urlGenerator, $this->userManager,
+			$this->calendarManager);
 	}
 
 	public function testSendUserSessionExpired():void {
@@ -98,7 +105,7 @@ class EmailControllerTest extends TestCase {
 		$this->urlGenerator->expects($this->never())
 			->method($this->anything());
 
-		$response = $this->controller->sendEmailPublicLink('foo@bar.com', 'token123', 'calendarHome');
+		$response = $this->controller->sendEmailPublicLink('foo@bar.com', 'token123');
 
 		$this->assertInstanceOf(JSONResponse::class, $response);
 		$this->assertEquals([
@@ -121,13 +128,53 @@ class EmailControllerTest extends TestCase {
 		$this->urlGenerator->expects($this->never())
 			->method($this->anything());
 
-		$response = $this->controller->sendEmailPublicLink('foo@bar.com', 'token123', 'calendarHome');
+		$response = $this->controller->sendEmailPublicLink('foo@bar.com', 'token123');
 
 		$this->assertInstanceOf(JSONResponse::class, $response);
 		$this->assertEquals([
 			'message' => 'TRANSLATED: Provided email-address is not valid'
 		], $response->getData());
 		$this->assertEquals(400, $response->getStatus());
+	}
+
+	public function testSendInvalidToken(): void {
+		$testToken1 = 'token123';
+		$testToken2 = 'token456';
+		$testToken3 = 'token789';
+
+		$this->userSession->expects(self::once())
+			->method('getUser')
+			->willReturn($this->user);
+
+		$this->mailer->expects(self::once())
+			->method('validateMailAddress')
+			->with('foo@bar.com')
+			->willReturn(true);
+
+		$calendar1 = $this->createMock(CalendarImpl::class);
+		$calendar1->expects(self::once())
+			->method('getPublicToken')
+			->willReturn($testToken1);
+
+		$calendar2 = $this->createMock(CalendarImpl::class);
+		$calendar2->expects(self::once())
+			->method('getPublicToken')
+			->willReturn($testToken2);
+
+		$this->calendarManager->expects(self::once())
+			->method('getCalendarsForPrincipal')
+			->with("principals/users/{$this->user->getUID()}")
+			->willReturn([$calendar1, $calendar2]);
+
+		$response = $this->controller->sendEmailPublicLink(
+			'foo@bar.com',
+			$testToken3,
+		);
+
+		$this->assertEquals([
+			'message' => 'TRANSLATED: An error occured during sending email'
+		], $response->getData());
+		$this->assertEquals(Http::STATUS_BAD_REQUEST, $response->getStatus());
 	}
 
 	public function testSendWithMailerError() {
@@ -139,6 +186,19 @@ class EmailControllerTest extends TestCase {
 			->method('validateMailAddress')
 			->with('foo@bar.com')
 			->willReturn(true);
+
+		$calendar = $this->createMock(CalendarImpl::class);
+		$calendar->expects(self::once())
+			->method('getPublicToken')
+			->willReturn('token123');
+		$calendar->expects(self::once())
+			->method('getDisplayName')
+			->willReturn('calendar name 456');
+
+		$this->calendarManager->expects(self::once())
+			->method('getCalendarsForPrincipal')
+			->with("principals/users/{$this->user->getUID()}")
+			->willReturn([$calendar]);
 
 		$this->config->expects(self::exactly(2))
 			->method('getSystemValue')
@@ -219,7 +279,7 @@ class EmailControllerTest extends TestCase {
 			->with($message)
 			->willThrowException(new \Exception('123'));
 
-		$response = $this->controller->sendEmailPublicLink('foo@bar.com', 'token123', 'calendar name 456');
+		$response = $this->controller->sendEmailPublicLink('foo@bar.com', 'token123');
 
 		$this->assertInstanceOf(JSONResponse::class, $response);
 		$this->assertEquals([
@@ -238,6 +298,19 @@ class EmailControllerTest extends TestCase {
 			->method('validateMailAddress')
 			->with('foo@bar.com')
 			->willReturn(true);
+
+		$calendar = $this->createMock(CalendarImpl::class);
+		$calendar->expects(self::once())
+			->method('getPublicToken')
+			->willReturn('token123');
+		$calendar->expects(self::once())
+			->method('getDisplayName')
+			->willReturn('calendar name 456');
+
+		$this->calendarManager->expects(self::once())
+			->method('getCalendarsForPrincipal')
+			->with("principals/users/{$this->user->getUID()}")
+			->willReturn([$calendar]);
 
 		$this->config->expects(self::exactly(2))
 			->method('getSystemValue')
@@ -324,7 +397,7 @@ class EmailControllerTest extends TestCase {
 			->method('send')
 			->with($message);
 
-		$response = $this->controller->sendEmailPublicLink('foo@bar.com', 'token123', 'calendar name 456');
+		$response = $this->controller->sendEmailPublicLink('foo@bar.com', 'token123');
 
 		$this->assertInstanceOf(JSONResponse::class, $response);
 		$this->assertEquals([


### PR DESCRIPTION
This PR changes the logic of the `EmailController` to use the calendar name from the database.