### PR TITLE
fix(css): Use semantic font weight for event titles

### DIFF
--- a/css/fullcalendar.scss
+++ b/css/fullcalendar.scss
@@ -190,7 +190,7 @@
 
 	.fc-event-title {
 		text-overflow: ellipsis;
-		font-weight: 700;
+		font-weight: var(--font-weight-element);
 	}
 
 	// Reminder icon on events with alarms set


### PR DESCRIPTION
Since https://github.com/nextcloud-libraries/nextcloud-vue/pull/8469, clickable elements should use this font weight instead of hardcoding bold.

| Before | After |
|--------|--------|
| <img width="150" height="66" alt="Screenshot 2026-06-18 at 13 31 44" src="https://github.com/user-attachments/assets/ed320331-c52a-4123-8083-eab850cf9d91" /> | <img width="150" height="66" alt="Screenshot 2026-06-18 at 13 31 35" src="https://github.com/user-attachments/assets/841a01c0-d23e-4d5f-903b-8a22d2b86b66" /> | 

(PS: I hope I did this correctly!)