### PR TITLE
fix(alarms): do not add ATTENDEE/SUMMARY to DISPLAY alarms

### DIFF
--- a/src/utils/alarms.js
+++ b/src/utils/alarms.js
@@ -291,9 +291,7 @@ export function getDefaultReminderForEvent({ calendar, isAllDay }) {
 }
 
 /**
- * Propagate data from an event component to all EMAIL alarm components.
- * An alarm component must contain a description, summary and all attendees to be notified.
- * We don't have a separate UI for maintaining attendees of an alarm, so we just copy them from the event.
+ * Propagate data from an event component to its DISPLAY and EMAIL alarm components.
  *
  * https://www.rfc-editor.org/rfc/rfc5545#section-3.6.6
  *
@@ -305,7 +303,19 @@ export function updateAlarms(eventComponent) {
 			continue
 		}
 
+		if (!alarmComponent.hasProperty('DESCRIPTION')) {
+			const defaultDescription = t('calendar', 'This is an event reminder.')
+			alarmComponent.addProperty(new Property('DESCRIPTION', defaultDescription))
+		}
+
+		// Clear properties that are only valid on EMAIL alarms.
 		alarmComponent.deleteAllProperties('SUMMARY')
+		alarmComponent.deleteAllProperties('ATTENDEE')
+
+		if (alarmComponent.action !== 'EMAIL') {
+			continue
+		}
+
 		const summaryProperty = eventComponent.getFirstProperty('SUMMARY')
 		if (summaryProperty) {
 			alarmComponent.addProperty(summaryProperty.clone())
@@ -314,12 +324,6 @@ export function updateAlarms(eventComponent) {
 			alarmComponent.addProperty(new Property('SUMMARY', defaultSummary))
 		}
 
-		if (!alarmComponent.hasProperty('DESCRIPTION')) {
-			const defaultDescription = t('calendar', 'This is an event reminder.')
-			alarmComponent.addProperty(new Property('DESCRIPTION', defaultDescription))
-		}
-
-		alarmComponent.deleteAllProperties('ATTENDEE')
 		for (const attendee of eventComponent.getAttendeeIterator()) {
 			if (['RESOURCE', 'ROOM'].includes(attendee.userType)) {
 				continue

--- a/tests/javascript/unit/utils/alarms.test.js
+++ b/tests/javascript/unit/utils/alarms.test.js
@@ -7,8 +7,48 @@ import {
 	getAmountHoursMinutesAndUnitForAllDayEvents,
 	getAmountAndUnitForTimedEvents,
 	getTotalSecondsFromAmountAndUnitForTimedEvents,
-	getTotalSecondsFromAmountHourMinutesAndUnitForAllDayEvents
+	getTotalSecondsFromAmountHourMinutesAndUnitForAllDayEvents,
+	updateAlarms,
 } from '../../../../src/utils/alarms.js'
+import { getParserManager } from '@nextcloud/calendar-js'
+
+/**
+ * Parse an ICS string and return the first event component.
+ *
+ * @param {string} ics The calendar data
+ * @return {object} The first event component
+ */
+function firstEventFromICS(ics) {
+	const parser = getParserManager().getParserForFileType('text/calendar')
+	parser.parse(ics)
+	const calendarComponent = parser.getAllItems()[0]
+	return calendarComponent.getVObjectIterator().next().value
+}
+
+/**
+ * Build a single-event ICS with the given alarm and attendee blocks.
+ *
+ * @param {string} alarms VALARM blocks
+ * @param {string} attendees ATTENDEE lines
+ * @return {string} The calendar data
+ */
+function eventICS(alarms, attendees = '') {
+	return [
+		'BEGIN:VCALENDAR',
+		'PRODID:-//test//test//EN',
+		'VERSION:2.0',
+		'BEGIN:VEVENT',
+		'UID:alarm-attendee-test',
+		'DTSTAMP:20260101T000000Z',
+		'DTSTART:20260101T100000Z',
+		'DTEND:20260101T110000Z',
+		'SUMMARY:My event',
+		attendees,
+		alarms,
+		'END:VEVENT',
+		'END:VCALENDAR',
+	].filter(Boolean).join('\r\n')
+}
 
 describe('utils/alarms test suite', () => {
 
@@ -155,6 +195,76 @@ describe('utils/alarms test suite', () => {
 		expect(getTotalSecondsFromAmountHourMinutesAndUnitForAllDayEvents(10, 9, 0, 'days')).toEqual(-231 * 60 * 60)
 
 		expect(getTotalSecondsFromAmountHourMinutesAndUnitForAllDayEvents(1, 8, 30, 'weeks')).toEqual(-159 * 60 * 60 - 30 * 60)
+	})
+
+	describe('updateAlarms', () => {
+		it('keeps DISPLAY alarms RFC-conformant: a DESCRIPTION but no SUMMARY/ATTENDEE', () => {
+			const event = firstEventFromICS(eventICS(
+				['BEGIN:VALARM', 'ACTION:DISPLAY', 'TRIGGER:-PT15M', 'END:VALARM'].join('\r\n'),
+				['ATTENDEE:mailto:a@example.com', 'ATTENDEE:mailto:b@example.com'].join('\r\n'),
+			))
+
+			updateAlarms(event)
+
+			const alarm = event.getAlarmIterator().next().value
+			expect(alarm.action).toEqual('DISPLAY')
+			expect(alarm.hasProperty('DESCRIPTION')).toBe(true)
+			expect(alarm.hasProperty('SUMMARY')).toBe(false)
+			expect(alarm.hasProperty('ATTENDEE')).toBe(false)
+		})
+
+		it('populates EMAIL alarms with SUMMARY, DESCRIPTION and one ATTENDEE per event attendee', () => {
+			const event = firstEventFromICS(eventICS(
+				['BEGIN:VALARM', 'ACTION:EMAIL', 'TRIGGER:-PT30M', 'END:VALARM'].join('\r\n'),
+				['ATTENDEE:mailto:a@example.com', 'ATTENDEE:mailto:b@example.com'].join('\r\n'),
+			))
+
+			updateAlarms(event)
+
+			const alarm = event.getAlarmIterator().next().value
+			expect(alarm.action).toEqual('EMAIL')
+			expect(alarm.hasProperty('DESCRIPTION')).toBe(true)
+			expect(alarm.hasProperty('SUMMARY')).toBe(true)
+			expect([...alarm.getPropertyIterator('ATTENDEE')]).toHaveLength(2)
+		})
+
+		it('strips a stale SUMMARY/ATTENDEE that a DISPLAY alarm received previously', () => {
+			const event = firstEventFromICS(eventICS(
+				[
+					'BEGIN:VALARM',
+					'ACTION:DISPLAY',
+					'TRIGGER:-PT15M',
+					'DESCRIPTION:This is an event reminder.',
+					'SUMMARY:My event',
+					'ATTENDEE:mailto:a@example.com',
+					'END:VALARM',
+				].join('\r\n'),
+				'ATTENDEE:mailto:a@example.com',
+			))
+
+			updateAlarms(event)
+
+			const alarm = event.getAlarmIterator().next().value
+			expect(alarm.hasProperty('SUMMARY')).toBe(false)
+			expect(alarm.hasProperty('ATTENDEE')).toBe(false)
+			expect(alarm.hasProperty('DESCRIPTION')).toBe(true)
+		})
+
+		it('does not copy ROOM or RESOURCE attendees into EMAIL alarms', () => {
+			const event = firstEventFromICS(eventICS(
+				['BEGIN:VALARM', 'ACTION:EMAIL', 'TRIGGER:-PT30M', 'END:VALARM'].join('\r\n'),
+				[
+					'ATTENDEE:mailto:a@example.com',
+					'ATTENDEE;CUTYPE=ROOM:mailto:room@example.com',
+					'ATTENDEE;CUTYPE=RESOURCE:mailto:beamer@example.com',
+				].join('\r\n'),
+			))
+
+			updateAlarms(event)
+
+			const alarm = event.getAlarmIterator().next().value
+			expect([...alarm.getPropertyIterator('ATTENDEE')]).toHaveLength(1)
+		})
 	})
 })
 


### PR DESCRIPTION
### Summary

- Fixes #8372
- `updateAlarms()` no longer adds `SUMMARY` and `ATTENDEE` to `DISPLAY` alarms. Those properties are only valid on `EMAIL` alarms (RFC 5545 §3.6.6); on `DISPLAY` alarms they make the component invalid and strict CalDAV clients (e.g. Thunderbird) discard the whole alarm, silently dropping the reminder.

### Why

`updateAlarms()` iterates `DISPLAY` and `EMAIL` alarms and copies the event's attendees (plus a `SUMMARY`) into each one. That is required for `EMAIL` alarms but not allowed for `DISPLAY` alarms:

- `dispprop` (RFC 5545 §3.6.6) only allows `action / description / trigger / duration / repeat / x-prop / iana-prop`.
- `emailprop` requires `action / description / trigger / summary` and one or more `attendee`.

So as soon as an event has an attendee, every `DISPLAY` reminder gets an `ATTENDEE` line and becomes non-conformant. Thunderbird drops it (no reminder), while the lenient web editor still shows it - which is why the regression is easy to miss. The bug dates back to `150cc297` ("feat(alarms): improve email alarm RFC compliance", v4.2.0).

The fix keeps `DESCRIPTION` for both alarm types (required for `DISPLAY` and `EMAIL`), and clears/re-adds `SUMMARY` and `ATTENDEE` only for `EMAIL` alarms. Clearing them unconditionally also repairs events that already received the invalid properties: re-saving such an event strips them.

This does not affect Nextcloud's server-side reminder emails: `OCA\DAV\CalDAV\Reminder\NotificationProvider\EmailProvider` derives recipients from `VEVENT.ATTENDEE`, not from the alarm's `ATTENDEE`.

### Tested

Manual, on Nextcloud 33.0.3.2 / Calendar 6.4.1 with Thunderbird (CalDAV) against the organizer's own `personal` calendar:
- Before the fix: create an event with reminders -> the reminder shows in Thunderbird; add an attendee -> it disappears after sync; remove the attendee -> it comes back.
- After the fix: adding/removing attendees no longer affects the `DISPLAY` reminders; they keep showing. Re-saving an affected event also confirmed server-side (CalDAV REPORT) that its `DISPLAY` VALARM no longer carries `ATTENDEE` or `SUMMARY`.
- Switching a reminder to the email type on an event with an attendee: the reminder fired and emails were delivered to both the organizer and the attendee, so `EMAIL` alarms keep working. Server-side the event then carries both a clean `DISPLAY` alarm and the `EMAIL` alarm(s).

Unit tests (added in this PR, `npm run test:unit`):
- `DISPLAY` alarm keeps `DESCRIPTION` but has no `SUMMARY`/`ATTENDEE`.
- `EMAIL` alarm receives `SUMMARY`, `DESCRIPTION` and one `ATTENDEE` per event attendee.
- A `DISPLAY` alarm that previously received `SUMMARY`/`ATTENDEE` is cleaned up on the next update.
- `ROOM`/`RESOURCE` attendees are not copied into `EMAIL` alarms.
- Confirmed the new tests fail against the unfixed code.
