### PR TITLE
fix: default null alarm

### DIFF
--- a/src/utils/alarms.js
+++ b/src/utils/alarms.js
@@ -226,7 +226,7 @@ export function updateDefaultAlarm(calendarId, calendarObjectInstance) {
 		isAllDay: calendarObjectInstance.isAllDay,
 	})
 
-	if (isNaN(defaultReminder)) {
+	if (defaultReminder === null || isNaN(defaultReminder)) {
 		return
 	}
 


### PR DESCRIPTION
### Summary
- Resolves https://github.com/nextcloud/calendar/issues/8368
- Fixed empty alarm check "isNaN(null);      // false (null converts to 0)"