### PR TITLE
fix(room-availability): remove remnants of the interaction plugin

### DIFF
--- a/src/components/Editor/FreeBusy/RoomAvailabilityModal.vue
+++ b/src/components/Editor/FreeBusy/RoomAvailabilityModal.vue
@@ -71,7 +71,6 @@
 </template>
 
 <script>
-import interactionPlugin from '@fullcalendar/interaction'
 import resourceTimelinePlugin from '@fullcalendar/resource-timeline'
 import FullCalendar from '@fullcalendar/vue3'
 import { NcButton, NcDateTimePickerNative, NcModal, NcPopover } from '@nextcloud/vue'
@@ -210,7 +209,6 @@ export default {
 				resourceTimelinePlugin,
 				momentPlugin,
 				VTimezoneNamedTimezone,
-				interactionPlugin,
 			]
 		},
 
@@ -257,10 +255,6 @@ export default {
 				resources: this.resources,
 				// Plugins
 				plugins: this.plugins,
-				// Interaction:
-				editable: false,
-				selectable: true,
-				select: this.handleSelect,
 				// Localization:
 				...getDateFormattingConfig(),
 				...getFullCalendarLocale(),


### PR DESCRIPTION
Fixes https://github.com/nextcloud/calendar/issues/8520

No interactions are implemented so the plugin (and related config) is superfluous.

## Before

Clicking on the room availability modal will produce a harmless error on the console.

<img width="889" height="368" alt="Image" src="https://github.com/user-attachments/assets/57e6b1fb-b6cb-42f9-bbf9-279a1d7c603b" />

## After

No error is produced.

## 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
