### PR TITLE
feat(calendar): plural default calendar reminders

### DIFF
--- a/src/components/AppNavigation/EditCalendarModal.vue
+++ b/src/components/AppNavigation/EditCalendarModal.vue
@@ -43,36 +43,61 @@
 					{{ $t('calendar', 'Never show me as busy (set this calendar to transparent)') }}
 				</NcCheckboxRadioSwitch>
 			</template>
-			<template v-if="!calendar.isSharedWithMe && isAfterVersion">
-				<div class="edit-calendar-modal__default-alarm">
-					<label for="default-alarm-partday-select" class="edit-calendar-modal__default-alarm__label">
-						{{ $t('calendar', 'Default reminder for part-day events') }}
-					</label>
-					<NcSelect
-						v-model="selectedDefaultAlarmPartDay"
-						inputId="default-alarm-partday-select"
-						:options="defaultAlarmPartDayOptions"
-						:clearable="false"
-						:placeholder="$t('calendar', 'Select default reminder')"
-						class="edit-calendar-modal__default-alarm__select"
-						@update:modelValue="defaultAlarmChanged = true" />
-				</div>
-				<div class="edit-calendar-modal__default-alarm">
-					<label for="default-alarm-fullday-select" class="edit-calendar-modal__default-alarm__label">
-						{{ $t('calendar', 'Default reminder for full-day events') }}
-					</label>
-					<NcSelect
-						v-model="selectedDefaultAlarmFullDay"
-						inputId="default-alarm-fullday-select"
-						:options="defaultAlarmFullDayOptions"
-						:clearable="false"
-						:placeholder="$t('calendar', 'Select default reminder')"
-						class="edit-calendar-modal__default-alarm__select"
-						@update:modelValue="defaultAlarmChanged = true" />
-					<p class="edit-calendar-modal__default-alarm__hint">
-						{{ $t('calendar', 'These reminders will be automatically added to new events created in this calendar') }}
-					</p>
-				</div>
+			<template v-if="!calendar.isSharedWithMe && supportsDefaultCalendarAlarms">
+				<template v-if="supportsPluralDefaultCalendarAlarms">
+					<div class="edit-calendar-modal__default-alarm">
+						<label class="edit-calendar-modal__default-alarm__label">
+							{{ $t('calendar', 'Default reminder for part-day events') }}
+						</label>
+						<DefaultAlarmsList
+							v-model="defaultAlarmsPartDay"
+							:isAllDay="false"
+							@update:modelValue="defaultAlarmChanged = true" />
+					</div>
+					<div class="edit-calendar-modal__default-alarm">
+						<label class="edit-calendar-modal__default-alarm__label">
+							{{ $t('calendar', 'Default reminder for full-day events') }}
+						</label>
+						<DefaultAlarmsList
+							v-model="defaultAlarmsFullDay"
+							:isAllDay="true"
+							@update:modelValue="defaultAlarmChanged = true" />
+						<p class="edit-calendar-modal__default-alarm__hint">
+							{{ $t('calendar', 'These reminders will be automatically added to new events created in this calendar') }}
+						</p>
+					</div>
+				</template>
+				<template v-else>
+					<div class="edit-calendar-modal__default-alarm">
+						<label for="default-alarm-partday-select" class="edit-calendar-modal__default-alarm__label">
+							{{ $t('calendar', 'Default reminder for part-day events') }}
+						</label>
+						<NcSelect
+							v-model="selectedDefaultAlarmPartDay"
+							inputId="default-alarm-partday-select"
+							:options="defaultAlarmPartDayOptions"
+							:clearable="false"
+							:placeholder="$t('calendar', 'Select default reminder')"
+							class="edit-calendar-modal__default-alarm__select"
+							@update:modelValue="defaultAlarmChanged = true" />
+					</div>
+					<div class="edit-calendar-modal__default-alarm">
+						<label for="default-alarm-fullday-select" class="edit-calendar-modal__default-alarm__label">
+							{{ $t('calendar', 'Default reminder for full-day events') }}
+						</label>
+						<NcSelect
+							v-model="selectedDefaultAlarmFullDay"
+							inputId="default-alarm-fullday-select"
+							:options="defaultAlarmFullDayOptions"
+							:clearable="false"
+							:placeholder="$t('calendar', 'Select default reminder')"
+							class="edit-calendar-modal__default-alarm__select"
+							@update:modelValue="defaultAlarmChanged = true" />
+						<p class="edit-calendar-modal__default-alarm__hint">
+							{{ $t('calendar', 'These reminders will be automatically added to new events created in this calendar') }}
+						</p>
+					</div>
+				</template>
 			</template>
 			<template v-if="canBeShared">
 				<h3 class="edit-calendar-modal__sharing-header">
@@ -130,6 +155,7 @@ import CheckIcon from 'vue-material-design-icons/Check.vue'
 import CloseIcon from 'vue-material-design-icons/Close.vue'
 import DeleteIcon from 'vue-material-design-icons/TrashCanOutline.vue'
 import DownloadIcon from 'vue-material-design-icons/TrayArrowDown.vue'
+import DefaultAlarmsList from './EditCalendarModal/DefaultAlarmsList.vue'
 import InternalLink from './EditCalendarModal/InternalLink.vue'
 import PublishCalendar from './EditCalendarModal/PublishCalendar.vue'
 import ShareItem from './EditCalendarModal/ShareItem.vue'
@@ -163,6 +189,7 @@ export default {
 		InternalLink,
 		NcAppNavigationSpacer,
 		NcCheckboxRadioSwitch,
+		DefaultAlarmsList,
 	},
 
 	data() {
@@ -174,6 +201,8 @@ export default {
 			calendarNameChanged: false,
 			selectedDefaultAlarmPartDay: null,
 			selectedDefaultAlarmFullDay: null,
+			defaultAlarmsPartDay: [],
+			defaultAlarmsFullDay: [],
 			defaultAlarmChanged: false,
 		}
 	},
@@ -327,8 +356,17 @@ export default {
 		 *
 		 * @return {boolean}
 		 */
-		isAfterVersion() {
+		supportsDefaultCalendarAlarms() {
 			return isAfterVersion(34)
+		},
+
+		/**
+		 * Whether plural default alarms are supported (Nextcloud 35+)
+		 *
+		 * @return {boolean}
+		 */
+		supportsPluralDefaultCalendarAlarms() {
+			return isAfterVersion(35)
 		},
 	},
 
@@ -344,22 +382,27 @@ export default {
 			this.calendarColorChanged = false
 			this.isTransparent = calendar.transparency === 'transparent'
 
-			// Initialize default alarm for part-day events
-			if (calendar.defaultAlarmPartDay === null) {
-				this.selectedDefaultAlarmPartDay = this.defaultAlarmPartDayOptions[0]
+			if (isAfterVersion(35)) {
+				this.defaultAlarmsPartDay = [...(calendar.defaultAlarmsPartDay ?? [])]
+				this.defaultAlarmsFullDay = [...(calendar.defaultAlarmsFullDay ?? [])]
 			} else {
-				const value = parseInt(calendar.defaultAlarmPartDay)
-				const option = this.defaultAlarmPartDayOptions.find((opt) => opt.value === value)
-				this.selectedDefaultAlarmPartDay = option || this.defaultAlarmPartDayOptions[0]
-			}
+				// Initialize default alarm for part-day events
+				if (calendar.defaultAlarmPartDay === null) {
+					this.selectedDefaultAlarmPartDay = this.defaultAlarmPartDayOptions[0]
+				} else {
+					const value = parseInt(calendar.defaultAlarmPartDay)
+					const option = this.defaultAlarmPartDayOptions.find((opt) => opt.value === value)
+					this.selectedDefaultAlarmPartDay = option || this.defaultAlarmPartDayOptions[0]
+				}
 
-			// Initialize default alarm for full-day events
-			if (calendar.defaultAlarmFullDay === null) {
-				this.selectedDefaultAlarmFullDay = this.defaultAlarmFullDayOptions[0]
-			} else {
-				const value = parseInt(calendar.defaultAlarmFullDay)
-				const option = this.defaultAlarmFullDayOptions.find((opt) => opt.value === value)
-				this.selectedDefaultAlarmFullDay = option || this.defaultAlarmFullDayOptions[0]
+				// Initialize default alarm for full-day events
+				if (calendar.defaultAlarmFullDay === null) {
+					this.selectedDefaultAlarmFullDay = this.defaultAlarmFullDayOptions[0]
+				} else {
+					const value = parseInt(calendar.defaultAlarmFullDay)
+					const option = this.defaultAlarmFullDayOptions.find((opt) => opt.value === value)
+					this.selectedDefaultAlarmFullDay = option || this.defaultAlarmFullDayOptions[0]
+				}
 			}
 			this.defaultAlarmChanged = false
 		},
@@ -432,6 +475,15 @@ export default {
 		 */
 		async saveDefaultAlarm() {
 			try {
+				if (isAfterVersion(35)) {
+					await this.calendarsStore.changeCalendarDefaultAlarms({
+						calendar: this.calendar,
+						defaultAlarmsPartDay: this.defaultAlarmsPartDay,
+						defaultAlarmsFullDay: this.defaultAlarmsFullDay,
+					})
+					return
+				}
+
 				const pdayValue = this.selectedDefaultAlarmPartDay ? this.selectedDefaultAlarmPartDay.value : null
 				const fdayValue = this.selectedDefaultAlarmFullDay ? this.selectedDefaultAlarmFullDay.value : null
 				await this.calendarsStore.changeCalendarDefaultAlarms({
@@ -464,7 +516,7 @@ export default {
 				if (this.calendarNameChanged) {
 					await this.saveName()
 				}
-				if (this.isAfterVersion && this.defaultAlarmChanged) {
+				if (isAfterVersion(34) && this.defaultAlarmChanged) {
 					await this.saveDefaultAlarm()
 				}
 			} catch (error) {

--- a/src/components/AppNavigation/EditCalendarModal/DefaultAlarmsList.vue
+++ b/src/components/AppNavigation/EditCalendarModal/DefaultAlarmsList.vue
@@ -1,0 +1,70 @@
+<!--
+  - SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+  - SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
+<template>
+	<div class="property-alarm-list">
+		<DefaultAlarmsListNew
+			:isAllDay="isAllDay"
+			:showIcon="alarms.length === 0"
+			@addAlarm="addAlarm" />
+		<DefaultAlarmsListItem
+			v-for="(alarm, index) in alarms"
+			:key="index"
+			:alarm="alarm"
+			:isAllDay="isAllDay"
+			:showIcon="index === 0"
+			@updateAlarm="(updated) => updateAlarm(index, updated)"
+			@removeAlarm="removeAlarm(index)" />
+	</div>
+</template>
+
+<script>
+import DefaultAlarmsListItem from './DefaultAlarmsListItem.vue'
+import DefaultAlarmsListNew from './DefaultAlarmsListNew.vue'
+
+export default {
+	name: 'DefaultAlarmsList',
+	components: {
+		DefaultAlarmsListItem,
+		DefaultAlarmsListNew,
+	},
+
+	props: {
+		isAllDay: {
+			type: Boolean,
+			required: true,
+		},
+
+		modelValue: {
+			type: Array,
+			required: true,
+		},
+	},
+
+	computed: {
+		alarms() {
+			return this.modelValue
+		},
+	},
+
+	methods: {
+		addAlarm(alarm) {
+			this.$emit('update:modelValue', [...this.alarms, alarm])
+		},
+
+		updateAlarm(index, updated) {
+			const next = [...this.alarms]
+			next[index] = updated
+			this.$emit('update:modelValue', next)
+		},
+
+		removeAlarm(index) {
+			const next = [...this.alarms]
+			next.splice(index, 1)
+			this.$emit('update:modelValue', next)
+		},
+	},
+}
+</script>

--- a/src/components/AppNavigation/EditCalendarModal/DefaultAlarmsListItem.vue
+++ b/src/components/AppNavigation/EditCalendarModal/DefaultAlarmsListItem.vue
@@ -1,0 +1,255 @@
+<!--
+  - SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+  - SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
+<template>
+	<div class="property-alarm-item">
+		<div v-if="!isEditing" class="property-alarm-item__front">
+			<div class="property-alarm-item__label">
+				{{ formatAlarm(displayAlarm, isAllDay, currentUserTimezone, locale) }}
+			</div>
+		</div>
+		<div
+			v-if="isEditing && !isAllDay"
+			class="property-alarm-item__edit property-alarm-item__edit--timed">
+			<NcTextField
+				type="number"
+				:label="$t('calendar', 'Amount')"
+				:labelOutside="true"
+				:modelValue="String(displayAlarm.relativeAmountTimed)"
+				@update:modelValue="changeRelativeAmountTimed" />
+			<AlarmTimeUnitSelect
+				:isAllDay="isAllDay"
+				:count="displayAlarm.relativeAmountTimed"
+				:unit="displayAlarm.relativeUnitTimed"
+				:disabled="false"
+				@change="changeRelativeUnitTimed" />
+		</div>
+		<div
+			v-if="isEditing && isAllDay"
+			class="property-alarm-item__edit property-alarm-item__edit--all-day">
+			<div class="property-alarm-item__edit--all-day__distance">
+				<NcTextField
+					type="number"
+					:label="$t('calendar', 'Amount')"
+					:labelOutside="false"
+					:modelValue="String(displayAlarm.relativeAmountAllDay)"
+					@update:modelValue="changeRelativeAmountAllDay" />
+				<AlarmTimeUnitSelect
+					:isAllDay="isAllDay"
+					:count="displayAlarm.relativeAmountAllDay"
+					:unit="displayAlarm.relativeUnitAllDay"
+					:disabled="false"
+					class="time-unit-select"
+					@change="changeRelativeUnitAllDay" />
+			</div>
+			<div class="property-alarm-item__edit--all-day__time">
+				<span class="property-alarm-item__edit--all-day__time__before-at-label">
+					{{ $t('calendar', 'before at') }}
+				</span>
+				<TimePicker
+					:date="relativeAllDayDate"
+					@change="changeRelativeHourMinuteAllDay" />
+			</div>
+		</div>
+		<div class="property-alarm-item__options">
+			<Actions
+				:open="showMenu"
+				@update:open="(open) => showMenu = open">
+				<ActionRadio
+					:name="alarmTypeName"
+					value="DISPLAY"
+					:modelValue="alarm.action"
+					@update:modelValue="changeType('DISPLAY')">
+					{{ $t('calendar', 'Notification') }}
+				</ActionRadio>
+				<ActionRadio
+					:name="alarmTypeName"
+					value="EMAIL"
+					:modelValue="alarm.action"
+					@update:modelValue="changeType('EMAIL')">
+					{{ $t('calendar', 'Email') }}
+				</ActionRadio>
+
+				<ActionSeparator />
+
+				<ActionButton
+					v-if="!isEditing"
+					@click.stop="toggleEditAlarm">
+					<template #icon>
+						<Pencil :size="20" decorative />
+					</template>
+					{{ $t('calendar', 'Edit time') }}
+				</ActionButton>
+				<ActionButton
+					v-if="isEditing"
+					@click="toggleEditAlarm">
+					<template #icon>
+						<Check :size="20" decorative />
+					</template>
+					{{ $t('calendar', 'Save time') }}
+				</ActionButton>
+
+				<ActionButton @click="removeAlarm">
+					<template #icon>
+						<Delete :size="20" decorative />
+					</template>
+					{{ $t('calendar', 'Remove reminder') }}
+				</ActionButton>
+			</Actions>
+		</div>
+	</div>
+</template>
+
+<script>
+import {
+	NcActionButton as ActionButton,
+	NcActionRadio as ActionRadio,
+	NcActions as Actions,
+	NcActionSeparator as ActionSeparator,
+	NcTextField,
+} from '@nextcloud/vue'
+import { mapState, mapStores } from 'pinia'
+import Check from 'vue-material-design-icons/CheckOutline.vue'
+import Pencil from 'vue-material-design-icons/PencilOutline.vue'
+import Delete from 'vue-material-design-icons/TrashCanOutline.vue'
+import TimePicker from '../../Shared/TimePicker.vue'
+import AlarmTimeUnitSelect from '../../Editor/Alarm/AlarmTimeUnitSelect.vue'
+import formatAlarm from '../../../filters/alarmFormat.js'
+import useSettingsStore from '../../../store/settings.js'
+import { alarmObjectToTrigger, triggerToAlarmObject } from '../../../utils/defaultCalendarAlarms.js'
+
+export default {
+	name: 'DefaultAlarmsListItem',
+	components: {
+		TimePicker,
+		AlarmTimeUnitSelect,
+		Actions,
+		ActionButton,
+		ActionRadio,
+		ActionSeparator,
+		NcTextField,
+		Check,
+		Delete,
+		Pencil,
+	},
+
+	props: {
+		alarm: {
+			type: Object,
+			required: true,
+		},
+
+		isAllDay: {
+			type: Boolean,
+			required: true,
+		},
+
+		showIcon: {
+			type: Boolean,
+			default: false,
+		},
+	},
+
+	data() {
+		return {
+			isEditing: false,
+			showMenu: false,
+		}
+	},
+
+	computed: {
+		...mapStores(useSettingsStore),
+		...mapState(useSettingsStore, {
+			locale: 'momentLocale',
+		}),
+
+		currentUserTimezone() {
+			return this.settingsStore.getResolvedTimezone
+		},
+
+		displayAlarm() {
+			return triggerToAlarmObject(this.alarm.trigger)
+		},
+
+		alarmTypeName() {
+			return this.$.uid + '-radio-type-name'
+		},
+
+		relativeAllDayDate() {
+			const date = new Date()
+			date.setHours(this.displayAlarm.relativeHoursAllDay)
+			date.setMinutes(this.displayAlarm.relativeMinutesAllDay)
+
+			return date
+		},
+	},
+
+	methods: {
+		formatAlarm,
+
+		emitUpdate(trigger, action = this.alarm.action) {
+			this.$emit('updateAlarm', {
+				trigger,
+				action,
+			})
+		},
+
+		toggleEditAlarm() {
+			this.isEditing = !this.isEditing
+			if (this.isEditing) {
+				this.showMenu = false
+			}
+		},
+
+		changeType(type) {
+			this.$emit('updateAlarm', {
+				trigger: this.alarm.trigger,
+				action: type,
+			})
+			this.showMenu = false
+		},
+
+		removeAlarm() {
+			this.$emit('removeAlarm')
+			this.showMenu = false
+		},
+
+		changeRelativeAmountTimed(value) {
+			const selectedValue = parseInt(value, 10)
+			if (selectedValue >= 0 && selectedValue <= 3600) {
+				const alarmObject = { ...this.displayAlarm, relativeAmountTimed: selectedValue }
+				this.emitUpdate(alarmObjectToTrigger(alarmObject, false))
+			}
+		},
+
+		changeRelativeUnitTimed(unit) {
+			const alarmObject = { ...this.displayAlarm, relativeUnitTimed: unit }
+			this.emitUpdate(alarmObjectToTrigger(alarmObject, false))
+		},
+
+		changeRelativeAmountAllDay(value) {
+			const selectedValue = parseInt(value, 10)
+			if (selectedValue >= 0 && selectedValue <= 3600) {
+				const alarmObject = { ...this.displayAlarm, relativeAmountAllDay: selectedValue }
+				this.emitUpdate(alarmObjectToTrigger(alarmObject, true))
+			}
+		},
+
+		changeRelativeUnitAllDay(unit) {
+			const alarmObject = { ...this.displayAlarm, relativeUnitAllDay: unit }
+			this.emitUpdate(alarmObjectToTrigger(alarmObject, true))
+		},
+
+		changeRelativeHourMinuteAllDay(date) {
+			const alarmObject = {
+				...this.displayAlarm,
+				relativeHoursAllDay: date.getHours(),
+				relativeMinutesAllDay: date.getMinutes(),
+			}
+			this.emitUpdate(alarmObjectToTrigger(alarmObject, true))
+		},
+	},
+}
+</script>

--- a/src/components/AppNavigation/EditCalendarModal/DefaultAlarmsListNew.vue
+++ b/src/components/AppNavigation/EditCalendarModal/DefaultAlarmsListNew.vue
@@ -1,0 +1,87 @@
+<!--
+  - SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+  - SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
+<template>
+	<PropertySelect
+		:propModel="propModel"
+		:isReadOnly="disabled"
+		:value="null"
+		:showIcon="showIcon"
+		class="property-alarm-new"
+		@update:value="addReminderFromSelect" />
+</template>
+
+<script>
+import { mapState, mapStores } from 'pinia'
+import PropertySelect from '../../Editor/Properties/PropertySelect.vue'
+import { getDefaultAlarms } from '../../../defaults/defaultAlarmProvider.js'
+import alarmFormat from '../../../filters/alarmFormat.js'
+import useSettingsStore from '../../../store/settings.js'
+import { triggerToAlarmObject } from '../../../utils/defaultCalendarAlarms.js'
+
+export default {
+	name: 'DefaultAlarmsListNew',
+	components: {
+		PropertySelect,
+	},
+
+	props: {
+		isAllDay: {
+			type: Boolean,
+			required: true,
+		},
+
+		showIcon: {
+			type: Boolean,
+			required: true,
+		},
+
+		disabled: {
+			type: Boolean,
+			default: false,
+		},
+	},
+
+	computed: {
+		...mapState(useSettingsStore, {
+			locale: 'momentLocale',
+		}),
+
+		...mapStores(useSettingsStore),
+		currentUserTimezone() {
+			return this.settingsStore.getResolvedTimezone
+		},
+
+		options() {
+			return getDefaultAlarms(this.isAllDay).map((defaultAlarm) => {
+				const alarmObject = triggerToAlarmObject(defaultAlarm)
+
+				return {
+					value: defaultAlarm,
+					label: alarmFormat(alarmObject, this.isAllDay, this.currentUserTimezone, this.locale),
+				}
+			})
+		},
+
+		propModel() {
+			return {
+				options: this.options,
+				icon: 'Bell',
+				placeholder: this.$t('calendar', 'Add reminder'),
+				readableName: this.$t('calendar', 'Add reminder'),
+			}
+		},
+	},
+
+	methods: {
+		addReminderFromSelect(value) {
+			this.$emit('addAlarm', {
+				trigger: value,
+				action: 'DISPLAY',
+			})
+		},
+	},
+}
+</script>

--- a/src/models/calendar.js
+++ b/src/models/calendar.js
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 import { detectColor, uidToHexColor } from '../utils/color.js'
+import { normalizeFromDav } from '../utils/defaultCalendarAlarms.js'
 import { isAfterVersion } from '../utils/nextcloudVersion.ts'
 import { mapDavShareeToCalendarShareObject } from './calendarShare.js'
 
@@ -72,6 +73,9 @@ function getDefaultCalendarObject(props = {}) {
 		defaultAlarmPartDay: null,
 		// Default alarm/reminder for full-day events in seconds (null if disabled)
 		defaultAlarmFullDay: null,
+		// Default alarm lists for part-day / full-day events (NC35+)
+		defaultAlarmsPartDay: [],
+		defaultAlarmsFullDay: [],
 		...props,
 	}
 }
@@ -117,6 +121,12 @@ function mapDavCollectionToCalendar(calendar, currentUserPrincipal) {
 	const defaultAlarmPartDay = isAfterVersion(34) && calendar.defaultAlarmPartDay !== undefined ? calendar.defaultAlarmPartDay : null
 	// Default alarm for full-day events in this calendar (in seconds)
 	const defaultAlarmFullDay = isAfterVersion(34) && calendar.defaultAlarmFullDay !== undefined ? calendar.defaultAlarmFullDay : null
+	const defaultAlarmsPartDay = isAfterVersion(35)
+		? normalizeFromDav(calendar.defaultAlarmsPartDay, defaultAlarmPartDay)
+		: []
+	const defaultAlarmsFullDay = isAfterVersion(35)
+		? normalizeFromDav(calendar.defaultAlarmsFullDay, defaultAlarmFullDay)
+		: []
 
 	let isSharedWithMe = false
 	if (!currentUserPrincipal) {
@@ -177,6 +187,8 @@ function mapDavCollectionToCalendar(calendar, currentUserPrincipal) {
 		transparency,
 		defaultAlarmPartDay,
 		defaultAlarmFullDay,
+		defaultAlarmsPartDay,
+		defaultAlarmsFullDay,
 		dav: calendar,
 	})
 }

--- a/src/store/calendars.js
+++ b/src/store/calendars.js
@@ -26,6 +26,7 @@ import {
 import getTimezoneManager from '../services/timezoneDataProviderService.js'
 import { uidToHexColor } from '../utils/color.js'
 import { dateFactory, getUnixTimestampFromDate } from '../utils/date.js'
+import { defaultAlarmsEqual, toDavPayload } from '../utils/defaultCalendarAlarms.js'
 import logger from '../utils/logger.js'
 import { isAfterVersion } from '../utils/nextcloudVersion.ts'
 import useCalendarObjectsStore from './calendarObjects.js'
@@ -607,11 +608,22 @@ export default defineStore('calendars', {
 		 *
 		 * @param {object} data destructuring object
 		 * @param {object} data.calendar the calendar to modify
-		 * @param {number|null} data.defaultAlarmPartDay the new default alarm for part-day events in seconds (or null to disable)
-		 * @param {number|null} data.defaultAlarmFullDay the new default alarm for full-day events in seconds (or null to disable)
+		 * @param {number|null} [data.defaultAlarmPartDay] legacy default alarm for part-day events in seconds
+		 * @param {number|null} [data.defaultAlarmFullDay] legacy default alarm for full-day events in seconds
+		 * @param {Array|null} [data.defaultAlarmsPartDay] plural default alarms for part-day events (NC35+)
+		 * @param {Array|null} [data.defaultAlarmsFullDay] plural default alarms for full-day events (NC35+)
 		 * @return {Promise}
 		 */
-		async changeCalendarDefaultAlarms({ calendar, defaultAlarmPartDay, defaultAlarmFullDay }) {
+		async changeCalendarDefaultAlarms({ calendar, defaultAlarmPartDay, defaultAlarmFullDay, defaultAlarmsPartDay, defaultAlarmsFullDay }) {
+			if (isAfterVersion(35) && (defaultAlarmsPartDay !== undefined || defaultAlarmsFullDay !== undefined)) {
+				await this.changeCalendarPluralDefaultAlarms({
+					calendar,
+					defaultAlarmsPartDay: defaultAlarmsPartDay ?? [],
+					defaultAlarmsFullDay: defaultAlarmsFullDay ?? [],
+				})
+				return
+			}
+
 			if (!isAfterVersion(34)) {
 				return
 			}
@@ -637,6 +649,49 @@ export default defineStore('calendars', {
 			}
 			if (fullDayChanged) {
 				this.calendarsById[calendar.id].defaultAlarmFullDay = defaultAlarmFullDay
+			}
+		},
+
+		/**
+		 * Change plural default alarm lists (NC35+)
+		 *
+		 * @param {object} data destructuring object
+		 * @param {object} data.calendar the calendar to modify
+		 * @param {Array} data.defaultAlarmsPartDay
+		 * @param {Array} data.defaultAlarmsFullDay
+		 * @return {Promise}
+		 */
+		async changeCalendarPluralDefaultAlarms({ calendar, defaultAlarmsPartDay, defaultAlarmsFullDay }) {
+			if (!isAfterVersion(35)) {
+				return
+			}
+
+			const partDayPayload = toDavPayload(defaultAlarmsPartDay)
+			const fullDayPayload = toDavPayload(defaultAlarmsFullDay)
+
+			const currentPartDay = calendar.defaultAlarmsPartDay ?? []
+			const currentFullDay = calendar.defaultAlarmsFullDay ?? []
+			const partDayChanged = !defaultAlarmsEqual(currentPartDay, defaultAlarmsPartDay)
+			const fullDayChanged = !defaultAlarmsEqual(currentFullDay, defaultAlarmsFullDay)
+
+			if (!partDayChanged && !fullDayChanged) {
+				return
+			}
+
+			if (partDayChanged) {
+				calendar.dav.defaultAlarmsPartDay = partDayPayload
+			}
+			if (fullDayChanged) {
+				calendar.dav.defaultAlarmsFullDay = fullDayPayload
+			}
+
+			await calendar.dav.update()
+
+			if (partDayChanged) {
+				this.calendarsById[calendar.id].defaultAlarmsPartDay = [...defaultAlarmsPartDay]
+			}
+			if (fullDayChanged) {
+				this.calendarsById[calendar.id].defaultAlarmsFullDay = [...defaultAlarmsFullDay]
 			}
 		},
 

--- a/src/types/calendar.ts
+++ b/src/types/calendar.ts
@@ -33,6 +33,13 @@ export interface CalendarShareInterface {
  */
 export type CalendarTransparency = 'opaque' | 'transparent'
 
+export type DefaultCalendarAlarmAction = 'DISPLAY' | 'EMAIL'
+
+export type DefaultCalendarAlarm = {
+	trigger: number
+	action: DefaultCalendarAlarmAction
+}
+
 /**
  * Represents a calendar collection as used throughout the calendar app.
  *
@@ -101,6 +108,10 @@ export interface CalendarInterface {
 	defaultAlarmPartDay: number | null
 	/** Default alarm/reminder for full-day events in seconds (null if disabled) */
 	defaultAlarmFullDay: number | null
+	/** Default alarms for part-day events (NC35+ plural CalDAV props) */
+	defaultAlarmsPartDay: DefaultCalendarAlarm[]
+	/** Default alarms for full-day events (NC35+ plural CalDAV props) */
+	defaultAlarmsFullDay: DefaultCalendarAlarm[]
 }
 
 /**

--- a/src/utils/alarms.js
+++ b/src/utils/alarms.js
@@ -204,11 +204,35 @@ export function getTotalSecondsFromAmountHourMinutesAndUnitForAllDayEvents(amoun
 }
 
 /**
- * Updates or creates the default alarm for an event.
- * When no default alarm exists yet, one is only created for newly constructed instances
+ * Preferred resolver for default alarms when creating or updating an event.
+ * On NC35+, returns the normalized plural lists on the calendar model (DISPLAY/EMAIL).
+ * On NC34, wraps the legacy single-int reminder as one DISPLAY alarm.
+ *
+ * @param {object} data The destructuring object
+ * @param {object|undefined} data.calendar The selected calendar
+ * @param {boolean} data.isAllDay Whether the event is all-day
+ * @return {import('../types/calendar.ts').DefaultCalendarAlarm[]}
+ */
+export function getDefaultAlarmsForEvent({ calendar, isAllDay }) {
+	if (isAfterVersion(35) && calendar) {
+		const alarms = isAllDay ? calendar.defaultAlarmsFullDay : calendar.defaultAlarmsPartDay
+		return Array.isArray(alarms) ? [...alarms] : []
+	}
+
+	const legacyReminder = getDefaultReminderForEvent({ calendar, isAllDay })
+	if (legacyReminder === null || isNaN(legacyReminder)) {
+		return []
+	}
+
+	return [{ trigger: legacyReminder, action: 'DISPLAY' }]
+}
+
+/**
+ * Updates or creates the default alarms for an event.
+ * When no default alarms exist yet, they are only created for newly constructed instances
  * passed in by the caller.
  *
- * @param {string} calendarId The ID of the calendar to update the default alarm from
+ * @param {string} calendarId The ID of the calendar to update the default alarms from
  * @param {object} calendarObjectInstance The calendar object instance to update
  */
 export function updateDefaultAlarm(calendarId, calendarObjectInstance) {
@@ -221,47 +245,61 @@ export function updateDefaultAlarm(calendarId, calendarObjectInstance) {
 		return
 	}
 
-	const defaultReminder = getDefaultReminderForEvent({
+	const defaultAlarms = getDefaultAlarmsForEvent({
 		calendar,
 		isAllDay: calendarObjectInstance.isAllDay,
 	})
 
-	if (defaultReminder === null || isNaN(defaultReminder)) {
+	if (defaultAlarms.length === 0) {
 		return
 	}
 
-	// Find the existing default alarm (if any)
-	const existingDefaultAlarm = calendarObjectInstance.alarms.find((alarm) => alarm.alarmComponent.getFirstPropertyFirstValue('X-NC-DEFAULT-ALARM'))
-	if (existingDefaultAlarm) {
-		calendarObjectInstanceStore.removeAlarmFromCalendarObjectInstance({
-			calendarObjectInstance,
-			alarm: existingDefaultAlarm,
-		})
+	const existingDefaultAlarms = calendarObjectInstance.alarms.filter(
+		(alarm) => alarm.alarmComponent.getFirstPropertyFirstValue('X-NC-DEFAULT-ALARM'),
+	)
 
-		calendarObjectInstanceStore.addAlarmToCalendarObjectInstance({
-			calendarObjectInstance,
-			type: 'DISPLAY',
-			totalSeconds: defaultReminder,
-			isDefault: true,
-		})
+	if (existingDefaultAlarms.length > 0) {
+		for (const alarm of existingDefaultAlarms) {
+			calendarObjectInstanceStore.removeAlarmFromCalendarObjectInstance({
+				calendarObjectInstance,
+				alarm,
+			})
+		}
+
+		for (const { trigger, action } of defaultAlarms) {
+			calendarObjectInstanceStore.addAlarmToCalendarObjectInstance({
+				calendarObjectInstance,
+				type: action,
+				totalSeconds: trigger,
+				isDefault: true,
+			})
+		}
 		return
 	}
 
-	// Only create a missing default alarm for newly constructed event instances.
-	if (calendarObjectInstance !== calendarObjectInstanceStore.calendarObjectInstance) {
-		calendarObjectInstanceStore.addAlarmToCalendarObjectInstance({
-			calendarObjectInstance,
-			type: 'DISPLAY',
-			totalSeconds: defaultReminder,
-			isDefault: true,
-		})
+	// Only create missing default alarms for newly constructed event instances,
+	// or the active editor instance while composing a new unsaved event (calendar switch).
+	const isPreStoreInstance = calendarObjectInstance !== calendarObjectInstanceStore.calendarObjectInstance
+	const isNewEditorInstance = calendarObjectInstanceStore.isNew
+		&& calendarObjectInstance === calendarObjectInstanceStore.calendarObjectInstance
+
+	if (isPreStoreInstance || isNewEditorInstance) {
+		for (const { trigger, action } of defaultAlarms) {
+			calendarObjectInstanceStore.addAlarmToCalendarObjectInstance({
+				calendarObjectInstance,
+				type: action,
+				totalSeconds: trigger,
+				isDefault: true,
+			})
+		}
 	}
 }
 
 /**
- * Resolves the default reminder for an event.
- * Calendar-specific defaults win, then the global part/full-day defaults,
- * then the legacy global defaultReminder for backwards compatibility.
+ * Legacy resolver: single default reminder in seconds (DISPLAY only).
+ * Reads calendar DAV int defaults (NC34+) then global user settings.
+ *
+ * @deprecated Use {@link getDefaultAlarmsForEvent} instead. Kept exported for backwards compatibility.
  *
  * @param {object} data The destructuring object
  * @param {object|undefined} data.calendar The selected calendar

--- a/src/utils/defaultCalendarAlarms.js
+++ b/src/utils/defaultCalendarAlarms.js
@@ -1,0 +1,122 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import {
+	getAmountAndUnitForTimedEvents,
+	getAmountHoursMinutesAndUnitForAllDayEvents,
+	getTotalSecondsFromAmountAndUnitForTimedEvents,
+	getTotalSecondsFromAmountHourMinutesAndUnitForAllDayEvents,
+} from './alarms.js'
+
+/** @typedef {import('../types/calendar.ts').DefaultCalendarAlarm} DefaultCalendarAlarm */
+/** @typedef {import('../types/calendar.ts').DefaultCalendarAlarmAction} DefaultCalendarAlarmAction */
+
+const ALLOWED_ACTIONS = ['DISPLAY', 'EMAIL']
+
+/**
+ * @param {number} time
+ * @return {object}
+ */
+export function triggerToAlarmObject(time) {
+	const timedData = getAmountAndUnitForTimedEvents(time)
+	const allDayData = getAmountHoursMinutesAndUnitForAllDayEvents(time)
+
+	return {
+		isRelative: true,
+		absoluteDate: null,
+		absoluteTimezoneId: null,
+		relativeIsBefore: time < 0,
+		relativeIsRelatedToStart: true,
+		relativeUnitTimed: timedData.unit,
+		relativeAmountTimed: timedData.amount,
+		relativeUnitAllDay: allDayData.unit,
+		relativeAmountAllDay: allDayData.amount,
+		relativeHoursAllDay: allDayData.hours,
+		relativeMinutesAllDay: allDayData.minutes,
+		relativeTrigger: time,
+	}
+}
+
+/**
+ * @param {object} alarmObject
+ * @param {boolean} isAllDay
+ * @return {number}
+ */
+export function alarmObjectToTrigger(alarmObject, isAllDay) {
+	if (isAllDay) {
+		return getTotalSecondsFromAmountHourMinutesAndUnitForAllDayEvents(
+			alarmObject.relativeAmountAllDay,
+			alarmObject.relativeHoursAllDay,
+			alarmObject.relativeMinutesAllDay,
+			alarmObject.relativeUnitAllDay,
+		)
+	}
+
+	return getTotalSecondsFromAmountAndUnitForTimedEvents(
+		alarmObject.relativeAmountTimed,
+		alarmObject.relativeUnitTimed,
+		alarmObject.relativeIsBefore,
+	)
+}
+
+/**
+ * @param {Array|null|undefined} plural
+ * @param {number|null|undefined} legacyInt
+ * @return {DefaultCalendarAlarm[]}
+ */
+export function normalizeFromDav(plural, legacyInt) {
+	if (Array.isArray(plural) && plural.length > 0) {
+		return plural
+			.filter((entry) => entry && typeof entry.trigger === 'number' && typeof entry.action === 'string')
+			.map((entry) => ({
+				trigger: entry.trigger,
+				action: /** @type {DefaultCalendarAlarmAction} */ (entry.action),
+			}))
+	}
+
+	if (legacyInt !== null && legacyInt !== undefined) {
+		return [{ trigger: legacyInt, action: 'DISPLAY' }]
+	}
+
+	return []
+}
+
+/**
+ * @param {DefaultCalendarAlarm[]|null|undefined} alarms
+ * @return {DefaultCalendarAlarm[]|null}
+ */
+export function toDavPayload(alarms) {
+	if (!Array.isArray(alarms) || alarms.length === 0) {
+		return null
+	}
+
+	const normalized = alarms.map((alarm) => {
+		if (!ALLOWED_ACTIONS.includes(alarm.action)) {
+			throw new Error('Default alarm action must be DISPLAY or EMAIL')
+		}
+
+		return {
+			trigger: alarm.trigger,
+			action: alarm.action,
+		}
+	})
+
+	return normalized
+}
+
+/**
+ * @param {DefaultCalendarAlarm[]} alarms
+ * @return {boolean}
+ */
+export function defaultAlarmsEqual(alarmsA, alarmsB) {
+	if (alarmsA.length !== alarmsB.length) {
+		return false
+	}
+
+	return alarmsA.every((alarm, index) => {
+		const other = alarmsB[index]
+		return alarm.trigger === other.trigger && alarm.action === other.action
+	})
+}

--- a/tests/javascript/unit/models/calendar.test.js
+++ b/tests/javascript/unit/models/calendar.test.js
@@ -45,6 +45,8 @@ describe('Test suite: Calendar model (models/calendar.js)', () => {
 			transparency: 'opaque',
 			defaultAlarmFullDay: null,
 			defaultAlarmPartDay: null,
+			defaultAlarmsFullDay: [],
+			defaultAlarmsPartDay: [],
 			delegatorUrl: '',
 		})
 	})
@@ -83,6 +85,8 @@ describe('Test suite: Calendar model (models/calendar.js)', () => {
 			transparency: 'opaque',
 			defaultAlarmFullDay: null,
 			defaultAlarmPartDay: null,
+			defaultAlarmsFullDay: [],
+			defaultAlarmsPartDay: [],
 			delegatorUrl: '',
 		})
 	})
@@ -136,6 +140,8 @@ describe('Test suite: Calendar model (models/calendar.js)', () => {
 			loading: false,
 			defaultAlarmFullDay: null,
 			defaultAlarmPartDay: null,
+			defaultAlarmsFullDay: [],
+			defaultAlarmsPartDay: [],
 			delegatorUrl: '',
 		})
 
@@ -191,6 +197,8 @@ describe('Test suite: Calendar model (models/calendar.js)', () => {
 			loading: false,
 			defaultAlarmFullDay: null,
 			defaultAlarmPartDay: null,
+			defaultAlarmsFullDay: [],
+			defaultAlarmsPartDay: [],
 			delegatorUrl: '',
 		})
 
@@ -244,6 +252,8 @@ describe('Test suite: Calendar model (models/calendar.js)', () => {
 			loading: false,
 			defaultAlarmFullDay: null,
 			defaultAlarmPartDay: null,
+			defaultAlarmsFullDay: [],
+			defaultAlarmsPartDay: [],
 			delegatorUrl: '',
 		})
 
@@ -297,6 +307,8 @@ describe('Test suite: Calendar model (models/calendar.js)', () => {
 			loading: false,
 			defaultAlarmFullDay: null,
 			defaultAlarmPartDay: null,
+			defaultAlarmsFullDay: [],
+			defaultAlarmsPartDay: [],
 			delegatorUrl: '',
 		})
 
@@ -350,6 +362,8 @@ describe('Test suite: Calendar model (models/calendar.js)', () => {
 			loading: false,
 			defaultAlarmFullDay: null,
 			defaultAlarmPartDay: null,
+			defaultAlarmsFullDay: [],
+			defaultAlarmsPartDay: [],
 			delegatorUrl: '',
 		})
 
@@ -403,6 +417,8 @@ describe('Test suite: Calendar model (models/calendar.js)', () => {
 			loading: false,
 			defaultAlarmFullDay: null,
 			defaultAlarmPartDay: null,
+			defaultAlarmsFullDay: [],
+			defaultAlarmsPartDay: [],
 			delegatorUrl: '',
 		})
 
@@ -456,6 +472,8 @@ describe('Test suite: Calendar model (models/calendar.js)', () => {
 			loading: false,
 			defaultAlarmFullDay: null,
 			defaultAlarmPartDay: null,
+			defaultAlarmsFullDay: [],
+			defaultAlarmsPartDay: [],
 			delegatorUrl: '',
 		})
 
@@ -509,6 +527,8 @@ describe('Test suite: Calendar model (models/calendar.js)', () => {
 			loading: false,
 			defaultAlarmFullDay: null,
 			defaultAlarmPartDay: null,
+			defaultAlarmsFullDay: [],
+			defaultAlarmsPartDay: [],
 			delegatorUrl: '',
 		})
 
@@ -618,6 +638,8 @@ describe('Test suite: Calendar model (models/calendar.js)', () => {
 			loading: false,
 			defaultAlarmFullDay: null,
 			defaultAlarmPartDay: null,
+			defaultAlarmsFullDay: [],
+			defaultAlarmsPartDay: [],
 			delegatorUrl: '',
 		})
 
@@ -743,6 +765,8 @@ describe('Test suite: Calendar model (models/calendar.js)', () => {
 			loading: false,
 			defaultAlarmFullDay: null,
 			defaultAlarmPartDay: null,
+			defaultAlarmsFullDay: [],
+			defaultAlarmsPartDay: [],
 			delegatorUrl: '',
 		})
 
@@ -797,6 +821,8 @@ describe('Test suite: Calendar model (models/calendar.js)', () => {
 			loading: false,
 			defaultAlarmFullDay: null,
 			defaultAlarmPartDay: null,
+			defaultAlarmsFullDay: [],
+			defaultAlarmsPartDay: [],
 			delegatorUrl: '',
 		})
 	})

--- a/tests/javascript/unit/utils/alarms.test.js
+++ b/tests/javascript/unit/utils/alarms.test.js
@@ -8,9 +8,19 @@ import {
 	getAmountAndUnitForTimedEvents,
 	getTotalSecondsFromAmountAndUnitForTimedEvents,
 	getTotalSecondsFromAmountHourMinutesAndUnitForAllDayEvents,
+	getDefaultAlarmsForEvent,
+	getDefaultReminderForEvent,
+	updateDefaultAlarm,
 	updateAlarms,
 } from '../../../../src/utils/alarms.js'
 import { getParserManager } from '@nextcloud/calendar-js'
+import useCalendarObjectInstanceStore from '../../../../src/store/calendarObjectInstance.js'
+import useCalendarsStore from '../../../../src/store/calendars.js'
+import useSettingsStore from '../../../../src/store/settings.js'
+import { setActivePinia, createPinia } from 'pinia'
+
+vi.mock('../../../../src/store/calendarObjectInstance.js')
+vi.mock('../../../../src/store/calendars.js')
 
 /**
  * Parse an ICS string and return the first event component.
@@ -51,6 +61,224 @@ function eventICS(alarms, attendees = '') {
 }
 
 describe('utils/alarms test suite', () => {
+
+	beforeEach(() => {
+		setActivePinia(createPinia())
+		globalThis.OC.config.version = '34.0.0'
+		vi.clearAllMocks()
+	})
+
+	function setupUpdateDefaultAlarmStores({
+		isNew,
+		sameInstance,
+		calendar,
+		calendarObjectInstance,
+	}) {
+		const addAlarm = vi.fn()
+		const removeAlarm = vi.fn()
+		const calendarObjectInstanceStore = {
+			isNew,
+			calendarObjectInstance: sameInstance ? calendarObjectInstance : {},
+			addAlarmToCalendarObjectInstance: addAlarm,
+			removeAlarmFromCalendarObjectInstance: removeAlarm,
+		}
+		useCalendarObjectInstanceStore.mockReturnValue(calendarObjectInstanceStore)
+		useCalendarsStore.mockReturnValue({
+			getCalendarById: vi.fn(() => calendar),
+		})
+		return { addAlarm, removeAlarm }
+	}
+
+	describe('getDefaultAlarmsForEvent', () => {
+		it('returns plural part-day alarms on NC35+', () => {
+			globalThis.OC.config.version = '35.0.0'
+
+			const calendar = {
+				defaultAlarmsPartDay: [
+					{ trigger: -900, action: 'DISPLAY' },
+					{ trigger: -3600, action: 'EMAIL' },
+				],
+				defaultAlarmsFullDay: [],
+				dav: {},
+			}
+
+			expect(getDefaultAlarmsForEvent({ calendar, isAllDay: false })).toEqual([
+				{ trigger: -900, action: 'DISPLAY' },
+				{ trigger: -3600, action: 'EMAIL' },
+			])
+		})
+
+		it('returns plural full-day alarms on NC35+', () => {
+			globalThis.OC.config.version = '35.0.0'
+
+			const calendar = {
+				defaultAlarmsPartDay: [],
+				defaultAlarmsFullDay: [
+					{ trigger: -32400, action: 'DISPLAY' },
+				],
+				dav: {},
+			}
+
+			expect(getDefaultAlarmsForEvent({ calendar, isAllDay: true })).toEqual([
+				{ trigger: -32400, action: 'DISPLAY' },
+			])
+		})
+
+		it('returns empty list on NC35+ when calendar defaults are disabled', () => {
+			globalThis.OC.config.version = '35.0.0'
+
+			const calendar = {
+				defaultAlarmsPartDay: [],
+				defaultAlarmsFullDay: [],
+				dav: {},
+			}
+
+			expect(getDefaultAlarmsForEvent({ calendar, isAllDay: false })).toEqual([])
+		})
+
+		it('falls back to a single DISPLAY alarm from calendar DAV defaults on NC34', () => {
+			const calendar = {
+				defaultAlarmsPartDay: [],
+				defaultAlarmsFullDay: [],
+				dav: {
+					defaultAlarmPartDay: -900,
+				},
+			}
+
+			expect(getDefaultAlarmsForEvent({ calendar, isAllDay: false })).toEqual([
+				{ trigger: -900, action: 'DISPLAY' },
+			])
+		})
+
+		it('falls back to global settings when calendar has no defaults on NC34', () => {
+			const settingsStore = useSettingsStore()
+			settingsStore.defaultReminderPartDay = '-1800'
+
+			expect(getDefaultAlarmsForEvent({ calendar: undefined, isAllDay: false })).toEqual([
+				{ trigger: -1800, action: 'DISPLAY' },
+			])
+		})
+	})
+
+	describe('updateDefaultAlarm', () => {
+		it('applies NC34 legacy defaults when switching calendar on a new unsaved event', () => {
+			const calendarObjectInstance = { isAllDay: false, alarms: [] }
+			const calendar = {
+				defaultAlarmsPartDay: [],
+				defaultAlarmsFullDay: [],
+				dav: { defaultAlarmPartDay: -900 },
+			}
+			const { addAlarm } = setupUpdateDefaultAlarmStores({
+				isNew: true,
+				sameInstance: true,
+				calendar,
+				calendarObjectInstance,
+			})
+
+			updateDefaultAlarm('test1', calendarObjectInstance)
+
+			expect(addAlarm).toHaveBeenCalledWith({
+				calendarObjectInstance,
+				type: 'DISPLAY',
+				totalSeconds: -900,
+				isDefault: true,
+			})
+		})
+
+		it('applies NC35+ plural defaults when switching calendar on a new unsaved event', () => {
+			globalThis.OC.config.version = '35.0.0'
+
+			const calendarObjectInstance = { isAllDay: false, alarms: [] }
+			const calendar = {
+				defaultAlarmsPartDay: [
+					{ trigger: -900, action: 'DISPLAY' },
+					{ trigger: -3600, action: 'EMAIL' },
+				],
+				defaultAlarmsFullDay: [],
+				dav: {},
+			}
+			const { addAlarm } = setupUpdateDefaultAlarmStores({
+				isNew: true,
+				sameInstance: true,
+				calendar,
+				calendarObjectInstance,
+			})
+
+			updateDefaultAlarm('test1', calendarObjectInstance)
+
+			expect(addAlarm).toHaveBeenCalledTimes(2)
+			expect(addAlarm).toHaveBeenNthCalledWith(1, {
+				calendarObjectInstance,
+				type: 'DISPLAY',
+				totalSeconds: -900,
+				isDefault: true,
+			})
+			expect(addAlarm).toHaveBeenNthCalledWith(2, {
+				calendarObjectInstance,
+				type: 'EMAIL',
+				totalSeconds: -3600,
+				isDefault: true,
+			})
+		})
+
+		it('does not add defaults when editing an existing saved event', () => {
+			const calendarObjectInstance = { isAllDay: false, alarms: [] }
+			const calendar = {
+				defaultAlarmsPartDay: [],
+				defaultAlarmsFullDay: [],
+				dav: { defaultAlarmPartDay: -900 },
+			}
+			const { addAlarm } = setupUpdateDefaultAlarmStores({
+				isNew: false,
+				sameInstance: true,
+				calendar,
+				calendarObjectInstance,
+			})
+
+			updateDefaultAlarm('test1', calendarObjectInstance)
+
+			expect(addAlarm).not.toHaveBeenCalled()
+		})
+
+		it('still applies defaults for a pre-store constructed instance', () => {
+			const calendarObjectInstance = { isAllDay: false, alarms: [] }
+			const calendar = {
+				defaultAlarmsPartDay: [],
+				defaultAlarmsFullDay: [],
+				dav: { defaultAlarmPartDay: -900 },
+			}
+			const { addAlarm } = setupUpdateDefaultAlarmStores({
+				isNew: false,
+				sameInstance: false,
+				calendar,
+				calendarObjectInstance,
+			})
+
+			updateDefaultAlarm('test1', calendarObjectInstance)
+
+			expect(addAlarm).toHaveBeenCalledWith({
+				calendarObjectInstance,
+				type: 'DISPLAY',
+				totalSeconds: -900,
+				isDefault: true,
+			})
+		})
+	})
+
+	describe('getDefaultReminderForEvent', () => {
+		it('prefers calendar DAV defaults over global settings on NC34', () => {
+			const settingsStore = useSettingsStore()
+			settingsStore.defaultReminderPartDay = '-1800'
+
+			const calendar = {
+				dav: {
+					defaultAlarmPartDay: -900,
+				},
+			}
+
+			expect(getDefaultReminderForEvent({ calendar, isAllDay: false })).toEqual(-900)
+		})
+	})
 
 	it('should return the correct factor for different units', () => {
 		expect(getFactorForAlarmUnit('seconds')).toEqual(1)

--- a/tests/javascript/unit/utils/defaultCalendarAlarms.test.js
+++ b/tests/javascript/unit/utils/defaultCalendarAlarms.test.js
@@ -1,0 +1,96 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+import {
+	defaultAlarmsEqual,
+	normalizeFromDav,
+	toDavPayload,
+	triggerToAlarmObject,
+} from '../../../../src/utils/defaultCalendarAlarms.js'
+
+describe('Test suite: defaultCalendarAlarms utils', () => {
+
+	it('should normalize plural alarms from DAV', () => {
+		expect(normalizeFromDav([
+			{ trigger: -900, action: 'DISPLAY' },
+			{ trigger: -3600, action: 'EMAIL' },
+		], null)).toEqual([
+			{ trigger: -900, action: 'DISPLAY' },
+			{ trigger: -3600, action: 'EMAIL' },
+		])
+	})
+
+	it('should fall back to legacy int when plural is empty', () => {
+		expect(normalizeFromDav([], -900)).toEqual([
+			{ trigger: -900, action: 'DISPLAY' },
+		])
+	})
+
+	it('should return empty list when neither plural nor legacy is set', () => {
+		expect(normalizeFromDav(null, null)).toEqual([])
+	})
+
+	it('should preserve all normalized alarms from DAV', () => {
+		const plural = Array.from({ length: 12 }, (_, index) => ({
+			trigger: -60 * (index + 1),
+			action: 'DISPLAY',
+		}))
+
+		expect(normalizeFromDav(plural, null)).toHaveLength(12)
+	})
+
+	it('should serialize alarms for DAV', () => {
+		expect(toDavPayload([
+			{ trigger: -900, action: 'DISPLAY' },
+			{ trigger: -3600, action: 'EMAIL' },
+		])).toEqual([
+			{ trigger: -900, action: 'DISPLAY' },
+			{ trigger: -3600, action: 'EMAIL' },
+		])
+	})
+
+	it('should return null for empty alarm lists', () => {
+		expect(toDavPayload([])).toBeNull()
+		expect(toDavPayload(null)).toBeNull()
+	})
+
+	it('should serialize large alarm lists for DAV', () => {
+		const alarms = Array.from({ length: 11 }, (_, index) => ({
+			trigger: -60 * (index + 1),
+			action: 'DISPLAY',
+		}))
+
+		expect(toDavPayload(alarms)).toHaveLength(11)
+	})
+
+	it('should reject invalid alarm actions', () => {
+		expect(() => toDavPayload([{ trigger: -900, action: 'AUDIO' }])).toThrow('Default alarm action must be DISPLAY or EMAIL')
+	})
+
+	it('should compare alarm lists for equality', () => {
+		const alarmsA = [
+			{ trigger: -900, action: 'DISPLAY' },
+			{ trigger: -3600, action: 'EMAIL' },
+		]
+		const alarmsB = [
+			{ trigger: -900, action: 'DISPLAY' },
+			{ trigger: -3600, action: 'EMAIL' },
+		]
+		const alarmsC = [
+			{ trigger: -900, action: 'EMAIL' },
+		]
+
+		expect(defaultAlarmsEqual(alarmsA, alarmsB)).toBe(true)
+		expect(defaultAlarmsEqual(alarmsA, alarmsC)).toBe(false)
+	})
+
+	it('should build a relative alarm object from a trigger', () => {
+		expect(triggerToAlarmObject(-900)).toEqual(expect.objectContaining({
+			isRelative: true,
+			relativeIsBefore: true,
+			relativeTrigger: -900,
+		}))
+	})
+
+})


### PR DESCRIPTION
This PR is hand-written (other than the commit comment below, which was edited by me), but the code changes were created by AI.

I am a novice at PHP and new to Nextcloud development so I invite scrutiny.  I noted questions about nextcloud dev conventions  below.  Everything was reviewed and tested by me with both the stable server and the new app+lib, plus the stable app and the new server.

The intent of this feature is to extend the recent default calendar reminder feature by allowing multiple reminders to be set as well as the notification type for each.  Only relative reminder intervals are supported as I didn't think absolute reminders made much sense in a template.  This requires changes in server, cdav-library, and the calendar app.  

The server revisions are backwards-compatible with the current stable app, and the app revisions are backwards-compatible with the current stable server.  In the app the UI reflects a pre-v34 server, v34 (existing defaults functionality) and v35+ (new functionality).  I'll describe server-side compatibility in the server PR.

The calendar app has a dependency on the updated cdav-library, which is not reflected in package.json as I'm not sure what the convention is for bumping these revisions in tandem.

This is related to:
https://github.com/nextcloud/cdav-library/pull/1066
https://github.com/nextcloud/server/pull/61832

Commit comment:
Add multi-alarm list editors in Edit Calendar settings for part-day and full-day default reminders, mirroring the event alarm editor pattern. Reads and writes plural CalDAV properties via update to cdav-library.

- NC34: legacy single-dropdown UI unchanged
- NC35+: DefaultAlarmsList with relative triggers and DISPLAY/EMAIL

Assisted-by: Grok:grok-4

## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
