### PR TITLE
chore: Add eslint, rspack and vitest config giles to ignore list

### DIFF
--- a/.nextcloudignore
+++ b/.nextcloudignore
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 __mocks__
 .editorconfig
-.eslintrc.js
 .git
 .git-blame-ignore-revs
 .github
@@ -13,8 +12,6 @@ __mocks__
 .php-cs-fixer.dist.php
 .php-cs-fixer.cache
 .scrutinizer.yml
-.stylelintignore
-.stylelintrc
 .tx
 babel.config.js
 build
@@ -34,13 +31,15 @@ phpunit*.xml
 renovate.json
 screenshots
 src
-stylelint.config.js
+stylelint.config.mjs
 tests
 timezones
 /vendor/bin
 /vendor/bamarni/composer-bin-plugin/e2e
 /vendor-bin
-webpack.*
+eslint.config.mjs
+rspack.config.js
 playwright.config.js
+vitest.config.js
 tsconfig.json
 tsconfig.json.license


### PR DESCRIPTION
The `.nextcloudignore` list isn't up-to-date. The `rspack.config.js` is missing and looking into the distributed zip package, there are additional files that shouldn't be there:

<img width="655" height="595" alt="image" src="https://github.com/user-attachments/assets/a929637e-ebd8-4ef0-a046-36be5cf190b8" />

I'm unsure about the markdown files as well as the REUSE file, as they might be intended to be included in the zip. That's why I didn't do any changes there. Can include them as well if that's desired.