### PR TITLE
fix(appointment): capture Attendee browser language and save it

### DIFF
--- a/lib/Service/Appointments/BookingCalendarWriter.php
+++ b/lib/Service/Appointments/BookingCalendarWriter.php
@@ -175,7 +175,9 @@ class BookingCalendarWriter {
 				'CUTYPE' => 'INDIVIDUAL',
 				'RSVP' => 'TRUE',
 				'ROLE' => 'REQ-PARTICIPANT',
-				'PARTSTAT' => 'ACCEPTED'
+				'PARTSTAT' => 'ACCEPTED',
+				// Read by IMipService::setL10nFromAttendee for iTip update/cancel emails.
+				'LANGUAGE' => $this->l10nFactory->findLanguage(),
 			]
 		);
 


### PR DESCRIPTION
Language parameter is checked here https://github.com/nextcloud/server/blob/master/apps/dav/lib/CalDAV/Schedule/IMipService.php#L928 but never set 

This is for non authenticated attendees who have their browser language set to something different than server default