### PR TITLE
fix(editor): store categories again by disabling deselectFromDropdown

### DIFF
--- a/src/components/Editor/Properties/PropertySelectMultiple.vue
+++ b/src/components/Editor/Properties/PropertySelectMultiple.vue
@@ -27,7 +27,7 @@
 				:multiple="true"
 				:taggable="true"
 				:noWrap="false"
-				:deselectFromDropdown="true"
+				:deselectFromDropdown="false"
 				:createOption="(label) => ({ value: label, label })"
 				inputId="label"
 				label="label"


### PR DESCRIPTION
### Summary

- Fixes #8337
- Disable `deselectFromDropdown` on the categories `NcSelect` in `PropertySelectMultiple`, so selecting a category is no longer instantly undone. The point is that categories can be added and stored again at all - which is currently impossible.

### Why

With the current vue-select, `deselectFromDropdown` fires an `option:deselected` immediately after `option:selecting` for a freshly selected value in a multi-select (the condition is `deselectFromDropdown && (clearable || multiple && selectedValue.length > 1)`). `PropertySelectMultiple` adds the category on `option:selecting` and then removes it again on the spurious `option:deselected`, so categories cannot be added or stored.

Removing an existing category via the chip's close button uses a separate path and is unaffected. Disabling `deselectFromDropdown` removes the spurious deselect; categories are still removed via the chip.

Trade-off: with `deselectFromDropdown` off, you can no longer deselect an entry by clicking it again in the dropdown - but removal via the chip's close button still works, and in return categories can be added and stored at all again.

For context: `deselectFromDropdown="true"` was added in #5648 ("migrate to nextcloud/vue 8"), in the same commit that added the `// budget deselectFromDropdown since the vue-select implementation doesn't work` workaround in `tag()` - so that behavior was already known to be broken back then. This change just disables it; happy to keep an in-dropdown deselect instead if you prefer (see Follow-up).

### Tested

Manually, on NC 33.0.3 and Calendar 6.4.1:
- Before: selecting a category leaves the field empty and nothing is stored. (Instrumenting the component showed `option:selecting` immediately followed by `option:deselected` for the same value.)
- After: selecting a category keeps it and stores it on save; adding several works; removing a single category via its chip removes only that one.

No unit test is added: the bug is an interaction with the third-party vue-select component (a prop-value behavior), not in our own handler logic, so there is no meaningful behavioral unit test for it. Verified manually.

### Follow-up

With `deselectFromDropdown` off, an already-selected entry can no longer be deselected by clicking it again in the dropdown (removal is via the chip). The cleaner long-term UX is to hide already-selected entries from the dropdown entirely (standard multi-select behavior), which removes the need for `deselectFromDropdown` altogether; a toggle with a selected-state affordance would be the alternative. I left this out of the bug fix on purpose, but can follow up with it - just let me know which direction you prefer.