### PR TITLE
fix(dashboard): show all-day events correctly in calendar widget

### DIFF
--- a/lib/Dashboard/CalendarWidget.php
+++ b/lib/Dashboard/CalendarWidget.php
@@ -146,10 +146,20 @@ class CalendarWidget implements IAPIWidget, IAPIWidgetV2, IButtonWidget, IIconWi
 			foreach ($searchResult as $calendarEvent) {
 				// Find first recurrence in the future
 				$recurrence = null;
+				$isAllDay = false;
 				foreach ($calendarEvent['objects'] as $object) {
 					/** @var DateTimeImmutable $startDate */
 					$startDate = $object['DTSTART'][0];
-					if ($startDate->getTimestamp() >= $dateTime->getTimestamp()) {
+					$time = $startDate instanceof DateTimeImmutable ? $startDate->format('H:i:s') : '';
+					$isAllDay = $time === '00:00:00' || $time === '23:59:59';
+					if ($isAllDay) {
+						// All-day events have no time component; compare by calendar date
+						// so today's events are not excluded by a timestamp comparison
+						if ($startDate->format('Y-m-d') >= $dateTime->format('Y-m-d')) {
+							$recurrence = $object;
+							break;
+						}
+					} elseif ($startDate->getTimestamp() >= $dateTime->getTimestamp()) {
 						$recurrence = $object;
 						break;
 					}
@@ -159,9 +169,13 @@ class CalendarWidget implements IAPIWidget, IAPIWidgetV2, IButtonWidget, IIconWi
 					continue;
 				}
 
+				$subtitle = $isAllDay
+					? $this->l10n->t('All day')
+					: $this->dateTimeFormatter->formatTimeSpan(DateTime::createFromImmutable($startDate));
+
 				$widget = new WidgetItem(
 					$recurrence['SUMMARY'][0] ?? 'New Event',
-					$this->dateTimeFormatter->formatTimeSpan(DateTime::createFromImmutable($startDate)),
+					$subtitle,
 					$this->urlGenerator->getAbsoluteURL($this->urlGenerator->linkToRoute('calendar.view.index', ['objectId' => $calendarEvent['uid']])),
 					$this->getCalendarDotIconUrl($calendar->getDisplayColor()),
 					(string)$startDate->getTimestamp(),


### PR DESCRIPTION
## Summary

The dashboard calendar widget had two bugs with all-day (VALUE=DATE) events:

- **Hidden all day**: All-day events are stored as midnight UTC (00:00:00). The widget compared `DTSTART.timestamp >= now`, which always fails after midnight UTC, effectively hiding today's all-day events for the entire day.
- **Wrong label**: All-day events were displayed with `formatTimeSpan()`, showing e.g. "in 10 hours" instead of something meaningful.

### Changes

- Detect all-day events by checking whether the DTSTART time component is `00:00:00` (standard `VALUE=DATE`) or `23:59:59` (used by some third-party `ICalendar` providers as a forward-compatibility signal).
- For all-day events, compare by **calendar date** (`Y-m-d`) instead of timestamp, so today's events are always included.
- Show **"All day"** as the subtitle instead of a formatted time span.

## Test plan

- [ ] Add an all-day event to a calendar for today → verify it appears in the dashboard widget with label "All day"
- [ ] Add an all-day event for a future date → verify it appears with label "All day"
- [ ] Add a timed event → verify it still shows the relative time span (e.g. "in 2 hours")
- [ ] Verify today's all-day event is not shown once the day has passed (next day)

🤖 Generated with [Claude Code](https://claude.com/claude-code)