### PR TITLE
feat(chore): allow duplication of read-only events

### DIFF
--- a/src/mixins/EditorMixin.js
+++ b/src/mixins/EditorMixin.js
@@ -425,6 +425,14 @@ export default {
 		isCreateTalkRoomButtonVisible() {
 			return this.talkEnabled && this.isViewedByOrganizer !== false && this.isReadOnly !== true
 		},
+		/**
+		 * Returns true if at least one writable calendar exists
+		 *
+		 * @return {boolean}
+		 */
+		hasWritableCalendars() {
+			return this.calendarsStore.sortedCalendarsAllowingCreate.length > 0
+		},
 	},
 
 	async created() {
@@ -666,6 +674,8 @@ export default {
 		 */
 		async duplicateEvent() {
 			await this.calendarObjectInstanceStore.duplicateCalendarObjectInstance()
+			// Update the local calendarId to match the new calendar object
+			this.calendarId = this.calendarObject.calendarId
 		},
 
 		/**

--- a/src/store/calendarObjectInstance.js
+++ b/src/store/calendarObjectInstance.js
@@ -1546,17 +1546,31 @@ export default defineStore('calendarObjectInstance', {
 		 */
 		async duplicateCalendarObjectInstance() {
 			const calendarObjectsStore = useCalendarObjectsStore()
+			const calendarsStore = useCalendarsStore()
 
 			const oldCalendarObjectInstance = this.calendarObjectInstance
 			const oldEventComponent = oldCalendarObjectInstance.eventComponent
 			const startDate = oldEventComponent.startDate.getInUTC()
 			const endDate = oldEventComponent.endDate.getInUTC()
+
+			// Determine the target calendar ID
+			let targetCalendarId = this.calendarObject?.calendarId ?? null
+			const currentCalendar = targetCalendarId ? calendarsStore.getCalendarById(targetCalendarId) : null
+
+			// If the source calendar is read-only, use the first writable calendar
+			if (currentCalendar?.readOnly) {
+				const writableCalendars = calendarsStore.sortedCalendarsAllowingCreate
+				if (writableCalendars.length > 0) {
+					targetCalendarId = writableCalendars[0].id
+				}
+			}
+
 			const calendarObject = await calendarObjectsStore.createNewEvent({
 				start: startDate.unixTime,
 				end: endDate.unixTime,
 				timezoneId: oldEventComponent.startDate.timezoneId,
 				isAllDay: oldEventComponent.isAllDay(),
-				calendarId: this.calendarObject?.calendarId ?? null,
+				calendarId: targetCalendarId,
 			})
 			const eventComponent = getObjectAtRecurrenceId(calendarObject, startDate.jsDate)
 			copyCalendarObjectInstanceIntoEventComponent(oldCalendarObjectInstance, eventComponent, true)

--- a/src/store/calendars.js
+++ b/src/store/calendars.js
@@ -79,6 +79,20 @@ export default defineStore('calendars', {
 		},
 
 		/**
+		 * List of sorted calendars that allow creating objects
+		 *
+		 * @param {object} state the store data
+		 * @return {Array}
+		 */
+		sortedCalendarsAllowingCreate(state) {
+			return state.calendars
+				.filter((calendar) => calendar.supportsEvents)
+				.filter((calendar) => calendar.canCreateObject)
+				.filter((calendar) => !calendar.readOnly)
+				.sort((a, b) => a.order - b.order)
+		},
+
+		/**
 		 * List of sorted all calendars
 		 *
 		 * @param {object} state the store data

--- a/src/views/EditFull.vue
+++ b/src/views/EditFull.vue
@@ -70,7 +70,7 @@
 									</template>
 									{{ $t('calendar', 'Export') }}
 								</NcActionLink>
-								<NcActionButton v-if="!canCreateRecurrenceException && !isReadOnly && !isNew" @click="duplicateEvent()">
+								<NcActionButton v-if="!canCreateRecurrenceException && hasWritableCalendars && !isNew" @click="duplicateEvent()">
 									<template #icon>
 										<ContentDuplicate :size="20" decorative />
 									</template>

--- a/src/views/EditSimple.vue
+++ b/src/views/EditSimple.vue
@@ -84,7 +84,7 @@
 								</template>
 								{{ $t('calendar', 'Export') }}
 							</ActionLink>
-							<ActionButton v-if="!canCreateRecurrenceException && !isReadOnly" @click="duplicateEvent()">
+							<ActionButton v-if="!canCreateRecurrenceException && hasWritableCalendars" @click="duplicateEvent()">
 								<template #icon>
 									<ContentDuplicate :size="20" decorative />
 								</template>


### PR DESCRIPTION
Fixes #8361
This allows to duplicate read-only events into a writable calendar.