### PR TITLE
Various design fixes for "Repeat event" dialog

### DIFF
--- a/css/app-full.scss
+++ b/css/app-full.scss
@@ -224,7 +224,6 @@
 				border: var(--border-width-input) solid var(--color-border-dark);
 				text-align: center;
 				margin: 0;
-				border-radius: 0;
 			}
 		}
 	}

--- a/src/components/Editor/Repeat/Repeat.vue
+++ b/src/components/Editor/Repeat/Repeat.vue
@@ -85,7 +85,7 @@
 				v-if="!isRecurrenceException && !isReadOnly"
 				class="property-repeat__options__footer">
 				<NcButton variant="primary" @click="saveAndClose">
-					{{ $t('calendar', 'Add') }}
+					{{ $t('calendar', 'Set repetition') }}
 				</NcButton>
 			</div>
 		</NcModal>

--- a/src/components/Editor/Repeat/RepeatFreqInterval.vue
+++ b/src/components/Editor/Repeat/RepeatFreqInterval.vue
@@ -83,9 +83,20 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-.repeat-option-set--interval-freq {
-	display: flex;
-	flex-direction: column;
-	gap: calc(var(--default-grid-baseline) * 2);
+.repeat-option-set {
+	&--interval-freq {
+		display: flex;
+		flex-direction: row;
+		gap: var(--default-grid-baseline);
+	}
+
+	&__interval {
+		flex: 1 1 0px;
+	}
+
+	&__frequency {
+		min-width: initial;
+		flex: 1 1 0px;
+	}
 }
 </style>


### PR DESCRIPTION
- Fix layout of 'Repeat event' dialog, putting the number and day/week/month switcher on the same line at 50% width
- Change button label in 'Repeat event' dialog from generic 'Add' to specific 'Set repetition'
- Undo removal of border-radius in 'Repeat event' dialog so week/month/year view looks closer to styleguide

Before | After
-|-
<img width="656" height="656" alt="Screenshot From 2026-04-23 13-36-33" src="https://github.com/user-attachments/assets/ecfdb401-04b2-4345-91ca-720c47990323" />|<img width="656" height="585" alt="Screenshot From 2026-04-23 13-32-16" src="https://github.com/user-attachments/assets/e3b4c2c6-267e-4253-95c6-fa929b1c268a" />

Disregard the branch name, wanted to do something else but then got sidetracked by this. :D 