### PR TITLE
fix(models): markRaw calendar-js objects in Pinia state

### DIFF
--- a/src/models/alarm.js
+++ b/src/models/alarm.js
@@ -2,6 +2,7 @@
  * SPDX-FileCopyrightText: 2020 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
+import { markRaw } from 'vue'
 import {
 	getAmountAndUnitForTimedEvents,
 	getAmountHoursMinutesAndUnitForAllDayEvents,
@@ -75,7 +76,7 @@ function mapAlarmComponentToAlarmObject(alarmComponent) {
 		const relativeTrigger = alarmComponent.trigger.value.totalSeconds
 
 		return getDefaultAlarmObject({
-			alarmComponent,
+			alarmComponent: markRaw(alarmComponent),
 			type: alarmComponent.action,
 			isRelative: alarmComponent.trigger.isRelative(),
 			relativeIsBefore,
@@ -92,7 +93,7 @@ function mapAlarmComponentToAlarmObject(alarmComponent) {
 		const absoluteDate = getDateFromDateTimeValue(alarmComponent.trigger.value)
 
 		return getDefaultAlarmObject({
-			alarmComponent,
+			alarmComponent: markRaw(alarmComponent),
 			type: alarmComponent.action,
 			isRelative: alarmComponent.trigger.isRelative(),
 			absoluteDate,

--- a/src/models/attachment.js
+++ b/src/models/attachment.js
@@ -2,6 +2,7 @@
  * SPDX-FileCopyrightText: 2022 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
+import { markRaw } from 'vue'
 
 /**
  * Creates a complete attachment object based on given props
@@ -36,7 +37,7 @@ function getDefaultAttachmentObject(props = {}) {
  */
 function mapAttachmentPropertyToAttchmentObject(attachmentProperty) {
 	return getDefaultAttachmentObject({
-		attachmentProperty,
+		attachmentProperty: markRaw(attachmentProperty),
 		fileName: attachmentProperty.getParameterFirstValue('FILENAME'),
 		formatType: attachmentProperty.formatType,
 		uri: attachmentProperty.uri,

--- a/src/models/attendee.js
+++ b/src/models/attendee.js
@@ -4,6 +4,7 @@
  */
 
 import { AttendeeProperty } from '@nextcloud/calendar-js'
+import { markRaw } from 'vue'
 
 /**
  * Creates a complete attendee object based on given props
@@ -43,7 +44,7 @@ function getDefaultAttendeeObject(props = {}) {
  */
 function mapAttendeePropertyToAttendeeObject(attendeeProperty) {
 	return getDefaultAttendeeObject({
-		attendeeProperty,
+		attendeeProperty: markRaw(attendeeProperty),
 		commonName: attendeeProperty.commonName,
 		calendarUserType: attendeeProperty.userType,
 		participationStatus: attendeeProperty.participationStatus,

--- a/src/models/event.js
+++ b/src/models/event.js
@@ -4,6 +4,7 @@
  */
 
 import { DateTimeValue, DurationValue } from '@nextcloud/calendar-js'
+import { markRaw } from 'vue'
 import { getClosestCSS3ColorNameForHex, getHexForColorName } from '../utils/color.js'
 import { getDateFromDateTimeValue } from '../utils/date.js'
 import { mapAlarmComponentToAlarmObject } from './alarm.js'
@@ -84,7 +85,7 @@ function getDefaultEventObject(props = {}) {
  */
 function mapEventComponentToEventObject(eventComponent) {
 	const eventObject = getDefaultEventObject({
-		eventComponent,
+		eventComponent: markRaw(eventComponent),
 		title: eventComponent.title,
 		isAllDay: eventComponent.isAllDay(),
 		canModifyAllDay: eventComponent.canModifyAllDay(),

--- a/src/models/recurrenceRule.js
+++ b/src/models/recurrenceRule.js
@@ -1,8 +1,9 @@
-import { getDateFromDateTimeValue } from '../utils/date.js'
 /**
  * SPDX-FileCopyrightText: 2020 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
+import { markRaw } from 'vue'
+import { getDateFromDateTimeValue } from '../utils/date.js'
 import { getWeekDayFromDate } from '../utils/recurrence.js'
 
 /**
@@ -483,7 +484,7 @@ function getDefaultRecurrenceRuleObjectForRecurrenceValue(recurrenceRuleValue, p
 	}
 
 	return getDefaultRecurrenceRuleObject({
-		recurrenceRuleValue,
+		recurrenceRuleValue: markRaw(recurrenceRuleValue),
 		frequency: recurrenceRuleValue.frequency,
 		interval: parseInt(recurrenceRuleValue.interval, 10) || 1,
 		count: recurrenceRuleValue.count,

--- a/src/store/calendarObjectInstance.js
+++ b/src/store/calendarObjectInstance.js
@@ -486,7 +486,7 @@ export default defineStore('calendarObjectInstance', {
 				role,
 				rsvp,
 				uri,
-				attendeeProperty: attendee,
+				attendeeProperty: markRaw(attendee),
 			})
 
 			if (!calendarObjectInstance.organizer && organizer) {


### PR DESCRIPTION
### Summary

- Fixes #8364
- Wrap calendar-js `AttendeeProperty`, `EventComponent` (including organizer), `AlarmComponent`, `AttachmentProperty` and `RecurValue` with `markRaw` when they enter Pinia state, so Vue 3 does not deep-wrap them into reactive Proxies.

### Root cause

Vue 3 / Pinia deep-wrap any object stored in state into a reactive Proxy. `@nextcloud/calendar-js` mutations route through methods like `EventComponent.removeAttendee(prop)`, which in turn call `AbstractComponent.deleteProperty(prop)`:

```js
const arr = this._properties.get(property.name)
const index = arr.indexOf(property)
if (index === -1) return false
```

`Array.indexOf` uses strict object identity. The Proxy passed in from the store is not strictly equal to the raw property kept in `_properties` → `indexOf` returns `-1` → `deleteProperty` returns `false` and does nothing. The caller never checks the return value and proceeds with its local state splice, so the UI appears to update but the next `toICS()` serializes the unchanged VEVENT.

Verified live with a DevTools breakpoint at `calendarObjectInstance.js:512`:

```js
[!!attendee.attendeeProperty.__v_isReactive, !!attendee.attendeeProperty.__v_raw]
// → [true, true]   (Proxy)
attendee.attendeeProperty.__v_raw === eventComponent._properties.get('ATTENDEE')[0]
// → true           (correct underlying object)
eventComponent._properties.get('ATTENDEE').indexOf(attendee.attendeeProperty)
// → -1             (proxy ≠ raw, silent fail)
```

### Why this pattern

`calendarComponent` (VCALENDAR root) is already wrapped with `markRaw` in `src/models/calendarObject.js:76,103` and `src/store/calendarObjects.js:244,311,326,367`. `eventComponent` got the same treatment in `src/store/calendarObjectInstance.js:73,95`, but **after** `mapEventComponentToEventObject` had already populated `attendees[*].attendeeProperty` — too late, the proxies were already locked in.

This change applies the same hardening at every mapping site, so every calendar-js property/component enters Pinia state already raw. Same pattern as #7997, which applied it to the import parser.

### What this fixes

Confirmed live on Calendar 6.4.0 / Nextcloud 33.0.3.2:

- Removing an attendee from an event — PUT carries the modified VEVENT, server stores correctly, iTip CANCEL is sent.
- Changing an attendee's role (Chair / Required / Optional / Non-participant).

Both were previously silent no-ops at the `_properties.indexOf` step.

By the same mechanism this should also harden other calendar-js mutations that go through the same identity check on `_properties` — attachment removal, recurrence-rule property mutations, and other attendee setters that route into `deleteProperty` / `indexOf`. The same `markRaw` treatment is applied to all those calendar-js objects at their respective mapping sites.

### Out of scope (separate follow-ups)

After deploying the fix locally, an unrelated UI-side symptom remained — different root cause:

- **Stale editor state after save+reopen** — for up to ~60 s after a successful save, reopening the editor occasionally shows the pre-save state until a background calendar sync settles. Server-side state is correct; this looks like a client-side store-refresh race (`appendOrUpdateCalendarObjectsMutation` in `calendarObjects.js:308` overwrites the in-memory `calendarObject` after a FullCalendar refetch).

This will be filed as a separate issue.

### Tests

- All 392 unit tests pass locally.
- Lint clean on changed files (one pre-existing import-order issue in `recurrenceRule.js` fixed in the same commit).
- Manually tested on a Nextcloud 33.0.3.2 instance with Calendar 6.4.0 (bundle built from this branch's stable6.4 counterpart, deployed to `/var/www/html/apps/calendar/js`).

### Files changed

- `src/models/attendee.js` — `mapAttendeePropertyToAttendeeObject`
- `src/models/event.js` — `mapEventComponentToEventObject` (eventComponent + organizer's attendeeProperty)
- `src/models/alarm.js` — `mapAlarmComponentToAlarmObject` (both return branches)
- `src/models/attachment.js` — `mapAttachmentPropertyToAttchmentObject`
- `src/models/recurrenceRule.js` — `getDefaultRecurrenceRuleObjectForRecurrenceValue`
