### PR TITLE
feat(editor): check resource availability while editing

### DIFF
--- a/src/components/Editor/AvatarParticipationStatus.vue
+++ b/src/components/Editor/AvatarParticipationStatus.vue
@@ -89,6 +89,11 @@ export default {
 			default: false,
 		},
 
+		availability: {
+			type: String, // 'checking' | 'available' | 'unavailable' | null
+			default: null,
+		},
+
 		attendeeIsOrganizer: {
 			type: Boolean,
 			required: true,
@@ -202,6 +207,24 @@ export default {
 				// No status or status 1.0 indicate that the invitation is pending
 				if (!this.scheduleStatus || this.scheduleStatus === '1.0') {
 					if (this.isResource) {
+						switch (this.availability) {
+							case 'available':
+								return {
+									...acceptedIcon,
+									text: t('calendar', 'Still available'),
+								}
+							case 'unavailable':
+								return {
+									...declinedIcon,
+									text: t('calendar', 'Already booked'),
+								}
+							case 'checking':
+								return {
+									icon: IconNoResponse,
+									text: t('calendar', 'Checking availability'),
+								}
+						}
+
 						return {
 							icon: IconNoResponse,
 							text: t('calendar', 'Will be booked after saving, if available'),

--- a/src/components/Editor/AvatarParticipationStatus.vue
+++ b/src/components/Editor/AvatarParticipationStatus.vue
@@ -89,6 +89,11 @@ export default {
 			default: false,
 		},
 
+		availability: {
+			type: String, // 'checking' | 'available' | 'unavailable' | null
+			default: null,
+		},
+
 		attendeeIsOrganizer: {
 			type: Boolean,
 			required: true,
@@ -202,6 +207,24 @@ export default {
 				// No status or status 1.0 indicate that the invitation is pending
 				if (!this.scheduleStatus || this.scheduleStatus === '1.0') {
 					if (this.isResource) {
+						switch (this.availability) {
+							case 'available':
+								return {
+									...acceptedIcon,
+									text: t('calendar', 'Still available'),
+								}
+							case 'unavailable':
+								return {
+									...declinedIcon,
+									text: t('calendar', 'Already booked'),
+								}
+							case 'checking':
+								return {
+									icon: IconNoResponse,
+									text: t('calendar', 'Checking availability'),
+								}
+						}
+
 						return {
 							...noResponseIcon,
 							text: t('calendar', 'Will be booked after saving, if available'),

--- a/src/components/Editor/Resources/ResourceList.vue
+++ b/src/components/Editor/Resources/ResourceList.vue
@@ -20,6 +20,7 @@
 				:resource="resource"
 				:organizerDisplayName="organizerDisplayName"
 				:isViewedByOrganizer="isViewedByOrganizer"
+				:availability="availabilityFor(resource)"
 				@removeResource="removeResource" />
 
 			<ResourceListItem
@@ -36,6 +37,7 @@
 
 <script>
 import { loadState } from '@nextcloud/initial-state'
+import debounce from 'debounce'
 import { mapStores } from 'pinia'
 import MapMarker from 'vue-material-design-icons/MapMarker.vue'
 import ResourceListItem from './ResourceListItem.vue'
@@ -44,7 +46,7 @@ import { advancedPrincipalPropertySearch } from '../../../services/caldavService
 import { checkResourceAvailability } from '../../../services/freeBusyService.js'
 import useCalendarObjectInstanceStore from '../../../store/calendarObjectInstance.js'
 import usePrincipalsStore from '../../../store/principals.js'
-import { organizerDisplayName, removeMailtoPrefix } from '../../../utils/attendee.js'
+import { isPendingResourceBooking, organizerDisplayName, removeMailtoPrefix } from '../../../utils/attendee.js'
 import logger from '../../../utils/logger.js'
 
 export default {
@@ -70,6 +72,9 @@ export default {
 	data() {
 		return {
 			suggestedRooms: [],
+			// email -> 'checking' | 'available' | 'unavailable'
+			resourceAvailabilities: {},
+			availabilityRequestToken: 0,
 		}
 	},
 
@@ -120,18 +125,45 @@ export default {
 		resourceBookingEnabled() {
 			return loadState('calendar', 'resource_booking_enabled')
 		},
+
+		/**
+		 * Resources whose booking outcome is still unknown. Resources that
+		 * already accepted or declined have an authoritative answer from the
+		 * server. An accepted resource must not be probed again because its
+		 * own reservation would show up as busy (VFREEBUSY carries no UIDs).
+		 */
+		pendingResources() {
+			return this.resources.filter((resource) => {
+				const scheduleStatus = resource.attendeeProperty?.getParameterFirstValue('SCHEDULE-STATUS') ?? ''
+				return isPendingResourceBooking(resource.participationStatus, scheduleStatus)
+			})
+		},
+
+		/**
+		 * Cheap watch source for the event time. The store replaces the
+		 * startDate/endDate objects on every change.
+		 */
+		eventTimeRange() {
+			return `${this.calendarObjectInstance.startDate?.getTime()}/${this.calendarObjectInstance.endDate?.getTime()}`
+		},
 	},
 
 	watch: {
 		resources() {
 			if (this.isViewedByOrganizer) {
 				this.loadRoomSuggestions()
+				this.checkAvailabilityDebounced()
 			}
+		},
+
+		eventTimeRange() {
+			this.checkAvailabilityDebounced()
 		},
 	},
 
 	async mounted() {
 		if (this.isViewedByOrganizer) {
+			this.checkAvailabilityDebounced()
 			await this.loadRoomSuggestions()
 		}
 	},
@@ -158,6 +190,68 @@ export default {
 				calendarObjectInstance: this.calendarObjectInstance,
 				attendee: resource,
 			})
+		},
+
+		/**
+		 * Get the predicted availability of a resource
+		 *
+		 * @param {object} resource The resource attendee object
+		 * @return {?string} One of 'checking', 'available', 'unavailable' or null if unknown
+		 */
+		availabilityFor(resource) {
+			return this.resourceAvailabilities[removeMailtoPrefix(resource.uri)] ?? null
+		},
+
+		checkAvailabilityDebounced: debounce(function() {
+			this.checkPendingResourceAvailability()
+		}, 700),
+
+		/**
+		 * Predict the booking outcome of all pending resources with a
+		 * free busy request. The result is only a prediction because the
+		 * authoritative check happens on the server when the event is saved.
+		 * Recurring events are only probed for the edited occurrence.
+		 */
+		async checkPendingResourceAvailability() {
+			if (this.isReadOnly || !this.isViewedByOrganizer || !this.resourceBookingEnabled) {
+				return
+			}
+
+			// Invalidate results of any request still in flight
+			const token = ++this.availabilityRequestToken
+
+			const options = this.pendingResources.map((resource) => ({
+				email: removeMailtoPrefix(resource.uri),
+				isAvailable: true,
+			}))
+			if (options.length === 0) {
+				this.resourceAvailabilities = {}
+				return
+			}
+
+			this.resourceAvailabilities = Object.fromEntries(options.map(({ email }) => [email, 'checking']))
+
+			try {
+				await checkResourceAvailability(
+					options,
+					this.principalsStore.getCurrentUserPrincipalEmail,
+					this.calendarObjectInstance.eventComponent.startDate,
+					this.calendarObjectInstance.eventComponent.endDate,
+				)
+
+				if (token !== this.availabilityRequestToken) {
+					return
+				}
+
+				this.resourceAvailabilities = Object.fromEntries(options.map(({ email, isAvailable }) => [email, isAvailable ? 'available' : 'unavailable']))
+			} catch (error) {
+				if (token !== this.availabilityRequestToken) {
+					return
+				}
+
+				logger.warn('Could not check resource availability', { error })
+				this.resourceAvailabilities = {}
+			}
 		},
 
 		async loadRoomSuggestions() {

--- a/src/components/Editor/Resources/ResourceList.vue
+++ b/src/components/Editor/Resources/ResourceList.vue
@@ -75,6 +75,7 @@ export default {
 			// email -> 'checking' | 'available' | 'unavailable'
 			resourceAvailabilities: {},
 			availabilityRequestToken: 0,
+			suggestionsRequestToken: 0,
 		}
 	},
 
@@ -157,8 +158,17 @@ export default {
 		},
 
 		eventTimeRange() {
+			this.loadRoomSuggestions()
 			this.checkAvailabilityDebounced()
 		},
+	},
+
+	created() {
+		// Created per instance, since a debounced function shared across all
+		// ResourceList instances (e.g. via the methods object) would throw
+		// when called with a different `this` while a previous call is still
+		// pending.
+		this.checkAvailabilityDebounced = debounce(this.checkPendingResourceAvailability.bind(this), 700)
 	},
 
 	async mounted() {
@@ -202,10 +212,6 @@ export default {
 			return this.resourceAvailabilities[removeMailtoPrefix(resource.uri)] ?? null
 		},
 
-		checkAvailabilityDebounced: debounce(function() {
-			this.checkPendingResourceAvailability()
-		}, 700),
-
 		/**
 		 * Predict the booking outcome of all pending resources with a
 		 * free busy request. The result is only a prediction because the
@@ -229,6 +235,9 @@ export default {
 				return
 			}
 
+			// Kept so a failed request can restore the last known result
+			// instead of dropping it in favour of an unknown state.
+			const previousAvailabilities = this.resourceAvailabilities
 			this.resourceAvailabilities = Object.fromEntries(options.map(({ email }) => [email, 'checking']))
 
 			try {
@@ -250,7 +259,7 @@ export default {
 				}
 
 				logger.warn('Could not check resource availability', { error })
-				this.resourceAvailabilities = {}
+				this.resourceAvailabilities = previousAvailabilities
 			}
 		},
 
@@ -263,6 +272,9 @@ export default {
 				this.suggestedRooms = []
 				return
 			}
+
+			// Invalidate results of any request still in flight
+			const token = ++this.suggestionsRequestToken
 
 			try {
 				logger.info('fetching suggestions for ' + this.attendees.length + ' attendees')
@@ -290,9 +302,17 @@ export default {
 				)
 				logger.debug('availability of room suggestions fetched', { results })
 
+				if (token !== this.suggestionsRequestToken) {
+					return
+				}
+
 				// Take the first three available options
 				this.suggestedRooms = results.filter((room) => room.isAvailable).slice(0, 3)
 			} catch (error) {
+				if (token !== this.suggestionsRequestToken) {
+					return
+				}
+
 				logger.error('Could not find resources', { error })
 				this.suggestedRooms = []
 			}

--- a/src/components/Editor/Resources/ResourceList.vue
+++ b/src/components/Editor/Resources/ResourceList.vue
@@ -37,6 +37,7 @@
 			:resource="resource"
 			:organizerDisplayName="organizerDisplayName"
 			:isViewedByOrganizer="isViewedByOrganizer"
+			:availability="availabilityFor(resource)"
 			@removeResource="removeResource" />
 
 		<ResourceListItem
@@ -55,6 +56,7 @@ import { loadState } from '@nextcloud/initial-state'
 import {
 	NcButton,
 } from '@nextcloud/vue'
+import debounce from 'debounce'
 import { mapStores } from 'pinia'
 import DoorOpenIcon from 'vue-material-design-icons/DoorOpen.vue'
 import RoomAvailabilityList from '../FreeBusy/RoomAvailabilityList.vue'
@@ -64,7 +66,7 @@ import { advancedPrincipalPropertySearch } from '../../../services/caldavService
 import { checkResourceAvailability } from '../../../services/freeBusyService.js'
 import useCalendarObjectInstanceStore from '../../../store/calendarObjectInstance.js'
 import usePrincipalsStore from '../../../store/principals.js'
-import { organizerDisplayName, removeMailtoPrefix } from '../../../utils/attendee.js'
+import { isPendingResourceBooking, organizerDisplayName, removeMailtoPrefix } from '../../../utils/attendee.js'
 import logger from '../../../utils/logger.js'
 export default {
 	name: 'ResourceList',
@@ -92,6 +94,10 @@ export default {
 		return {
 			suggestedRooms: [],
 			showRoomAvailabilityModal: false,
+			// email -> 'checking' | 'available' | 'unavailable'
+			resourceAvailabilities: {},
+			availabilityRequestToken: 0,
+			suggestionsRequestToken: 0,
 		}
 	},
 
@@ -142,18 +148,54 @@ export default {
 		resourceBookingEnabled() {
 			return loadState('calendar', 'resource_booking_enabled')
 		},
+
+		/**
+		 * Resources whose booking outcome is still unknown. Resources that
+		 * already accepted or declined have an authoritative answer from the
+		 * server. An accepted resource must not be probed again because its
+		 * own reservation would show up as busy (VFREEBUSY carries no UIDs).
+		 */
+		pendingResources() {
+			return this.resources.filter((resource) => {
+				const scheduleStatus = resource.attendeeProperty?.getParameterFirstValue('SCHEDULE-STATUS') ?? ''
+				return isPendingResourceBooking(resource.participationStatus, scheduleStatus)
+			})
+		},
+
+		/**
+		 * Cheap watch source for the event time. The store replaces the
+		 * startDate/endDate objects on every change.
+		 */
+		eventTimeRange() {
+			return `${this.calendarObjectInstance.startDate?.getTime()}/${this.calendarObjectInstance.endDate?.getTime()}`
+		},
 	},
 
 	watch: {
 		resources() {
 			if (this.isViewedByOrganizer) {
 				this.loadRoomSuggestions()
+				this.checkAvailabilityDebounced()
 			}
 		},
+
+		eventTimeRange() {
+			this.loadRoomSuggestions()
+			this.checkAvailabilityDebounced()
+		},
+	},
+
+	created() {
+		// Created per instance, since a debounced function shared across all
+		// ResourceList instances (e.g. via the methods object) would throw
+		// when called with a different `this` while a previous call is still
+		// pending.
+		this.checkAvailabilityDebounced = debounce(this.checkPendingResourceAvailability.bind(this), 700)
 	},
 
 	async mounted() {
 		if (this.isViewedByOrganizer) {
+			this.checkAvailabilityDebounced()
 			await this.loadRoomSuggestions()
 		}
 	},
@@ -182,6 +224,67 @@ export default {
 			})
 		},
 
+		/**
+		 * Get the predicted availability of a resource
+		 *
+		 * @param {object} resource The resource attendee object
+		 * @return {?string} One of 'checking', 'available', 'unavailable' or null if unknown
+		 */
+		availabilityFor(resource) {
+			return this.resourceAvailabilities[removeMailtoPrefix(resource.uri)] ?? null
+		},
+
+		/**
+		 * Predict the booking outcome of all pending resources with a
+		 * free busy request. The result is only a prediction because the
+		 * authoritative check happens on the server when the event is saved.
+		 * Recurring events are only probed for the edited occurrence.
+		 */
+		async checkPendingResourceAvailability() {
+			if (this.isReadOnly || !this.isViewedByOrganizer || !this.resourceBookingEnabled) {
+				return
+			}
+
+			// Invalidate results of any request still in flight
+			const token = ++this.availabilityRequestToken
+
+			const options = this.pendingResources.map((resource) => ({
+				email: removeMailtoPrefix(resource.uri),
+				isAvailable: true,
+			}))
+			if (options.length === 0) {
+				this.resourceAvailabilities = {}
+				return
+			}
+
+			// Kept so a failed request can restore the last known result
+			// instead of dropping it in favour of an unknown state.
+			const previousAvailabilities = this.resourceAvailabilities
+			this.resourceAvailabilities = Object.fromEntries(options.map(({ email }) => [email, 'checking']))
+
+			try {
+				await checkResourceAvailability(
+					options,
+					this.principalsStore.getCurrentUserPrincipalEmail,
+					this.calendarObjectInstance.eventComponent.startDate,
+					this.calendarObjectInstance.eventComponent.endDate,
+				)
+
+				if (token !== this.availabilityRequestToken) {
+					return
+				}
+
+				this.resourceAvailabilities = Object.fromEntries(options.map(({ email, isAvailable }) => [email, isAvailable ? 'available' : 'unavailable']))
+			} catch (error) {
+				if (token !== this.availabilityRequestToken) {
+					return
+				}
+
+				logger.warn('Could not check resource availability', { error })
+				this.resourceAvailabilities = previousAvailabilities
+			}
+		},
+
 		async loadRoomSuggestions() {
 			if (!this.resourceBookingEnabled) {
 				return
@@ -191,6 +294,9 @@ export default {
 				this.suggestedRooms = []
 				return
 			}
+
+			// Invalidate results of any request still in flight
+			const token = ++this.suggestionsRequestToken
 
 			try {
 				logger.info('fetching suggestions for ' + this.attendees.length + ' attendees')
@@ -218,9 +324,17 @@ export default {
 				)
 				logger.debug('availability of room suggestions fetched', { results })
 
+				if (token !== this.suggestionsRequestToken) {
+					return
+				}
+
 				// Take the first three available options
 				this.suggestedRooms = results.filter((room) => room.isAvailable).slice(0, 3)
 			} catch (error) {
+				if (token !== this.suggestionsRequestToken) {
+					return
+				}
+
 				logger.error('Could not find resources', { error })
 				this.suggestedRooms = []
 			}

--- a/src/components/Editor/Resources/ResourceListItem.vue
+++ b/src/components/Editor/Resources/ResourceListItem.vue
@@ -12,6 +12,7 @@
 			:isSuggestion="isSuggestion"
 			:participationStatus="participationStatus"
 			:scheduleStatus="scheduleStatus"
+			:availability="availability"
 			:organizerDisplayName="organizerDisplayName"
 			:commonName="commonName" />
 		<div class="resource-list-item__displayname">
@@ -125,6 +126,11 @@ export default {
 		isViewedByOrganizer: {
 			type: Boolean,
 			default: false,
+		},
+
+		availability: {
+			type: String, // 'checking' | 'available' | 'unavailable' | null
+			default: null,
 		},
 	},
 

--- a/src/components/Editor/Resources/ResourceListSearch.vue
+++ b/src/components/Editor/Resources/ResourceListSearch.vue
@@ -124,7 +124,10 @@ export default {
 			matches: [],
 			capacity: NaN,
 			roomType: '',
-			isAvailable: true,
+			// Show busy resources too (annotated per result) instead of
+			// hiding them, so the search doesn't hide the exact conflict
+			// information this feature is meant to surface.
+			isAvailable: false,
 			isAccessible: false,
 			hasProjector: false,
 			hasWhiteboard: false,

--- a/src/components/Editor/Resources/ResourceListSearch.vue
+++ b/src/components/Editor/Resources/ResourceListSearch.vue
@@ -111,7 +111,10 @@ export default {
 			matches: [],
 			capacity: NaN,
 			roomType: '',
-			isAvailable: true,
+			// Show busy resources too (annotated per result) instead of
+			// hiding them, so the search doesn't hide the exact conflict
+			// information this feature is meant to surface.
+			isAvailable: false,
 			isAccessible: false,
 			hasProjector: false,
 			hasWhiteboard: false,

--- a/src/services/freeBusyService.js
+++ b/src/services/freeBusyService.js
@@ -34,7 +34,6 @@ export async function checkResourceAvailability(options, principalEmail, start, 
 		const attendeeEmail = removeMailtoPrefix(attendeeProperty.email)
 		for (const option of options) {
 			if (removeMailtoPrefix(option.email) === attendeeEmail) {
-				options.participationStatus = ''
 				option.isAvailable = false
 				break
 			}

--- a/src/utils/attendee.js
+++ b/src/utils/attendee.js
@@ -58,6 +58,19 @@ export function organizerDisplayName(organizer) {
 }
 
 /**
+ * Check if a resource booking is still pending, i.e. the resource has neither
+ * accepted nor declined and the server has not reported a scheduling result yet
+ *
+ * @param {string} participationStatus PARTSTAT of the resource attendee
+ * @param {string} scheduleStatus SCHEDULE-STATUS parameter value of the resource attendee
+ * @return {boolean} True if the booking outcome is still unknown
+ */
+export function isPendingResourceBooking(participationStatus, scheduleStatus) {
+	return !['ACCEPTED', 'DECLINED', 'TENTATIVE'].includes(participationStatus)
+		&& (!scheduleStatus || scheduleStatus === '1.0')
+}
+
+/**
  * Check if the current user is an attendee
  *
  * @param {string} currentUserPrincipalEmail Email address of the current user

--- a/tests/javascript/unit/services/freeBusyService.test.js
+++ b/tests/javascript/unit/services/freeBusyService.test.js
@@ -1,0 +1,63 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { AttendeeProperty } from '@nextcloud/calendar-js'
+import { checkResourceAvailability } from '../../../../src/services/freeBusyService'
+import { doFreeBusyRequest } from '../../../../src/utils/freebusy'
+
+vi.mock('../../../../src/utils/freebusy')
+
+describe('services/freeBusyService test suite', () => {
+	beforeEach(() => {
+		vi.clearAllMocks()
+	})
+
+	it('should mark busy resources as unavailable and leave others available', async () => {
+		doFreeBusyRequest.mockImplementationOnce(async function* () {
+			yield [new AttendeeProperty('ATTENDEE', 'mailto:room1@localhost'), undefined]
+		})
+
+		const options = [
+			{ email: 'room1@localhost', isAvailable: true },
+			{ email: 'room2@localhost', isAvailable: true },
+		]
+		await checkResourceAvailability(options, 'user@localhost', undefined, undefined)
+
+		expect(options[0].isAvailable).toEqual(false)
+		expect(options[1].isAvailable).toEqual(true)
+	})
+
+	it('should match attendees regardless of mailto prefixes', async () => {
+		doFreeBusyRequest.mockImplementationOnce(async function* () {
+			yield [new AttendeeProperty('ATTENDEE', 'mailto:room1@localhost'), undefined]
+		})
+
+		const options = [
+			{ email: 'mailto:room1@localhost', isAvailable: true },
+		]
+		await checkResourceAvailability(options, 'user@localhost', undefined, undefined)
+
+		expect(options[0].isAvailable).toEqual(false)
+	})
+
+	it('should not send a request without options', async () => {
+		await checkResourceAvailability([], 'user@localhost', undefined, undefined)
+
+		expect(doFreeBusyRequest).not.toHaveBeenCalled()
+	})
+
+	it('should not assign a participation status to the options array', async () => {
+		doFreeBusyRequest.mockImplementationOnce(async function* () {
+			yield [new AttendeeProperty('ATTENDEE', 'mailto:room1@localhost'), undefined]
+		})
+
+		const options = [
+			{ email: 'room1@localhost', isAvailable: true },
+		]
+		await checkResourceAvailability(options, 'user@localhost', undefined, undefined)
+
+		expect(options).not.toHaveProperty('participationStatus')
+	})
+})

--- a/tests/javascript/unit/utils/attendee.test.js
+++ b/tests/javascript/unit/utils/attendee.test.js
@@ -5,6 +5,7 @@
 
 import {
 	addMailtoPrefix,
+	isPendingResourceBooking,
 	organizerDisplayName,
 	removeMailtoPrefix,
 } from '../../../../src/utils/attendee.js'
@@ -47,5 +48,19 @@ describe('utils/attendee test suite', () => {
 			commonName,
 			uri,
 		})).toEqual(commonName)
+	})
+
+	it('should detect pending resource bookings', () => {
+		expect(isPendingResourceBooking('NEEDS-ACTION', '')).toEqual(true)
+		expect(isPendingResourceBooking('NEEDS-ACTION', '1.0')).toEqual(true)
+		expect(isPendingResourceBooking('', '')).toEqual(true)
+	})
+
+	it('should not detect answered or failed resource bookings as pending', () => {
+		expect(isPendingResourceBooking('ACCEPTED', '')).toEqual(false)
+		expect(isPendingResourceBooking('DECLINED', '2.0')).toEqual(false)
+		expect(isPendingResourceBooking('TENTATIVE', '')).toEqual(false)
+		expect(isPendingResourceBooking('NEEDS-ACTION', '3.7')).toEqual(false)
+		expect(isPendingResourceBooking('NEEDS-ACTION', '5.1')).toEqual(false)
 	})
 })


### PR DESCRIPTION
Follow-up to https://github.com/nextcloud/calendar/pull/8588 to automatically check availability of a selected room.

Full change log
* Availability is automatically checked and shown as subline of selected resources
* Availability is also shown in the search dropdown, including busy rooms, so that you know they are booked. Previously they were filtered out, which gave the UX as if your search was wrong.
* Suggested rooms adhere to the availability. They go away if they are already busy for the selected time.
* Time changes causes a re-evaluation of suggested rooms according to new availability.

Closes https://github.com/nextcloud/calendar/issues/7772

## How to test

1. Have at least one room (via calendar_resource_management)
2. Create event A with no attendee but the room -> it will show as *Still available* before saving
3. Create event B with no attendees at the same time as A -> it will show as *Already booked* before saving
4. Create event C with one attendee at a free time for the room -> it will suggest the room (if its capacity is >=1)
5. Create event D with one attendee at the same time as A -> it will not suggest the room
6. Same as 5. but move the time to a free slot -> it will suggest the room again

## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
