### PR TITLE
fix: invitee list avatar

### DIFF
--- a/src/components/Editor/Invitees/InviteesListSearch.vue
+++ b/src/components/Editor/Invitees/InviteesListSearch.vue
@@ -24,7 +24,7 @@
 				<Avatar
 					v-if="option.isUser"
 					:key="option.uid"
-					:user="option.avatar"
+					:url="option.avatar"
 					:displayName="option.dropdownName" />
 				<Avatar v-else-if="option.type === 'circle'">
 					<template #icon>


### PR DESCRIPTION
### Summary
- Resolves https://github.com/nextcloud/calendar/issues/8436
- Modified avatar to use URL instead of user name this should now work properly for internal users and contacts

<img width="580" height="732" alt="image" src="https://github.com/user-attachments/assets/9782f6b4-789e-448b-8f42-6de51fdab991" />
