### PR TITLE
fix: have both circle color and avatar in calendar selection

### DIFF
--- a/src/components/Editor/CalendarPickerHeader.vue
+++ b/src/components/Editor/CalendarPickerHeader.vue
@@ -33,7 +33,11 @@
 					:closeAfterClick="true"
 					@click="$emit('update:value', calendar)">
 					<template #icon>
-						<div class="calendar-picker-header__icon">
+						<div class="calendar-picker-header__picker__option__row">
+							<div
+								class="calendar-picker-header__icon__dot"
+								:style="{ 'background-color': calendar.color }" />
+							<span class="calendar-picker-header__picker__option__label">{{ getOptionLabel(calendar) }}</span>
 							<NcAvatar
 								v-if="calendar.isDelegated"
 								class="calendar-picker-header__picker__option__avatar"
@@ -54,13 +58,8 @@
 								:user="getOwnerUserId(calendar)"
 								:displayName="getOwnerDisplayName(calendar)"
 								:size="20" />
-							<div
-								v-else
-								class="calendar-picker-header__icon__dot"
-								:style="{ 'background-color': calendar.color }" />
 						</div>
 					</template>
-					{{ getOptionLabel(calendar) }}
 				</NcActionButton>
 			</template>
 		</NcActions>
@@ -229,8 +228,7 @@ export default {
 
 		/**
 		 * Builds the option label including the "(delegated by X)" suffix
-		 * when applicable. NcActionButton only renders the first text node of
-		 * its default slot, so the suffix must be part of the same string.
+		 * when applicable.
 		 *
 		 * @param {object} calendar The calendar object
 		 * @return {string}
@@ -298,8 +296,25 @@ export default {
 				align-items: center !important;
 			}
 
+			&__row {
+				display: flex;
+				align-items: center;
+				gap: calc(var(--default-grid-baseline) * 2);
+				min-width: 0;
+				padding-inline-start: var(--default-grid-baseline);
+			}
+
+			&__label {
+				flex: 0 1 auto;
+				min-width: 0;
+				overflow: hidden;
+				text-overflow: ellipsis;
+				text-align: start;
+				white-space: nowrap;
+			}
+
 			&__avatar {
-				margin: auto;
+				flex-shrink: 0;
 			}
 		}
 
@@ -339,6 +354,7 @@ export default {
 			width: $dot-size;
 			height: $dot-size;
 			border-radius: $dot-size;
+			flex-shrink: 0;
 		}
 	}
 }

--- a/src/components/Shared/CalendarPickerOption.vue
+++ b/src/components/Shared/CalendarPickerOption.vue
@@ -134,8 +134,34 @@ export default {
 </script>
 
 <style lang="scss" scoped>
+.calendar-picker-option {
+	display: flex;
+	align-items: center;
+	gap: calc(var(--default-grid-baseline) * 2);
+	min-width: 0;
+}
+
+.calendar-picker-option__color-indicator {
+	width: calc(var(--default-grid-baseline) * 3);
+	height: calc(var(--default-grid-baseline) * 3);
+	border-radius: 50%;
+	flex-shrink: 0;
+}
+
+.calendar-picker-option__label {
+	flex: 1 1 auto;
+	min-width: 0;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
 .calendar-picker-option__delegation {
 	color: var(--color-text-maxcontrast);
 	margin-inline-start: 4px;
+}
+
+.calendar-picker-option__avatar {
+	flex-shrink: 0;
 }
 </style>


### PR DESCRIPTION
Fix https://github.com/nextcloud/calendar/issues/8568

| Before | After |
| - | - |
| <img width="327" height="245" alt="2026-07-09-171601_2560x1440_scrot" src="https://github.com/user-attachments/assets/c4b8f82b-b854-4c42-9c6c-8e76c27bf2de" /> | <img width="414" height="182" alt="2026-07-09-164710_2560x1440_scrot" src="https://github.com/user-attachments/assets/7a04f504-9b94-4c96-ab80-06aa991a0bbf" /> |


Signed-off-by: Grigory Vodyanov <scratchx@gmx.com>
## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
