### PR TITLE
fix: identify if contact is a system user

### DIFF
--- a/lib/Controller/ContactController.php
+++ b/lib/Controller/ContactController.php
@@ -220,7 +220,8 @@ class ContactController extends Controller {
 				'lang' => $lang,
 				'tzid' => $timezoneId,
 				'photo' => $photo,
-				'type' => 'individual'
+				'type' => 'individual',
+				'source' => $isSystemUser ? 'system' : 'user',
 			];
 		}
 
@@ -242,6 +243,7 @@ class ContactController extends Controller {
 					'tzid' => '',
 					'photo' => '',
 					'type' => 'contactsgroup',
+					'source' => 'user',
 					'members' => $count,
 				];
 			}

--- a/src/components/Editor/Invitees/InviteesListSearch.vue
+++ b/src/components/Editor/Invitees/InviteesListSearch.vue
@@ -275,7 +275,7 @@ export default {
 						calendarUserType: 'INDIVIDUAL',
 						commonName: result.name,
 						email,
-						isUser: false,
+						isUser: result.source === 'system' ? true : false,
 						avatar: result.photo,
 						language: result.lang,
 						timezoneId: result.tzid,

--- a/tests/php/unit/Controller/ContactControllerTest.php
+++ b/tests/php/unit/Controller/ContactControllerTest.php
@@ -493,7 +493,8 @@ class ContactControllerTest extends TestCase {
 				'lang' => 'en',
 				'tzid' => 'UTC',
 				'photo' => null,
-				'type' => 'individual'
+				'type' => 'individual',
+				'source' => 'system',
 			]
 		], $response->getData());
 		$this->assertEquals(200, $response->getStatus());
@@ -610,6 +611,7 @@ class ContactControllerTest extends TestCase {
 				'tzid' => 'Europe/Berlin',
 				'photo' => null,
 				'type' => 'individual',
+				'source' => 'user',
 			],
 			[
 				'name' => 'Allowed System User',
@@ -618,6 +620,7 @@ class ContactControllerTest extends TestCase {
 				'tzid' => 'UTC',
 				'photo' => null,
 				'type' => 'individual',
+				'source' => 'system',
 			],
 			[
 				'name' => 'Excluded System User',
@@ -626,6 +629,7 @@ class ContactControllerTest extends TestCase {
 				'tzid' => 'UTC',
 				'photo' => null,
 				'type' => 'individual',
+				'source' => 'system',
 			],
 		], $response->getData());
 		$this->assertEquals(200, $response->getStatus());


### PR DESCRIPTION
### Summary
- Resolves:  There is a ticket on this but I can't find it atm
- Added source variable so that the front then know if the contact is a internal user. The contacts was always being created with isUser = false.