### PR TITLE
fix(editor): better resource wording and availability shortcut

### DIFF
--- a/src/components/Editor/AvatarParticipationStatus.vue
+++ b/src/components/Editor/AvatarParticipationStatus.vue
@@ -22,7 +22,7 @@
 				class="avatar-participation-status__indicator"
 				:fillColor="status.fillColor"
 				:size="20" />
-			<div class="avatar-participation-status__text">
+			<div class="avatar-participation-status__text" :title="statusTitle">
 				<span v-if="adjustedTime" class="avatar-participation-status__text__time">{{ adjustedTime }} local time, </span>{{ status.text.trim() }}
 			</div>
 		</template>
@@ -209,7 +209,7 @@ export default {
 					if (this.isResource) {
 						return {
 							icon: IconNoResponse,
-							text: t('calendar', 'Availability will be checked'),
+							text: t('calendar', 'Will be booked after saving, if available'),
 						}
 					}
 
@@ -258,6 +258,20 @@ export default {
 
 		adjustedTime() {
 			return adjustAttendeeTime(this.calendarObjectInstanceStore.calendarObjectInstance.startDate, this.timezone)
+		},
+
+		/**
+		 * Full status as native tooltip since the text may be ellipsised
+		 *
+		 * @return {string}
+		 */
+		statusTitle() {
+			const text = this.status.text.trim()
+			if (this.adjustedTime) {
+				return `${this.adjustedTime} local time, ${text}`
+			}
+
+			return text
 		},
 	},
 }

--- a/src/components/Editor/Resources/ResourceListItem.vue
+++ b/src/components/Editor/Resources/ResourceListItem.vue
@@ -44,6 +44,15 @@
 					v-if="isAccessible"
 					:name="$t('calendar', 'Wheelchair accessible')" />
 				<ActionSeparator v-if="seatingCapacity || roomType || hasProjector || hasWhiteboard || isAccessible" />
+				<ActionButton
+					v-if="principal"
+					:closeAfterClick="true"
+					@click="showAvailabilityModal = true">
+					<template #icon>
+						<CalendarSearch :size="20" decorative />
+					</template>
+					{{ $t('calendar', 'Check availability') }}
+				</ActionButton>
 				<ActionButton @click="removeResource">
 					<template #icon>
 						<Delete :size="20" decorative />
@@ -52,6 +61,15 @@
 				</ActionButton>
 			</actions>
 		</div>
+		<RoomAvailabilityModal
+			v-if="showAvailabilityModal"
+			:show="showAvailabilityModal"
+			:startDate="calendarObjectInstance.startDate"
+			:endDate="calendarObjectInstance.endDate"
+			:rooms="[roomPrincipal]"
+			:calendarObjectInstance="calendarObjectInstance"
+			:organizer="currentUserPrincipalAsAttendee"
+			@update:show="(value) => { showAvailabilityModal = value }" />
 	</div>
 </template>
 
@@ -62,11 +80,17 @@ import {
 	NcActions as Actions,
 	NcActionSeparator as ActionSeparator,
 } from '@nextcloud/vue'
+import { mapStores } from 'pinia'
+import CalendarSearch from 'vue-material-design-icons/CalendarSearch.vue'
 import Plus from 'vue-material-design-icons/Plus.vue'
 import Delete from 'vue-material-design-icons/TrashCanOutline.vue'
 import AvatarParticipationStatus from '../AvatarParticipationStatus.vue'
+import RoomAvailabilityModal from '../FreeBusy/RoomAvailabilityModal.vue'
+import { mapPrincipalObjectToAttendeeObject } from '../../../models/attendee.js'
 import { formatRoomType } from '../../../models/resourceProps.js'
 import { principalPropertySearchByDisplaynameOrEmail } from '../../../services/caldavService.js'
+import useCalendarObjectInstanceStore from '../../../store/calendarObjectInstance.js'
+import usePrincipalsStore from '../../../store/principals.js'
 import { removeMailtoPrefix } from '../../../utils/attendee.js'
 import logger from '../../../utils/logger.js'
 
@@ -78,8 +102,10 @@ export default {
 		ActionCaption,
 		ActionSeparator,
 		Actions,
+		CalendarSearch,
 		Delete,
 		Plus,
+		RoomAvailabilityModal,
 	},
 
 	props: {
@@ -112,10 +138,47 @@ export default {
 	data() {
 		return {
 			principal: null,
+			showAvailabilityModal: false,
 		}
 	},
 
 	computed: {
+		...mapStores(usePrincipalsStore, useCalendarObjectInstanceStore),
+		calendarObjectInstance() {
+			return this.calendarObjectInstanceStore.calendarObjectInstance
+		},
+
+		/**
+		 * The room principal in the shape expected by the availability modal.
+		 * The principal property search returns raw cdav principals where the
+		 * email address is stored in email rather than emailAddress.
+		 *
+		 * @return {?object}
+		 */
+		roomPrincipal() {
+			if (!this.principal) {
+				return null
+			}
+
+			return {
+				displayname: this.principal.displayname,
+				emailAddress: this.principal.email,
+				calendarUserType: this.principal.calendarUserType,
+			}
+		},
+
+		/**
+		 * Return the current user principal as an ORGANIZER attendee object
+		 *
+		 * @return {object}
+		 */
+		currentUserPrincipalAsAttendee() {
+			return mapPrincipalObjectToAttendeeObject(
+				this.principalsStore.getCurrentUserPrincipal,
+				true,
+			)
+		},
+
 		commonName() {
 			if (this.resource.commonName) {
 				return this.resource.commonName

--- a/src/views/EditFull.vue
+++ b/src/views/EditFull.vue
@@ -865,6 +865,13 @@ export default {
 		min-width: unset !important;
 	}
 
+	// The cap above is sized for the wide invitees column. In the narrow
+	// resources column long statuses would still overflow onto the actions
+	// menu, so clamp them to the column width instead.
+	.app-full-footer__right :deep(.avatar-participation-status__text) {
+		max-width: calc(var(--total-width) / 3 - var(--column-gap) / 2 - 58px - var(--default-clickable-area)) !important;
+	}
+
 	&__header {
 		display: flex;
 		flex-direction: column;


### PR DESCRIPTION
The pending state for a room/resource read "Availability will be checked", which sounds like a check is in progress. The availability is only checked by the server once the event is saved, so reword it to "Will be booked if available".

Also add a "Check availability" shortcut to the resource's actions menu that opens the existing room availability timeline directly, instead of going through "Show all rooms" and finding the room in the list again.

Ellipsis was also fixed, because it overflowed, and a native title now shows the full text on hover.

Ref https://github.com/nextcloud/calendar/issues/7772

Assisted-by: ClaudeCode:claude-fable-5

## Screenshots

| Before | After |
|--------|--------|
| <img width="449" height="321" alt="Bildschirmfoto vom 2026-07-10 11-28-20" src="https://github.com/user-attachments/assets/1c691242-1c4b-4b94-b554-77440db7183e" /> | <img width="439" height="303" alt="image" src="https://github.com/user-attachments/assets/7a85f9d4-1e2d-4f6b-b5cb-9b9b220782c3" /> | 

## How to test

1. Enable *Calendar Resource Management* app
2. Create a test room
3. Open Calendar
4. Create new event
5. Add room
6. Don't click *Save*

## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
