### PR TITLE
feat: Resize events from start.

### DIFF
--- a/src/components/CalendarGrid.vue
+++ b/src/components/CalendarGrid.vue
@@ -132,6 +132,7 @@ export default {
 				eventClick: eventClick(this.$router, this.$route, window, this.isWidget, this.$refs),
 				eventDrop: this.isWidget ? false : (...args) => eventDrop(this.$refs.fullCalendar.getApi())(...args),
 				eventResize: this.isWidget ? false : eventResize(),
+				eventResizableFromStart: true,
 				navLinkDayClick: this.isWidget ? false : navLinkDayClick(this.$router, this.$route),
 				navLinkWeekClick: this.isWidget ? false : navLinkWeekClick(this.$router, this.$route),
 				select: this.isWidget ? false : select(this.$router, this.$route, window),


### PR DESCRIPTION
Features #8191. As it turns out, this is already implemented by [FullCalendar](https://fullcalendar.io/docs/eventResizableFromStart), it just needs to be turned on ^ ^"