### PR TITLE
chore: fix php tests

### DIFF
--- a/.github/workflows/php-test.yml
+++ b/.github/workflows/php-test.yml
@@ -48,7 +48,7 @@ jobs:
       uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
-        file: nextcloud/apps/calendar/clover.unit.xml
+        files: nextcloud/apps/calendar/clover.unit.xml
         flags: php
         fail_ci_if_error: ${{ !github.event.pull_request.head.repo.fork }}
         verbose: true


### PR DESCRIPTION
### Summary
- Modified work flow to use "files" instead of "file". codecov/codecov-action v6 no longer supports the "file" parameter