### PR TITLE
Security: State-changing GET endpoint is marked NoCSRFRequired and can be abused for CSRF-driven storage spam

### DIFF
--- a/lib/Controller/ViewController.php
+++ b/lib/Controller/ViewController.php
@@ -11,11 +11,9 @@ use OC\App\CompareVersion;
 use OCA\Calendar\Service\CalendarInitialStateService;
 use OCP\App\IAppManager;
 use OCP\AppFramework\Controller;
-use OCP\AppFramework\Http\FileDisplayResponse;
+use OCP\AppFramework\Http\DataDisplayResponse;
 use OCP\AppFramework\Http\TemplateResponse;
 use OCP\Files\IAppData;
-use OCP\Files\NotFoundException;
-use OCP\Files\NotPermittedException;
 use OCP\IConfig;
 use OCP\IRequest;
 
@@ -74,28 +72,16 @@ class ViewController extends Controller {
 	 * or a Nextcloud blue svg if the colour is not
 	 *
 	 * @param string $color - url encoded HEX colour
-	 * @return FileDisplayResponse
-	 * @throws NotPermittedException
+	 * @return DataDisplayResponse
 	 */
-	public function getCalendarDotSvg(string $color = '#0082c9'): FileDisplayResponse {
+	public function getCalendarDotSvg(string $color = '#0082c9'): DataDisplayResponse {
 		$validColor = '#0082c9';
 		$color = trim(urldecode($color), '#');
 		if (preg_match('/^([0-9a-f]{3}|[0-9a-f]{6})$/i', $color)) {
 			$validColor = '#' . $color;
 		}
 		$svg = '<svg height="32" width="32" viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg"><rect width="100%" height="100%" fill="' . $validColor . '"/></svg>';
-		$folderName = implode('_', [
-			'calendar',
-			$this->userId
-		]);
-		try {
-			$folder = $this->appData->getFolder($folderName);
-		} catch (NotFoundException $e) {
-			$folder = $this->appData->newFolder($folderName);
-		}
-		$file = $folder->newFile($color . '.svg', $svg);
-		$response = new FileDisplayResponse($file);
-		// Some browsers won't render SVGs without content types (for security reasons)
+		$response = new DataDisplayResponse($svg);
 		$response->addHeader('Content-Type', 'image/svg+xml');
 		$response->cacheFor(24 * 3600); // 1 day
 		return $response;


### PR DESCRIPTION
## Summary

Security: State-changing GET endpoint is marked NoCSRFRequired and can be abused for CSRF-driven storage spam

## Problem

**Severity**: `Medium` | **File**: `lib/Controller/ViewController.php:L70`

`getCalendarDotSvg` is documented as `@NoCSRFRequired` and performs a write operation (`newFile`) in app data based on request input. Because this is a GET-style retrieval endpoint with side effects, a third-party site can trigger authenticated users' browsers to hit it repeatedly, causing unwanted file creation and potential storage exhaustion/DoS.

## Solution

Make the endpoint side-effect free (serve generated SVG directly without persisting), or require POST with CSRF protection for writes. Add rate limiting and cleanup/overwrite logic to prevent unbounded file growth.

## Changes

- `lib/Controller/ViewController.php` (modified)