### PR TITLE
fix: do not update share item on mount

### DIFF
--- a/src/components/AppNavigation/EditCalendarModal/ShareItem.vue
+++ b/src/components/AppNavigation/EditCalendarModal/ShareItem.vue
@@ -20,7 +20,7 @@
 			v-if="canBeSharedWritable"
 			v-model="isWriteable"
 			:disabled="updatingSharee"
-			@update:checked="updatePermission">
+			@update:modelValue="updatePermission">
 			{{ $t('calendar', 'can edit and see confidential events') }}
 		</NcCheckboxRadioSwitch>
 
@@ -79,7 +79,7 @@ export default {
 			id: randomId(),
 			updatingSharee: false,
 			shareeEmail: '',
-			isWriteable: false,
+			isWriteable: this.sharee.writeable,
 		}
 	},
 
@@ -109,22 +109,9 @@ export default {
 			return this.calendar.canCreateObject || this.calendar.canModifyObject
 		},
 
-		/**
-		 * @return {boolean}
-		 */
-		initialIsWriteable() {
-			return this.sharee.writeable
-		},
-	},
-
-	watch: {
-		isWriteable() {
-			this.updatePermission()
-		},
 	},
 
 	mounted() {
-		this.isWriteable = this.initialIsWriteable
 		this.updateShareeEmail()
 	},
 


### PR DESCRIPTION
### Summary
- Resolves: https://github.com/nextcloud/calendar/issues/8326
- Resolves: https://github.com/nextcloud/server/issues/60338
- Modified share item to only update permissions on user click

### Testing
- Without PR opening the calendar settings dialog would trigger a share update request for each user in the list
