### PR TITLE
[stable6.4] fix(deps): update dependency @nextcloud/cdav-library to ^2.6.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "@nextcloud/axios": "^2.5.2",
         "@nextcloud/calendar-availability-vue": "^3.0.0",
         "@nextcloud/calendar-js": "^8.1.6",
-        "@nextcloud/cdav-library": "^2.6.0",
+        "@nextcloud/cdav-library": "^2.6.2",
         "@nextcloud/dialogs": "^7.3.0",
         "@nextcloud/event-bus": "^3.3.3",
         "@nextcloud/initial-state": "^3.0.0",
@@ -3266,9 +3266,9 @@
       }
     },
     "node_modules/@nextcloud/cdav-library": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/@nextcloud/cdav-library/-/cdav-library-2.6.0.tgz",
-      "integrity": "sha512-7VpPk95W070mWsbqqcmyRxmF3FV0PvfoSQV+C85ltbiROr1wKeoIGh7ZjNETlpcS2FgdgbLQZeD7L+9zS9c+hw==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@nextcloud/cdav-library/-/cdav-library-2.6.2.tgz",
+      "integrity": "sha512-TVksMa2Liy4Vq3s3CdEgMZM4AZsU0yvm1oznMalKOKbMsvEknNEXb5nhh/+hINpJdmooYtY6Og9KC0HW4MfjCw==",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@nextcloud/axios": "^2.6.0"

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "@nextcloud/axios": "^2.5.2",
     "@nextcloud/calendar-availability-vue": "^3.0.0",
     "@nextcloud/calendar-js": "^8.1.6",
-    "@nextcloud/cdav-library": "^2.6.0",
+    "@nextcloud/cdav-library": "^2.6.2",
     "@nextcloud/dialogs": "^7.3.0",
     "@nextcloud/event-bus": "^3.3.3",
     "@nextcloud/initial-state": "^3.0.0",


### PR DESCRIPTION
### Summary
- Manually bumped cdav-library