### PR TITLE
fix: Scroll month view to current day so it’s visible

### DIFF
--- a/src/components/CalendarGrid.vue
+++ b/src/components/CalendarGrid.vue
@@ -170,6 +170,7 @@ export default {
 				droppable: true,
 				eventReceive: this.handleEventReceive,
 				eventShortHeight: 38,
+				loading: this.scrollMonthViewToToday,
 			}
 		},
 
@@ -314,6 +315,26 @@ export default {
 	},
 
 	methods: {
+		/**
+		 * Scroll the month view to today when loading the calendar,
+		 * so people can directly see today's date and events.
+		 */
+		scrollMonthViewToToday(isLoading) {
+			if (isLoading) {
+				return
+			}
+			const calendarApi = this.$refs.fullCalendar.getApi()
+			if (calendarApi.view.type !== 'dayGridMonth') {
+				return
+			}
+			this.$nextTick(() => {
+				const todayEl = this.$refs.fullCalendar.$el.querySelector('.fc-day-today')
+				if (todayEl) {
+					todayEl.scrollIntoView({ block: 'nearest', behavior: 'smooth' })
+				}
+			})
+		},
+
 		/**
 		 * When a user changes the view, remember it and
 		 * use it the next time they open the calendar app


### PR DESCRIPTION
When in the month view of the current month, the current day might often be very far down or even outside of the viewport. This is an issue especially for filled calendars (like when our vacation calendar is enabled), or if the setting "Limit number of events shown in month view" is disabled, or if it’s at the end of a month.

Was thinking this could be fixable by cross-checking which element has the class "fc-day-today" and then using the id of the a element inside (for example id="fc-dom-32") to navigate to it via a simple hash link.

Fix longstanding issue https://github.com/nextcloud/calendar/issues/146 and fix https://github.com/nextcloud/calendar/issues/8016

No video/screenshot as I used an export of our internal calendars since they are so full. ;)

---

AI-assisted: Claude Code (Sonnet 4.6)

Adds a loading callback to the FullCalendar options that fires once all event sources have finished fetching – at which point row heights are final. When loading completes in dayGridMonth view and today is in the visible range, the `.fc-day-today` cell is scrolled into view using `scrollIntoView({ block: 'nearest', behavior: 'smooth' })`, which only scrolls if the element is actually outside the viewport.