### PR TITLE
Fix active day highlight in month view for longer languages like Japanese

### DIFF
--- a/css/fullcalendar.scss
+++ b/css/fullcalendar.scss
@@ -77,12 +77,10 @@
 
 	.fc-daygrid-day-top {
 		.fc-daygrid-day-number {
-			margin: 4px;
-			width: 24px;
-			height: 24px;
+			margin: var(--default-grid-baseline) 0 calc(var(--default-grid-baseline) + 1px);
+			padding: 0 var(--default-grid-baseline);
 			text-align: center;
 			font-weight: bold !important;
-			padding: 0 !important;
 			background: var(--color-primary-element);
 			color: var(--color-primary-element-text);
 			border-radius: var(--border-radius-small);


### PR DESCRIPTION
In Japanese, the date display is a bit longer than just 2 numbers as the kanji for "day" is appended. This way it’s much more flexible and also adjusts the English version to look better.

The grid baseline + 1px hack is necessary so alignment still works out as before.

Before | After
-|-
<img width="866" height="507" alt="Screenshot From 2026-04-23 17-34-12" src="https://github.com/user-attachments/assets/5f3acc55-76ea-48da-94cb-b12ab1226a96" />|<img width="866" height="507" alt="Screenshot From 2026-04-23 17-52-02" src="https://github.com/user-attachments/assets/8d7aae87-0883-4119-a7de-68145a67f29d" />
<img width="866" height="507" alt="Screenshot From 2026-04-23 17-34-24" src="https://github.com/user-attachments/assets/3df81884-5c5c-42ab-9dfa-965242e4868a" />|<img width="866" height="507" alt="Screenshot From 2026-04-23 17-52-20" src="https://github.com/user-attachments/assets/035003fe-166e-4230-b23f-65078be3cff1" />

