### PR TITLE
fix(editor): keep description editable when switching browser tab

### DIFF
--- a/src/mixins/PropertyLinksMixin.js
+++ b/src/mixins/PropertyLinksMixin.js
@@ -70,6 +70,13 @@ export default {
 				// do nothing
 				return
 			}
+			// Keep the textarea open when the user merely switches to another
+			// browser tab or window. Otherwise the blur fired while the page is
+			// hidden collapses the field back to the linkified view, and the
+			// edit state (and caret position) is lost when the user returns.
+			if (hasFocus === false && document.hidden) {
+				return
+			}
 			this.textareaHasFocus = hasFocus
 		},
 	},


### PR DESCRIPTION
## Summary

Small, targeted improvement toward #7679.

The description/text field (`PropertyText.vue` + `PropertyLinksMixin.js`) toggles between a **linkified read-only view** and a **plain textarea**. Today, switching to another browser tab fires a `blur` on the textarea, which sets `textareaHasFocus = false` and collapses the field back to the linkified view. When the user comes back to the tab, their edit context (and caret position) is gone — exactly the pain described in #7679:

> This is particularly disruptive when you start editing the description and then switch to another browser tab to gather information – upon returning, the view state may have changed.

## Change

In `handleToggleTextareaFocus`, ignore the focus loss when it is caused by the page being hidden (`document.hidden`), i.e. a tab/window switch. Focus changes *within* the visible page keep the previous behaviour.

```js
if (hasFocus === false && document.hidden) {
    return
}
```

## Notes

- This does **not** implement the full `contenteditable` solution requested in #7679 — it's a low-risk fix for the most disruptive symptom (losing edits on tab switch). A `contenteditable` rework can still follow.
- No behaviour change when `linkifyLinks` is disabled, or for in-page focus moves.

## Checklist
- [x] Code style (tabs, no semicolons) matches surrounding code
- [x] `Signed-off-by` added (DCO)