### PR TITLE
chore: bump cdav library to 2.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "@nextcloud/axios": "^2.6.0",
         "@nextcloud/calendar-availability-vue": "^3.0.0",
         "@nextcloud/calendar-js": "^8.1.6",
-        "@nextcloud/cdav-library": "^2.5.0",
+        "@nextcloud/cdav-library": "^2.6.0",
         "@nextcloud/dialogs": "^7.3.0",
         "@nextcloud/event-bus": "^3.3.3",
         "@nextcloud/initial-state": "^3.0.0",
@@ -1293,9 +1293,9 @@
       }
     },
     "node_modules/@nextcloud/cdav-library": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@nextcloud/cdav-library/-/cdav-library-2.5.1.tgz",
-      "integrity": "sha512-ZFf1YDQMTZgn/cxayNmy+awaDN34EqtPYLzxzq5lBgbk4BsK1aCidwLdXAb4SFZV5/Xn3TxgWZD19bm30QM/fQ==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@nextcloud/cdav-library/-/cdav-library-2.6.0.tgz",
+      "integrity": "sha512-7VpPk95W070mWsbqqcmyRxmF3FV0PvfoSQV+C85ltbiROr1wKeoIGh7ZjNETlpcS2FgdgbLQZeD7L+9zS9c+hw==",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@nextcloud/axios": "^2.6.0"

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "@nextcloud/axios": "^2.6.0",
     "@nextcloud/calendar-availability-vue": "^3.0.0",
     "@nextcloud/calendar-js": "^8.1.6",
-    "@nextcloud/cdav-library": "^2.5.0",
+    "@nextcloud/cdav-library": "^2.6.0",
     "@nextcloud/dialogs": "^7.3.0",
     "@nextcloud/event-bus": "^3.3.3",
     "@nextcloud/initial-state": "^3.0.0",


### PR DESCRIPTION
### Summary
- Manually bumped cdav library to 2.6, required for new features