### PR TITLE
chore: bump main and stable versions

### DIFF
--- a/.github/workflows/npm-audit-fix.yml
+++ b/.github/workflows/npm-audit-fix.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        branches: ['main', 'stable5.5', 'stable6.3']
+        branches: ['main', 'stable5.5', 'stable6.4']
 
     name: npm-audit-fix-${{ matrix.branches }}
 

--- a/.tx/backport
+++ b/.tx/backport
@@ -1,2 +1,2 @@
 stable5.5
-stable6.2
+stable6.4

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -23,7 +23,7 @@
 * 📎 **Attachments!** Add, upload and view event attachments
 * 🙈 **We’re not reinventing the wheel!** Based on the great [c-dav library](https://github.com/nextcloud/cdav-library), [ical.js](https://github.com/mozilla-comm/ical.js) and [fullcalendar](https://github.com/fullcalendar/fullcalendar) libraries.
 	]]></description>
-	<version>6.4.0-dev.0</version>
+	<version>6.5.0-dev.0</version>
 	<licence>agpl</licence>
 	<author homepage="https://github.com/GVodyanov">Grigory Vodyanov</author>
 	<author homepage="https://github.com/SebastianKrupinski">Sebastian Krupinski </author>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "calendar",
-  "version": "6.4.0-dev.0",
+  "version": "6.5.0-dev.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "calendar",
-      "version": "6.4.0-dev.0",
+      "version": "6.5.0-dev.0",
       "license": "agpl",
       "dependencies": {
         "@fullcalendar/core": "6.1.20",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "calendar",
   "description": "A calendar app for Nextcloud. Easily sync events from various devices, share and edit them online.",
-  "version": "6.4.0-dev.0",
+  "version": "6.5.0-dev.0",
   "keywords": [
     "nextcloud",
     "calendars",

--- a/renovate.json
+++ b/renovate.json
@@ -22,7 +22,7 @@
 	"ignoreUnstable": false,
 	"baseBranchPatterns": [
 		"main",
-		"stable6.3",
+		"stable6.4",
 		"stable5.5"
 	],
 	"enabledManagers": [


### PR DESCRIPTION
### Summary
- Bumped main version due to unintentional  automation version bump on stable6.3
- Bumped relevant files to stable6.4 due to unintentional  automation version bump on 6.3