### PR TITLE
fix(editor): close attendee action menu after Remove

### DIFF
--- a/src/components/Editor/Invitees/InviteesListItem.vue
+++ b/src/components/Editor/Invitees/InviteesListItem.vue
@@ -88,7 +88,7 @@
 					{{ $t('calendar', 'Non-participant') }}
 				</ActionRadio>
 
-				<ActionButton @click="removeAttendee(attendee)">
+				<ActionButton :closeAfterClick="true" @click="removeAttendee(attendee)">
 					<template #icon>
 						<Delete :size="20" decorative />
 					</template>


### PR DESCRIPTION
### Summary

- Fixes #8371
- Pass `:closeAfterClick` to the remove-attendee `NcActionButton` in `InviteesListItem`, so the action menu closes when an attendee is removed.

### Why

The attendee list renders each row via `v-for` with a stable `:key="invitee.email"`. When the user opens the three-dot menu on a non-last attendee and clicks Remove, the attendee is spliced from the list and the row below shifts up into the same screen slot. Because the `NcActionButton` did not close the menu after click, the menu stayed open and then displayed the role / RSVP / Remove controls of the attendee that shifted up - confusing, with no feedback that the original action succeeded.

Same one-line approach as #7486, which fixed the same behavior for the view-selection menu.

### Tested

- Built against stable6.4 and deployed on Nextcloud 33.0.3.2 / Calendar 6.4.1.
- Before: removing a non-last attendee leaves the menu open showing the next attendee's data.
- After: the menu closes cleanly on Remove. Verified with 3+ attendees.

### Note

Resources (`ResourceListItem`) were considered too, but the remove control there is rendered differently (only the first item gets an `NcActions` menu; the rest have a direct trash button), so the same symptom does not occur. Left untouched on purpose.
