### PR TITLE
fix(room-availability): color caption popover not showing

### DIFF
--- a/src/components/Editor/FreeBusy/RoomAvailabilityModal.vue
+++ b/src/components/Editor/FreeBusy/RoomAvailabilityModal.vue
@@ -47,7 +47,7 @@
 								</template>
 							</NcButton>
 						</template>
-						<template>
+						<template #default>
 							<div class="freebusy-caption">
 								<div class="freebusy-caption__calendar-user-types" />
 								<div class="freebusy-caption__colors">


### PR DESCRIPTION
## Before

https://github.com/user-attachments/assets/6d118407-9a0c-4bd0-ab90-0da6fe751eea

## After

https://github.com/user-attachments/assets/7ea1c04a-bc68-4077-bd67-71d6b1c2d118

## 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI