### PR TITLE
Proposal move the respond button below the description 

### DIFF
--- a/lib/Service/Proposal/ProposalService.php
+++ b/lib/Service/Proposal/ProposalService.php
@@ -509,6 +509,11 @@ class ProposalService {
 				$this->l10n->t('Dear %s, a proposed meeting has been cancelled', [$recipientName])
 			)
 		};
+		// buttons
+		$template->addBodyButton(
+			$this->l10n->t('Respond'),
+			$this->urlGenerator->linkToRouteAbsolute('Calendar.ProposalPublic.index', ['token' => $recipientToken])
+		);
 		// description
 		if (!empty($proposal->getDescription())) {
 			$template->addBodyListItem($proposal->getDescription(), $this->l10n->t('Description:'));
@@ -541,11 +546,6 @@ class ProposalService {
 
 		$temporaryText .= '(' . $userTimezone->getName() . ')';
 		$template->addBodyListItem($temporaryText, $this->l10n->t('Dates:'));
-		// buttons
-		$template->addBodyButton(
-			$this->l10n->t('Respond'),
-			$this->urlGenerator->linkToRouteAbsolute('Calendar.ProposalPublic.index', ['token' => $recipientToken])
-		);
 
 		$template->addFooter();
 


### PR DESCRIPTION
in order to respond to #8408 
move the respond button and place it below the description
<img width="493" height="440" alt="image" src="https://github.com/user-attachments/assets/47e357ae-bce5-426d-8c18-3d11296c0e50" />
