### PR TITLE
fix(css): keep unscheduled tasks toggle inside the scroll container

### DIFF
--- a/css/global.scss
+++ b/css/global.scss
@@ -7,12 +7,6 @@
 	white-space: pre-wrap;
 }
 
-.content.app-calendar {
-	> div.app-content {
-		overflow-x: hidden;
-	}
-}
-
 .app-navigation-spacer {
 	list-style-type: none;
 }

--- a/src/views/Calendar.vue
+++ b/src/views/Calendar.vue
@@ -454,8 +454,7 @@ export default {
 .app-navigation-toggle-wrapper {
 	position: absolute;
 	top: var(--app-navigation-padding);
-	inset-inline-end: calc(0px - var(--app-navigation-padding));
-	margin-inline-end: calc(-1 * var(--default-clickable-area));
+	inset-inline-end: 0;
 }
 
 .calendar-wrapper {
@@ -467,7 +466,7 @@ export default {
 .toggle-button {
 	position: absolute;
 	top: 2px;
-	inset-inline-end: 50px;
+	inset-inline-end: var(--app-navigation-padding);
 	z-index: 1000;
 }
 


### PR DESCRIPTION
Fixes #7525, Duplicate #7734

## Summary

If there is a task in the calendar without a due date and you have enabled the display of tasks in the calendar, the right sidebar for unscheduled tasks is triggered. The toggle button wrapper `.app-navigation-toggle-wrapper` is pushed beyond the right edge of `main.app-content`. The button inside the wrapper is moved back to the left with `inset-inline-end: 50px` and this creates an empty element that triggers the scrollbar because the `main.app-content` from `NcAppContent` has `overflow: auto`.

## Fix
The fix does not change the visible position of the button. It remains at 8px from the right edge, but is set directly via `var(--app-navigation-padding)` and is independent of `var(--default-clickable-area)`. The wrapper is no longer shifted to the right but remains at 0. Instead, the button inside the wrapper is shifted by the value of `var(--app-navigation-padding)`. 

The code for `div.app-content` in css/global.scss was removed because nextcloud/vue renders `main` and no longer `div`

### Before

<img width="1083" height="723" alt="Screenshot_20260612_210641" src="https://github.com/user-attachments/assets/e12f0dd5-5af1-4e2b-a92b-bf08c1895a5f" />

<img width="1083" height="721" alt="Screenshot_20260612_211346" src="https://github.com/user-attachments/assets/c8021af1-1a3a-453a-b65a-a87e2ea42c8a" />

### After

<img width="1083" height="721" alt="Screenshot_20260612_210342" src="https://github.com/user-attachments/assets/47c2f750-0ab5-4c45-b18e-b7bb09fb5ace" />

## How to Test

This branch, built with `npm run build`, running as apps-extra app on Nextcloud server master (NC 35 dev)

**1. Create Task List**

```bash
curl -u admin:admin -X MKCALENDAR -H 'Content-Type: application/xml' \
  --data '<?xml version="1.0"?><c:mkcalendar xmlns:d="DAV:" xmlns:c="urn:ietf:params:xml:ns:caldav"><d:set><d:prop><d:displayname>Tasks</d:displayname><c:supported-calendar-component-set><c:comp name="VTODO"/></c:supported-calendar-component-set></d:prop></d:set></c:mkcalendar>' \
  https://<instance>/remote.php/dav/calendars/<user>/tasks/
```

**2. Create Task**

```bash
curl -u admin:admin -X PUT -H 'Content-Type: text/calendar' \
  --data $'BEGIN:VCALENDAR\nVERSION:2.0\nPRODID:-//repro//EN\nBEGIN:VTODO\nUID:repro-7525\nDTSTAMP:20260612T120000Z\nSUMMARY:Task without due date\nSTATUS:NEEDS-ACTION\nEND:VTODO\nEND:VCALENDAR' \
  https://<instance>/remote.php/dav/calendars/<user>/tasks/repro-7525.ics
```

**3. Check Fix**
Check Result via Browser https://<instance>/index.php/apps/calendar/
(Show Tasks must be enabled - is default)

Horizontal scrollbar will **not** appear anymore (played around with different responsive resolutions and with and without zoom)

## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
- Assisted-by: ClaudeCode:claude-fable-5
- searched the source code for the cause
- suggested a solution to the problem
- checked the nextcloud/vue history so I could actually delete the dead fix
- Review of this git diff