### PR TITLE
fix(store): propagate organizer/attendees to recurrence-exceptions on…

### DIFF
--- a/src/store/calendarObjectInstance.js
+++ b/src/store/calendarObjectInstance.js
@@ -34,6 +34,35 @@ import useCalendarsStore from './calendars.js'
 import useSettingsStore from './settings.js'
 import { updateRoomParticipantsFromEvent } from '@/services/talkService'
 
+/**
+ * Overwrites the ATTENDEE/ORGANIZER of the master's current-and-future exceptions
+ * with clones of the master's own, after an in-place "this and all future" master update.
+ *
+ * @param {object} eventComponent Forked event component being saved.
+ */
+export function syncMasterParticipantsOntoFutureExceptions(eventComponent) {
+	if (!eventComponent.isExactForkOfPrimary || !eventComponent.primaryItem.isMasterItem()) {
+		return
+	}
+	const master = eventComponent.primaryItem
+	const ref = eventComponent.getReferenceRecurrenceId()
+	const futureExceptions = master.recurrenceManager
+		.getRecurrenceExceptionList()
+		.filter((exception) => ref.compare(exception.recurrenceId) <= 0)
+	const masterAttendees = master.getAttendeeList()
+	const masterOrganizer = master.getFirstProperty('ORGANIZER')
+	for (const exception of futureExceptions) {
+		exception.deleteAllProperties('ATTENDEE')
+		for (const att of masterAttendees) {
+			exception.addProperty(att.clone())
+		}
+		if (masterOrganizer) {
+			exception.deleteAllProperties('ORGANIZER')
+			exception.addProperty(masterOrganizer.clone())
+		}
+	}
+}
+
 export default defineStore('calendarObjectInstance', {
 	state: () => {
 		return {
@@ -1518,6 +1547,11 @@ export default defineStore('calendarObjectInstance', {
 				// - eventComponent.canCreateRecurrenceExceptions() - Can we create a recurrence-exception for this item
 				if (isForkedItem && eventComponent.canCreateRecurrenceExceptions()) {
 					[original, fork] = eventComponent.createRecurrenceException(thisAndAllFuture)
+
+					// calendar-js leaves existing exceptions untouched on in-place master overrides.
+					if (thisAndAllFuture) {
+						syncMasterParticipantsOntoFutureExceptions(eventComponent)
+					}
 				}
 
 				await calendarObjectsStore.updateCalendarObject({ calendarObject })

--- a/tests/javascript/unit/store/calendarObjectInstance.test.js
+++ b/tests/javascript/unit/store/calendarObjectInstance.test.js
@@ -1,0 +1,107 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+import { setActivePinia, createPinia } from 'pinia'
+import { syncMasterParticipantsOntoFutureExceptions } from '../../../../src/store/calendarObjectInstance.js'
+
+describe('store/calendarObjectInstance syncMasterParticipantsOntoFutureExceptions', () => {
+
+	beforeEach(() => {
+		setActivePinia(createPinia())
+	})
+
+	const makeProperty = (tag, id) => {
+		const property = { tag, id }
+		property.clone = () => ({ ...property, cloned: true })
+		return property
+	}
+
+	const makeException = (recurrenceId) => ({
+		recurrenceId,
+		deleted: [],
+		added: [],
+		deleteAllProperties(name) {
+			this.deleted.push(name)
+		},
+		addProperty(property) {
+			this.added.push(property)
+		},
+	})
+
+	const makeMaster = ({ attendees, organizer, exceptions }) => ({
+		isMasterItem: () => true,
+		getAttendeeList: () => attendees,
+		getFirstProperty: (name) => (name === 'ORGANIZER' ? organizer : null),
+		recurrenceManager: {
+			getRecurrenceExceptionList: () => exceptions,
+		},
+	})
+
+	const makeEventComponent = (master, referenceRecurrenceId) => ({
+		isExactForkOfPrimary: true,
+		primaryItem: master,
+		getReferenceRecurrenceId: () => referenceRecurrenceId,
+	})
+
+	it('does nothing when the component is not an exact fork of its primary', () => {
+		const exception = makeException({ compare: () => 0 })
+		const master = makeMaster({ attendees: [makeProperty('ATTENDEE', 'a')], organizer: makeProperty('ORGANIZER', 'o'), exceptions: [exception] })
+		const eventComponent = makeEventComponent(master, { compare: () => 0 })
+		eventComponent.isExactForkOfPrimary = false
+
+		syncMasterParticipantsOntoFutureExceptions(eventComponent)
+
+		expect(exception.deleted).toEqual([])
+		expect(exception.added).toEqual([])
+	})
+
+	it('does nothing when the primary item is not the master', () => {
+		const exception = makeException({})
+		const master = makeMaster({ attendees: [], organizer: null, exceptions: [exception] })
+		master.isMasterItem = () => false
+		const eventComponent = makeEventComponent(master, { compare: () => 0 })
+
+		syncMasterParticipantsOntoFutureExceptions(eventComponent)
+
+		expect(exception.deleted).toEqual([])
+		expect(exception.added).toEqual([])
+	})
+
+	it('overwrites attendees and organizer on current-and-future exceptions only', () => {
+		// ref.compare(exceptionId): +1 when ref is after the exception (past, skipped),
+		// 0 when equal, -1 when ref is before it (future). Filter keeps <= 0.
+		const ref = { compare: (recurrenceId) => recurrenceId.cmp }
+		const past = makeException({ cmp: 1 })
+		const current = makeException({ cmp: 0 })
+		const future = makeException({ cmp: -1 })
+		const attendees = [makeProperty('ATTENDEE', 'a1'), makeProperty('ATTENDEE', 'a2')]
+		const organizer = makeProperty('ORGANIZER', 'o')
+		const master = makeMaster({ attendees, organizer, exceptions: [past, current, future] })
+		const eventComponent = makeEventComponent(master, ref)
+
+		syncMasterParticipantsOntoFutureExceptions(eventComponent)
+
+		expect(past.deleted).toEqual([])
+		expect(past.added).toEqual([])
+
+		for (const exception of [current, future]) {
+			expect(exception.deleted).toEqual(['ATTENDEE', 'ORGANIZER'])
+			expect(exception.added.map((p) => p.id)).toEqual(['a1', 'a2', 'o'])
+			expect(exception.added.every((p) => p.cloned)).toBe(true)
+		}
+	})
+
+	it('overwrites only attendees when the master has no organizer', () => {
+		const ref = { compare: () => 0 }
+		const exception = makeException({})
+		const attendees = [makeProperty('ATTENDEE', 'a1')]
+		const master = makeMaster({ attendees, organizer: null, exceptions: [exception] })
+		const eventComponent = makeEventComponent(master, ref)
+
+		syncMasterParticipantsOntoFutureExceptions(eventComponent)
+
+		expect(exception.deleted).toEqual(['ATTENDEE'])
+		expect(exception.added.map((p) => p.id)).toEqual(['a1'])
+	})
+})


### PR DESCRIPTION
## Summary

Fixes nextcloud/calendar#8450.

When the organizer applies **"Update this and all future"** to the master occurrence (NR-1) of a recurring series that already contains a moved occurrence (RECURRENCE-ID override), calendar-js' `_overridePrimaryItem()` copies the new state onto the master but leaves the existing override VEVENT untouched. Consequence: if the user just added the first attendee (and thus the ORGANIZER), the override ends up without either property. Two visible symptoms:

- **Attendee side:** Sabre's TipBroker omits the override from the iTip REQUEST (no ATTENDEE = no recipient on that VEVENT), so the attendee's client expands the RRULE normally and shows the moved occurrence at its original time.
- **Organizer side:** the Nextcloud WebUI crashes silently inside `OrganizerListItem.vue` (`organizer.attendeeProperty.getParameterFirstValue(...)` on `undefined`), the attendee list does not render, and the override appears empty even though Thunderbird and other CalDAV clients display it correctly.

## Fix

+30 LOC in `src/store/calendarObjectInstance.js`: one new file-local helper `syncMasterParticipantsOntoExceptions(master, exceptions)` plus a four-line guarded call inside `saveCalendarObjectInstance`.

Immediately after `eventComponent.createRecurrenceException(thisAndAllFuture)` returns, if the call entered the master-in-place override path (`thisAndAllFuture && isExactForkOfPrimary && primaryItem.isMasterItem()`), iterate the recurrence-exceptions whose `RECURRENCE-ID` is at or after the master start and overwrite each exception's `ATTENDEE` list and `ORGANIZER` with clones of the master's. The `RECURRENCE-ID >= master start` filter is defensive: for any RFC-compliant series every exception already satisfies this, so in practice the filter selects all exceptions, but it guards against pathological data where an exception's RID precedes the current master start. `ORGANIZER` on the exception is only deleted when a replacement exists, to avoid introducing the same crash this PR fixes.

The fix lives in the calendar app store rather than in `calendar-js`'s `_overridePrimaryItem()` for delivery speed; the same propagation arguably belongs one layer down so every consumer of `createRecurrenceException(true)` on a master-aligned fork benefits. A follow-up against `nextcloud/calendar-js` is a reasonable next step.

## Trade-offs

- **Scope limited to `ATTENDEE` and `ORGANIZER`.** The same shape of bug almost certainly applies to any other master-level property edit (`SUMMARY`, `DESCRIPTION`, `LOCATION`, ...) when "this and all future" is applied to the master in place: the override keeps its stale value while the master gets the new one. Out of scope for this PR, which targets the reported #8450 attendee-visibility regression specifically. Worth a follow-up if anyone reproduces another property surfacing the same way.
- **Wholesale replacement of override attendees, not a delta.** The Nextcloud WebUI does not currently expose per-occurrence attendee editing, but other CalDAV clients (Thunderbird) do. Any per-occurrence attendee customisation a user has set on an override is overwritten by this propagation. Acceptable for the reported scenario; a future enhancement could diff against the pre-update master to preserve overrides whose attendees diverge intentionally.
- **Per-occurrence `PARTSTAT`, `RSVP`, `SCHEDULE-STATUS`** on an override-side attendee are similarly overwritten in the same gesture. This is the intended semantics for "Update this and all future" applied to attendees.

## Test plan

Manual repro on a live Nextcloud 33 / Calendar 6.4.2 instance, two real accounts (organizer + attendee), both Thunderbird CalDAV and the NC WebUI verified:

- [x] Create a daily/4× series with no attendees.
- [x] Move NR-2 (+1h), "Update this occurrence".
- [x] Open NR-1, add an attendee, "Update this and all future".
- [x] Reopen NR-2 as organizer in popover and full editor: ORGANIZER and ATTENDEE both rendered.
- [x] Verify the override VEVENT in the iTip REQUEST received by the attendee carries the same `ATTENDEE` and `ORGANIZER` as the master (Thunderbird as ground truth: the moved occurrence shows up with organizer and attendee on it).
- [x] Attendee's CalDAV-synced calendar (Thunderbird and NC WebUI) shows the moved NR-2 at the new time with the attendee listed.
- [ ] Unit test in `tests/javascript/unit/store/calendarObjectInstance.test.js` — file does not exist yet; happy to add one in a follow-up if maintainer prefers that here.

## Related / follow-ups

- A separate iTip REPLY-side issue surfaces with the same series afterwards: when the attendee clicks "Accept" in Thunderbird, only the master VEVENT's PARTSTAT is updated. The override stays NEEDS-ACTION even though the REQUEST and the organizer's stored copy both correctly list the attendee on it. Filed as nextcloud/server#61114. Likely a server-side TipBroker concern, adjacent to nextcloud/server#60452 / nextcloud/server#60536, not in scope here.

## 🤖 AI (if applicable)
- [x] The content of this PR was partly or fully generated using AI