### PR TITLE
fix: calendar initiial state

### DIFF
--- a/lib/Service/CalendarInitialStateService.php
+++ b/lib/Service/CalendarInitialStateService.php
@@ -163,18 +163,19 @@ class CalendarInitialStateService {
 			return false;
 		}
 
-		$userGroups = $userGroups = $this->groupManager->getUserGroupIds($user);
-
+		$userGroups = $this->groupManager->getUserGroupIds($user);
 
 		//groups allowed to start a conversation
 		$startConversation = $this->config->getAppValue('spreed', 'start_conversations', '[]');
 		$startConversation = json_decode($startConversation, true);
+		$startConversation = is_array($startConversation) ? $startConversation : [];
 
 		$canStartConversation = !empty(array_intersect($startConversation, $userGroups));
 
 		//groups allowed to use talk
 		$allowedGroups = $this->config->getAppValue('spreed', 'allowed_groups', '[]');
 		$allowedGroups = json_decode($allowedGroups, true);
+		$allowedGroups = is_array($allowedGroups) ? $allowedGroups : [];
 
 		$canUseTalk = !empty(array_intersect($allowedGroups, $userGroups));
 


### PR DESCRIPTION
### Summary
- Resolves: https://github.com/nextcloud/calendar/issues/8237
- Added guards to prevent json_decode from returning an invalid value