### PR TITLE
fix: new event transparancy

### DIFF
--- a/src/store/calendarObjectInstance.js
+++ b/src/store/calendarObjectInstance.js
@@ -1423,10 +1423,11 @@ export default defineStore('calendarObjectInstance', {
 			const calendarsStore = useCalendarsStore()
 			const calendar = calendarsStore.getCalendarById(calendarObject.calendarId)
 
-			// Inherit calendar transparency to new events (fix for "Never show me as busy")
-			if (calendar?.transparency === 'transparent') {
-				calendarObjectInstance.timeTransparency = 'transparent'
-				calendarObjectInstance.eventComponent.timeTransparency = 'transparent'
+			// Inherit calendar transparency to new events
+			if (['TRANSPARENT', 'OPAQUE'].includes(calendar.transparency.toUpperCase())) {
+				const value = calendar.transparency.toUpperCase()
+				calendarObjectInstance.timeTransparency = value
+				calendarObjectInstance.eventComponent.timeTransparency = value
 			}
 
 			updateDefaultAlarm(calendarObject.calendarId, calendarObjectInstance)


### PR DESCRIPTION
### Summary
- altered new calendar event creation logic to upper case the inherited transparency value.

### Issue
- a lower case value was causing an error

<img width="1684" height="419" alt="image" src="https://github.com/user-attachments/assets/d4e2c440-ca03-4940-b275-6061fe44e387" />

- the lower case value was not being recognized properly

<img width="372" height="296" alt="image" src="https://github.com/user-attachments/assets/bdafe983-e7b2-4563-b4f3-736741c01a64" />

