### PR TITLE
chore: Force node version 24.15.0

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -48,10 +48,10 @@ jobs:
           fallbackNode: '^24'
           fallbackNpm: '^11'
           path: nextcloud/apps/calendar
-      - name: Set up node ${{ steps.package-engines-versions.outputs.nodeVersion }}
+      - name: Set up node 24.15.0
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
-          node-version: ${{ steps.package-engines-versions.outputs.nodeVersion }}
+          node-version: 24.15.0
       - name: Set up npm ${{ steps.package-engines-versions.outputs.npmVersion }}
         run: npm i -g 'npm@${{ steps.package-engines-versions.outputs.npmVersion }}'
       - name: Install php dependencies


### PR DESCRIPTION
### Summary
- Force node version 24.15.0 due to regression in node 24.16.0
- https://github.com/nodejs/node/issues/63487

### Issue
- workflow hangs when installing chromium with all dependencies. 