### PR TITLE
Clarify update and delete actions on repeating events

### DIFF
--- a/src/components/Editor/SaveButtons.vue
+++ b/src/components/Editor/SaveButtons.vue
@@ -53,7 +53,7 @@
 			</template>
 			<NcActionButton @click="saveThisAndAllFuture">
 				<template #icon>
-					<CheckIcon :size="20" />
+					<CheckAllIcon :size="20" />
 				</template>
 				{{ $t('calendar', 'Update this and all future') }}
 			</NcActionButton>
@@ -73,12 +73,14 @@
 <script>
 import { NcActionButton, NcActions, NcButton } from '@nextcloud/vue'
 import CheckIcon from 'vue-material-design-icons/Check.vue'
+import CheckAllIcon from 'vue-material-design-icons/CheckAll.vue'
 
 export default {
 	name: 'SaveButtons',
 	components: {
 		NcButton,
 		CheckIcon,
+		CheckAllIcon,
 		NcActions,
 		NcActionButton,
 	},

--- a/src/views/EditFull.vue
+++ b/src/views/EditFull.vue
@@ -82,6 +82,7 @@
 									</template>
 									{{ $t('calendar', 'Delete this occurrence') }}
 								</NcActionButton>
+								<NcActionSeparator v-if="canDelete && canCreateRecurrenceException && !isNew" />
 								<NcActionButton v-if="canDelete && canCreateRecurrenceException && !isNew" @click="deleteAndLeave(true)">
 									<template #icon>
 										<Delete :size="20" decorative />
@@ -338,6 +339,7 @@ import {
 	NcActionButton,
 	NcActionLink,
 	NcActions,
+	NcActionSeparator,
 	NcButton,
 	NcCheckboxRadioSwitch,
 	NcDialog,
@@ -411,6 +413,7 @@ export default {
 		IconVideo,
 		HelpCircleIcon,
 		NcActions,
+		NcActionSeparator,
 		Close,
 	},
 

--- a/src/views/EditSimple.vue
+++ b/src/views/EditSimple.vue
@@ -96,6 +96,7 @@
 								</template>
 								{{ $t('calendar', 'Delete this occurrence') }}
 							</ActionButton>
+							<NcActionSeparator v-if="canDelete && canCreateRecurrenceException" />
 							<ActionButton v-if="canDelete && canCreateRecurrenceException" @click="deleteAndLeave(true)">
 								<template #icon>
 									<Delete :size="20" decorative />
@@ -268,6 +269,7 @@ import {
 	NcActionLink as ActionLink,
 	NcActions as Actions,
 	NcEmptyContent as EmptyContent,
+	NcActionSeparator,
 	NcButton,
 	NcCheckboxRadioSwitch,
 	NcDialog,
@@ -312,6 +314,7 @@ export default {
 		Actions,
 		ActionButton,
 		ActionLink,
+		NcActionSeparator,
 		AlarmList,
 		Bell,
 		EmptyContent,


### PR DESCRIPTION
The wording was already clear, but this adds further clarity and separation just for safety:
- Specific icon for 'Update this and all future' to be more distinguishable
- Separate 'Delete this and all future' as last most destructive action of the menu with a separator as we do in Files. There wasn’t a nicely fitting icon unfortunately – I tried the filled Trash Can icon but it looked off, and DeleteSweep is too different.

Before | After
-|-
<img width="408" height="232" alt="Screenshot From 2026-04-23 17-07-23" src="https://github.com/user-attachments/assets/1af7d287-44e2-4482-b99b-113dea0e4a99" />|<img width="408" height="232" alt="Screenshot From 2026-04-23 16-59-32" src="https://github.com/user-attachments/assets/d044cd62-4bf4-4edb-af79-561765ef1a82" />
<img width="408" height="232" alt="Screenshot From 2026-04-23 17-07-26" src="https://github.com/user-attachments/assets/721d7fb1-3965-4bd4-8b41-76a7826c8f82" />|<img width="408" height="232" alt="Screenshot From 2026-04-23 16-59-36" src="https://github.com/user-attachments/assets/2655bd85-30f6-4286-99c7-f9c98829633c" />


--- 

Fun fact: One big reason for this fix is since I’m forcing myself to learn Japanese, this is something I often stumbled over ;)
<img width="325" height="206" alt="Screenshot From 2026-04-21 12-44-05" src="https://github.com/user-attachments/assets/a9be73ab-dad9-4a34-8d32-ef4e5ed97ad9" />
