### PR TITLE
fix: free event height

### DIFF
--- a/css/fullcalendar.scss
+++ b/css/fullcalendar.scss
@@ -142,7 +142,9 @@
 	// Free (TRANSP:TRANSPARENT) events: hollow left strip — 1px accent | page-bg | 1px accent
 	&.fc-event-nc-free {
 		&:not(.fc-daygrid-dot-event):not(.fc-list-event) {
-			position: relative;
+			&:not(.fc-timegrid-event) {
+				position: relative;
+			}
 			// Hide the solid left border; the ::before pseudo-element takes its place
 			border-inline-start-color: transparent !important;
 


### PR DESCRIPTION
Fix https://github.com/nextcloud/calendar/issues/8325

| Before | After |
| - | - |
| <img width="994" height="843" alt="image" src="https://github.com/user-attachments/assets/f9adedb6-d2d4-4f0b-8624-ea385659236d" /> | <img width="974" height="862" alt="image" src="https://github.com/user-attachments/assets/1da039df-cbc9-4353-a185-21012415ce05" /> |