### PR TITLE
fix(eventDidMount): increase past event opacity

### DIFF
--- a/css/fullcalendar.scss
+++ b/css/fullcalendar.scss
@@ -135,7 +135,7 @@
 		border-block-start-width: 0 !important;
 		border-block-end-width: 0 !important;
 		border-inline-end-width: 0 !important;
-		border-inline-start-width: var(--default-grid-baseline) !important;
+		border-inline-start-width: calc(var(--default-grid-baseline) + var(--default-grid-basline) * 0.5) !important;
 		border-inline-start-style: solid !important;
 	}
 
@@ -184,7 +184,7 @@
 			border-block-start-width: 1px !important;
 			border-block-end-width: 1px !important;
 			border-inline-end-width: 1px !important;
-			border-inline-start-width: var(--default-grid-baseline) !important;
+			border-inline-start-width: calc(var(--default-grid-baseline) + var(--default-grid-basline) * 0.5) !important;
 		}
 	}
 

--- a/src/fullcalendar/rendering/eventDidMount.js
+++ b/src/fullcalendar/rendering/eventDidMount.js
@@ -118,7 +118,7 @@ export default errorCatch(function({ event, el }) {
 			if (rgb) {
 				const now = new Date()
 				const isPast = event.end ? event.end < now : (event.start ? event.start < now : false)
-				const opacity = isPast ? 0.05 : 0.35
+				const opacity = isPast ? 0.15 : 0.35
 				// Solid page-background as the base so overlapping events are opaque,
 				// with the accent colour layered on top as a translucent gradient.
 				el.style.backgroundColor = 'var(--fc-page-bg-color)'
@@ -215,7 +215,7 @@ export default errorCatch(function({ event, el }) {
 				const stripeColor = `rgba(${rgb.r}, ${rgb.g}, ${rgb.b}, 0.25)`
 				const now = new Date()
 				const isPast = event.end ? event.end < now : (event.start ? event.start < now : false)
-				const overlayOpacity = isPast ? 0.05 : 0.35
+				const overlayOpacity = isPast ? 0.15 : 0.35
 				const overlayColor = `rgba(${rgb.r}, ${rgb.g}, ${rgb.b}, ${overlayOpacity})`
 				el.style.backgroundColor = 'var(--fc-page-bg-color)'
 				el.style.backgroundImage = `repeating-linear-gradient(45deg, ${stripeColor}, ${stripeColor} 2px, transparent 2px, transparent 10px), linear-gradient(${overlayColor}, ${overlayColor})`


### PR DESCRIPTION
Fix https://github.com/nextcloud/calendar/issues/8380
Fix https://github.com/nextcloud/calendar/issues/8418

| Before | After | 
| - | - |
| <img width="659" height="228" alt="Screenshot From 2026-06-05 17-37-25" src="https://github.com/user-attachments/assets/253a5ffc-fbee-46ef-97ae-86a8e3f50332" /> | <img width="659" height="228" alt="Screenshot From 2026-06-05 17-34-12" src="https://github.com/user-attachments/assets/ec839b79-09b5-4f59-a2e8-8fcce847e75f" /> |
