### PR TITLE
fix: vue router 5 matching behaviour

### DIFF
--- a/src/router.js
+++ b/src/router.js
@@ -83,7 +83,7 @@ const router = createRouter({
 		},
 		{
 			path: '/new/:view?',
-			redirect: (to) => `/${to.params.view ?? getInitialView()}/now/new/${getPreferredEditorRoute()}/0/${getDefaultStartDateForNewEvent()}/${getDefaultEndDateForNewEvent()}`,
+			redirect: (to) => `/${to.params.view || getInitialView()}/now/new/${getPreferredEditorRoute()}/0/${getDefaultStartDateForNewEvent()}/${getDefaultEndDateForNewEvent()}`,
 		},
 		{
 			path: '/new/:allDay/:dtstart/:dtend',

--- a/tests/javascript/unit/router.test.js
+++ b/tests/javascript/unit/router.test.js
@@ -56,6 +56,11 @@ describe('router redirect test suite', () => {
 		expect(router.currentRoute.value.path).toBe('/embed/e9NifA4gGmfHJo54/dayGridMonth/now')
 	})
 
+	it('redirects /new to the initial view', async () => {
+		await router.push('/new')
+		expect(router.currentRoute.value.path).toMatch(/^\/dayGridMonth\/now\/new\/popover\/0\/\d+\/\d+$/)
+	})
+
 	it('redirects /edit/:object with the real object id', async () => {
 		await router.push('/edit/someObjectId')
 		expect(router.currentRoute.value.path).toBe('/dayGridMonth/now/edit/popover/someObjectId/next')


### PR DESCRIPTION
### Summary
- Resolves: https://github.com/nextcloud/calendar/issues/8334

### Cause
- Vue router 5 matching "/new/:view?" seams to return empty string now instead of null. So the null check "to.params.view ?? getInitialView()" was failing