### PR TITLE
feat: add client-side event filter in app navigation

### DIFF
--- a/src/components/AppNavigation/AppNavigationHeader.vue
+++ b/src/components/AppNavigation/AppNavigationHeader.vue
@@ -5,6 +5,10 @@
 
 <template>
 	<header class="app-navigation-header">
+		<NcAppNavigationSearch
+			v-model="searchQuery"
+			:label="t('calendar', 'Filter events …')"
+			class="app-navigation-header__filter" />
 		<AppNavigationHeaderDatePicker />
 		<div class="new-event-today-view-section">
 			<AppNavigationHeaderNewEvent v-if="!isPublic" />
@@ -15,10 +19,14 @@
 </template>
 
 <script>
+import { translate as t } from '@nextcloud/l10n'
+import { mapStores } from 'pinia'
+import NcAppNavigationSearch from '@nextcloud/vue/components/NcAppNavigationSearch'
 import AppNavigationHeaderDatePicker from './AppNavigationHeader/AppNavigationHeaderDatePicker.vue'
 import AppNavigationHeaderNewEvent from './AppNavigationHeader/AppNavigationHeaderNewEvent.vue'
 import AppNavigationHeaderTodayButton from './AppNavigationHeader/AppNavigationHeaderTodayButton.vue'
 import AppNavigationHeaderViewMenu from './AppNavigationHeader/AppNavigationHeaderViewMenu.vue'
+import useSettingsStore from '../../store/settings.js'
 
 export default {
 	name: 'AppNavigationHeader',
@@ -27,6 +35,7 @@ export default {
 		AppNavigationHeaderTodayButton,
 		AppNavigationHeaderNewEvent,
 		AppNavigationHeaderViewMenu,
+		NcAppNavigationSearch,
 	},
 
 	props: {
@@ -35,5 +44,25 @@ export default {
 			required: true,
 		},
 	},
+
+	computed: {
+		...mapStores(useSettingsStore),
+
+		searchQuery: {
+			get() { return this.settingsStore.searchQuery },
+			set(val) { this.settingsStore.setSearchQuery(val) },
+		},
+	},
+
+	methods: {
+		t,
+	},
 }
 </script>
+
+<style lang="scss" scoped>
+.app-navigation-header__filter {
+	padding: 0;
+	margin-bottom: var(--default-grid-baseline);
+}
+</style>

--- a/src/components/CalendarGrid.vue
+++ b/src/components/CalendarGrid.vue
@@ -108,6 +108,7 @@ export default {
 			'showWeekends',
 			'showWeekNumbers',
 			'slotDuration',
+			'searchQuery',
 		]),
 
 		...mapState(useCalendarObjectsStore, ['modificationCount']),
@@ -225,6 +226,11 @@ export default {
 			const calendarApi = this.$refs.fullCalendar.getApi()
 			calendarApi.refetchEvents()
 		}, 50),
+
+		searchQuery: debounce(function() {
+			const calendarApi = this.$refs.fullCalendar.getApi()
+			calendarApi.refetchEvents()
+		}, 300),
 	},
 
 	/**

--- a/src/fullcalendar/eventSources/eventSourceFunction.js
+++ b/src/fullcalendar/eventSources/eventSourceFunction.js
@@ -4,6 +4,7 @@
  */
 import { translate as t } from '@nextcloud/l10n'
 import usePrincipalsStore from '../../store/principals.js'
+import useSettingsStore from '../../store/settings.js'
 import useTasksStore from '../../store/unscheduledTasks.js'
 import { getAllObjectsInTimeRange } from '../../utils/calendarObject.js'
 import {
@@ -25,7 +26,10 @@ import logger from '../../utils/logger.js'
 export function eventSourceFunction(calendarObjects, calendar, start, end, timezone) {
 	const principalsStore = usePrincipalsStore()
 	const tasksStore = useTasksStore()
+	const settingsStore = useSettingsStore()
 	tasksStore.emptyCalendar(calendar.id)
+
+	const searchTerms = settingsStore.searchQuery.trim().toLowerCase().split(/\s+/).filter(Boolean)
 
 	const fcEvents = []
 	for (const calendarObject of calendarObjects) {
@@ -183,6 +187,21 @@ export function eventSourceFunction(calendarObjects, calendar, start, end, timez
 					fcEvent.borderColor = customColor
 				}
 			}
+			if (searchTerms.length > 0) {
+				const organizerProperty = object.getFirstProperty('ORGANIZER')
+				const organizerText = organizerProperty
+					? [organizerProperty.commonName, organizerProperty.email?.replace('mailto:', '')].filter(Boolean).join(' ')
+					: ''
+				const attendeeText = [...object.getPropertyIterator('ATTENDEE')]
+					.map((a) => [a.commonName, a.email?.replace('mailto:', '')].filter(Boolean).join(' '))
+					.join(' ')
+				const haystack = [title, object.location, object.description, organizerText, attendeeText]
+					.filter(Boolean).join(' ').toLowerCase()
+				if (!searchTerms.some((term) => haystack.includes(term))) {
+					continue
+				}
+			}
+
 			if (object.name === 'VTODO' && object.endDate === null && object.percent !== 100 && object.status !== 'COMPLETED') {
 				fcEvent.create = true
 				tasksStore.appendTask(calendar.id, fcEvent)

--- a/src/store/settings.js
+++ b/src/store/settings.js
@@ -47,6 +47,7 @@ export default defineStore('settings', {
 			momentLocale: 'en',
 			attachmentsFolder: '/Calendar',
 			attachmentsFolderCreated: false,
+			searchQuery: '',
 		}
 	},
 	getters: {
@@ -408,6 +409,10 @@ Initial settings:
 			logInfo(`Updated moment locale: ${locale}`)
 
 			this.momentLocale = locale
+		},
+
+		setSearchQuery(query) {
+			this.searchQuery = query
 		},
 	},
 

--- a/tests/javascript/unit/fullcalendar/eventSources/freeBusyResourceEventSourceFunction.test.js
+++ b/tests/javascript/unit/fullcalendar/eventSources/freeBusyResourceEventSourceFunction.test.js
@@ -12,6 +12,7 @@ import {
 import { translate } from '@nextcloud/l10n'
 import {getAllObjectsInTimeRange} from "../../../../../src/utils/calendarObject.js";
 import { createPinia, setActivePinia } from 'pinia'
+import useSettingsStore from '../../../../../src/store/settings.js'
 vi.mock('@nextcloud/l10n')
 vi.mock('../../../../../src/utils/color.js')
 vi.mock("../../../../../src/utils/calendarObject.js")
@@ -756,6 +757,125 @@ describe('fullcalendar/freeBusyResourceEventSourceFunction test suite', () => {
 
 		expect(getHexForColorName).toHaveBeenCalledTimes(0)
 		expect(generateTextColorForHex).toHaveBeenCalledTimes(0)
+	})
+
+	it('should filter events by search query matching title, location, description, attendee, and organizer', () => {
+		translate.mockImplementation((app, str) => str)
+		isLight.mockImplementation(() => false)
+
+		const start = new Date(Date.UTC(2019, 0, 1, 0, 0, 0, 0))
+		const end = new Date(Date.UTC(2020, 0, 31, 59, 59, 59, 999))
+		const timezone = { calendarJsTimezone: true, tzid: 'UTC' }
+
+		const makeEvent = (id, overrides) => ({
+			name: 'VEVENT',
+			id,
+			isAllDay: vi.fn().mockReturnValue(false),
+			getReferenceRecurrenceId: vi.fn().mockReturnValue({ unixTime: 1 }),
+			canModifyAllDay: vi.fn().mockReturnValue(false),
+			startDate: { getInTimezone: vi.fn().mockReturnValue({ jsDate: new Date(2020, 1, 1, 10, 0, 0) }) },
+			endDate: { getInTimezone: vi.fn().mockReturnValue({ jsDate: new Date(2020, 1, 1, 11, 0, 0) }) },
+			hasComponent: vi.fn().mockReturnValue(false),
+			getFirstPropertyFirstValue: vi.fn().mockReturnValue(null),
+			getFirstProperty: vi.fn().mockReturnValue(null),
+			getPropertyIterator: vi.fn().mockReturnValue([]),
+			...overrides,
+		})
+
+		const eventMatchTitle = makeEvent('title', { title: 'Team meeting' })
+		const eventMatchLocation = makeEvent('location', { title: 'Other', location: 'Main office' })
+		const eventMatchDescription = makeEvent('description', { title: 'Other', description: 'project review' })
+		const eventMatchAttendee = makeEvent('attendee', {
+			title: 'Other',
+			getPropertyIterator: vi.fn().mockReturnValue([
+				{ commonName: 'John Doe', email: 'mailto:john@example.com' },
+			]),
+		})
+		const eventMatchOrganizer = makeEvent('organizer', {
+			title: 'Other',
+			getFirstProperty: vi.fn().mockReturnValue({ commonName: 'Jane Smith', email: 'mailto:jane@example.com' }),
+		})
+		const eventNoMatch = makeEvent('nomatch', { title: 'Lunch break', location: 'Canteen' })
+
+		const calendarObjects = [{ id: 'cal1', dav: { url: 'url1' } }]
+		const calendar = { order: 1, displayName: 'Test', id: 'cal1', color: '#ff0000' }
+
+		const settingsStore = useSettingsStore()
+		settingsStore.searchQuery = 'meeting'
+		getAllObjectsInTimeRange.mockReturnValueOnce([eventMatchTitle, eventNoMatch])
+		let result = eventSourceFunction(calendarObjects, calendar, start, end, timezone)
+		expect(result).toHaveLength(1)
+		expect(result[0].id).toEqual('cal1###title')
+
+		settingsStore.searchQuery = 'office'
+		getAllObjectsInTimeRange.mockReturnValueOnce([eventMatchLocation, eventNoMatch])
+		result = eventSourceFunction(calendarObjects, calendar, start, end, timezone)
+		expect(result).toHaveLength(1)
+		expect(result[0].id).toEqual('cal1###location')
+
+		settingsStore.searchQuery = 'project'
+		getAllObjectsInTimeRange.mockReturnValueOnce([eventMatchDescription, eventNoMatch])
+		result = eventSourceFunction(calendarObjects, calendar, start, end, timezone)
+		expect(result).toHaveLength(1)
+		expect(result[0].id).toEqual('cal1###description')
+
+		settingsStore.searchQuery = 'john'
+		getAllObjectsInTimeRange.mockReturnValueOnce([eventMatchAttendee, eventNoMatch])
+		result = eventSourceFunction(calendarObjects, calendar, start, end, timezone)
+		expect(result).toHaveLength(1)
+		expect(result[0].id).toEqual('cal1###attendee')
+
+		settingsStore.searchQuery = 'jane'
+		getAllObjectsInTimeRange.mockReturnValueOnce([eventMatchOrganizer, eventNoMatch])
+		result = eventSourceFunction(calendarObjects, calendar, start, end, timezone)
+		expect(result).toHaveLength(1)
+		expect(result[0].id).toEqual('cal1###organizer')
+	})
+
+	it('should treat multiple search words as OR and return all events when query is empty', () => {
+		translate.mockImplementation((app, str) => str)
+		isLight.mockImplementation(() => false)
+
+		const start = new Date(Date.UTC(2019, 0, 1, 0, 0, 0, 0))
+		const end = new Date(Date.UTC(2020, 0, 31, 59, 59, 59, 999))
+		const timezone = { calendarJsTimezone: true, tzid: 'UTC' }
+
+		const makeEvent = (id, title) => ({
+			name: 'VEVENT',
+			id,
+			title,
+			isAllDay: vi.fn().mockReturnValue(false),
+			getReferenceRecurrenceId: vi.fn().mockReturnValue({ unixTime: 1 }),
+			canModifyAllDay: vi.fn().mockReturnValue(false),
+			startDate: { getInTimezone: vi.fn().mockReturnValue({ jsDate: new Date(2020, 1, 1, 10, 0, 0) }) },
+			endDate: { getInTimezone: vi.fn().mockReturnValue({ jsDate: new Date(2020, 1, 1, 11, 0, 0) }) },
+			hasComponent: vi.fn().mockReturnValue(false),
+			getFirstPropertyFirstValue: vi.fn().mockReturnValue(null),
+			getFirstProperty: vi.fn().mockReturnValue(null),
+			getPropertyIterator: vi.fn().mockReturnValue([]),
+		})
+
+		const eventA = makeEvent('a', 'Team meeting')
+		const eventB = makeEvent('b', 'Lunch break')
+		const eventC = makeEvent('c', 'Doctor appointment')
+
+		const calendarObjects = [{ id: 'cal1', dav: { url: 'url1' } }]
+		const calendar = { order: 1, displayName: 'Test', id: 'cal1', color: '#ff0000' }
+
+		const settingsStore = useSettingsStore()
+
+		// Multiple words: OR logic — 'meeting' matches A, 'lunch' matches B, C excluded
+		settingsStore.searchQuery = 'meeting lunch'
+		getAllObjectsInTimeRange.mockReturnValueOnce([eventA, eventB, eventC])
+		let result = eventSourceFunction(calendarObjects, calendar, start, end, timezone)
+		expect(result).toHaveLength(2)
+		expect(result.map((e) => e.id)).toEqual(['cal1###a', 'cal1###b'])
+
+		// Empty query: all events returned
+		settingsStore.searchQuery = ''
+		getAllObjectsInTimeRange.mockReturnValueOnce([eventA, eventB, eventC])
+		result = eventSourceFunction(calendarObjects, calendar, start, end, timezone)
+		expect(result).toHaveLength(3)
 	})
 
 })

--- a/tests/javascript/unit/store/settings.test.js
+++ b/tests/javascript/unit/store/settings.test.js
@@ -61,6 +61,7 @@ describe('store/settings test suite', () => {
 			attachmentsFolderCreated: false,
 			showResources: true,
 			publicCalendars: null,
+			searchQuery: '',
 		})
 	})
 
@@ -176,6 +177,7 @@ Initial settings:
 			attachmentsFolderCreated: false,
 			showResources: true,
 			publicCalendars: null,
+			searchQuery: '',
 		})
 	})
 
@@ -606,6 +608,16 @@ Initial settings:
 		expect(setConfig).toHaveBeenNthCalledWith(1, 'timezone', 'Europe/Berlin')
 
 		expect(settingsStore.timezone).toEqual('Europe/Berlin')
+	})
+
+	it('should provide an action to set the search query', () => {
+		const settingsStore = useSettingsStore()
+
+		settingsStore.setSearchQuery('meeting')
+		expect(settingsStore.searchQuery).toEqual('meeting')
+
+		settingsStore.setSearchQuery('')
+		expect(settingsStore.searchQuery).toEqual('')
 	})
 
 	it('should provide an action to initialize the calendar-js config', () => {


### PR DESCRIPTION
[Screencast From 2026-05-28 18-41-32.webm](https://github.com/user-attachments/assets/2decd3e6-fbc9-41c7-8d8c-76182dfc2375)



## Summary

Adds a client-side filter input to the top of the app navigation sidebar, resolving #2474.

- Uses `NcAppNavigationSearch` (standard Nextcloud placement, includes clear button)
- Filters events in the currently active FullCalendar view in real time across title, location, description, organizer, and attendee names/emails
- Multiple words are treated as OR (as specified in the issue)
- Filter persists when changing views or navigating between time periods
- Purely client-side – uses already-cached event data, no extra network requests

## Implementation

- `src/store/settings.js` – adds `searchQuery` state and `setSearchQuery` action
- `src/components/AppNavigation/AppNavigationHeader.vue` – adds `NcAppNavigationSearch` as the first item in the navigation header
- `src/fullcalendar/eventSources/eventSourceFunction.js` – filters events against the search query before returning them to FullCalendar
- `src/components/CalendarGrid.vue` – watches `searchQuery` (debounced 300 ms) and calls `calendarApi.refetchEvents()` to re-run the filter against cached data

## Test plan

- [x] Type a word in the filter box – only matching events remain visible
- [x] Filter works across title, location, description, organizer, and attendee names/emails
- [x] Multiple words (OR): typing "meeting John" shows events containing either word
- [x] Clear button (×) removes the filter and restores all events
- [x] Filter persists when switching views (day/week/month) or navigating to next/previous period

Closes #2474

🤖 Generated with [Claude Code](https://claude.com/claude-code)

> **Initial prompt**
> Please implement a super simple client-side filtering for the Calendar app. There should be a NcAppNavigationSearch on the top of the NcAppNavigation with placeholder "Filter …" which when used filters the events in the currently active view.
> Filter should work across basically all properties of the event which are possible while keeping performance quick, like of course title, attendees, description, and location.
> The filter should stay active when changing view or switching to the next/previous day/week/month etc.
> You can roughly check the requirements and how to do it with the Fullcalendar API in issue https://github.com/nextcloud/calendar/issues/2474