### PR TITLE
fix(proposal): notify invited participants when a proposal is converted to an event

### DIFF
--- a/lib/Service/Proposal/ProposalService.php
+++ b/lib/Service/Proposal/ProposalService.php
@@ -375,6 +375,7 @@ class ProposalService {
 				$vObject->serialize()
 			);
 		}
+		$this->applyCalendarBlockersParticipant($user, $proposal, 'M', $vObject);
 
 		// destroy the proposal entry
 		$this->proposalVoteMapper->deleteByProposalId($user->getUID(), $proposal->getId());
@@ -633,7 +634,7 @@ class ProposalService {
 		$vObject = $this->constructCalendarBlocker($user, $proposal);
 
 		$this->applyCalendarBlockersOrganizer($user, $userCalendarUri, $userEventUri, $vObject);
-		$this->applyCalendarBlockersParticipant($user, $proposal, $reason, $userCalendarUri, $userEventUri, $vObject);
+		$this->applyCalendarBlockersParticipant($user, $proposal, $reason, $vObject);
 
 	}
 
@@ -720,7 +721,7 @@ class ProposalService {
 	/**
 	 *  Create or update calendar blocker event(s) for participant(s)
 	 */
-	private function applyCalendarBlockersParticipant(IUser $user, ProposalObject $proposal, string $reason, string $calendarUri, ?string $eventUri, VCalendar $vObject): void {
+	private function applyCalendarBlockersParticipant(IUser $user, ProposalObject $proposal, string $reason, VCalendar $vObject): void {
 		// if the calendar manager does not have a handleIMip method, we cannot generate iTip messages
 		if (!method_exists($this->calendarManager, 'handleIMip')) {
 			return;

--- a/tests/php/unit/Service/Proposal/ProposalServiceTest.php
+++ b/tests/php/unit/Service/Proposal/ProposalServiceTest.php
@@ -580,6 +580,16 @@ class ProposalServiceTest extends TestCase {
 			->method('deleteById')
 			->with('testuser', 1);
 
+		// the internal participant must be looked up and notified of the finalised event via iTIP
+		$participantUser = $this->createMock(IUser::class);
+		$participantUser->method('getUID')->willReturn('alice');
+		$this->userManager->expects($this->once())
+			->method('getByEmail')
+			->with('alice@example.com')
+			->willReturn([$participantUser]);
+		$this->calendarManager->expects($this->once())
+			->method('handleIMip');
+
 		// test and assertions
 		$this->service->convertProposal($this->user, 1, 10, ['attendancePreset' => true]);
 		$this->addToAssertionCount(1); // If we reached this point, the test is successfully completed


### PR DESCRIPTION
### Summary
When the organiser converts a meeting proposal into a real event, the invited
participants do not receive the event. They keep the tentative "[Proposed]"
blocker in their calendar indefinitely.

### Steps to reproduce
1. User A creates a meeting proposal and invites user B.
2. User B votes/accepts a date.
3. User A converts the proposal into an event.
4. ❌ User A gets the event, but user B still only sees the original "[Proposed]"
   tentative blocker — the finalised event never reaches B.

### Root cause
`ProposalService::convertProposal()` writes the finalised event only to the
**organiser's** calendar (`applyCalendarBlockersOrganizer()`), but never sends the
iTIP scheduling message to the **participants**. At proposal *creation* time,
`syncCalendarBlockers()` correctly calls both `applyCalendarBlockersOrganizer()`
**and** `applyCalendarBlockersParticipant()`; the conversion path is missing the
second call.

### Fix
After writing the organiser's event, also call `applyCalendarBlockersParticipant()`
with the finalised event. Since the event keeps the proposal's UID, the iMIP
message (`handleIMip` with `['absent' => 'create']`) updates the participants'
existing tentative blocker into the real event.

### How tested
- Reproduced the issue on Calendar 6.5.0 (Nextcloud 32) with two users.
- Applied the fix: after conversion, the invited user's tentative blocker is
  correctly replaced by the finalised event. Verified on staging and production.