### PR TITLE
fix: appointment config check boxes

### DIFF
--- a/src/components/AppointmentConfigModal/CheckedDurationSelect.vue
+++ b/src/components/AppointmentConfigModal/CheckedDurationSelect.vue
@@ -8,7 +8,7 @@
 		<div class="checked-duration-select__checkbox-row">
 			<NcCheckboxRadioSwitch
 				:modelValue="enabled"
-				@update:checked="$emit('update:enabled', $event)">
+				@update:modelValue="$emit('update:enabled', $event)">
 				{{ label }}
 			</NcCheckboxRadioSwitch>
 		</div>


### PR DESCRIPTION
### Summary
- Fixed Vue 3 migration bug, in appointment config, missed conversion from :checked to :modelValue