### PR TITLE
refactor: remove usage of `this._uid` in Vue components

### DIFF
--- a/src/components/AppNavigation/CalendarList.vue
+++ b/src/components/AppNavigation/CalendarList.vue
@@ -190,10 +190,6 @@ export default {
 			serverCalendars: 'sortedCalendarsSubscriptions',
 		}),
 
-		loadingKeyCalendars() {
-			return this._uid + '-loading-placeholder-calendars'
-		},
-
 		isDelegationSupported() {
 			return isAfterVersion(34)
 		},

--- a/src/components/AppNavigation/EditCalendarModal/ShareItem.vue
+++ b/src/components/AppNavigation/EditCalendarModal/ShareItem.vue
@@ -85,9 +85,6 @@ export default {
 
 	computed: {
 		...mapStores(useCalendarsStore, usePrincipalsStore),
-		uid() {
-			return this._uid
-		},
 
 		/**
 		 * @return {string}

--- a/src/components/Editor/FreeBusy/FreeBusy.vue
+++ b/src/components/Editor/FreeBusy/FreeBusy.vue
@@ -271,6 +271,7 @@ import { isRTL } from '@nextcloud/l10n'
 import { NcActionButton, NcActions, NcButton, NcDateTimePickerNative, NcListItemIcon, NcModal, NcPopover, NcSelect, NcUserBubble } from '@nextcloud/vue'
 import { useIsMobile } from '@nextcloud/vue/composables/useIsMobile'
 import { mapState } from 'pinia'
+import { useId } from 'vue'
 import CheckIcon from 'vue-material-design-icons/Check.vue'
 import ChevronLeftIcon from 'vue-material-design-icons/ChevronLeft.vue'
 import ChevronRightIcon from 'vue-material-design-icons/ChevronRight.vue'
@@ -378,7 +379,8 @@ export default {
 
 	setup() {
 		const isMobile = useIsMobile()
-		return { isMobile }
+		const uniqueComponentId = useId()
+		return { isMobile, uniqueComponentId }
 	},
 
 	data() {
@@ -466,7 +468,7 @@ export default {
 			const organizer = new AttendeeProperty('ATTENDEE', this.organizer.attendeeProperty.email)
 			organizer.commonName = this.organizer.attendeeProperty.commonName
 			return [...attendees, organizer].map((a) => freeBusyEventSource(
-				this._uid,
+				this.uniqueComponentId,
 				this.organizer.attendeeProperty,
 				a,
 			))

--- a/src/components/Editor/FreeBusy/RoomAvailabilityModal.vue
+++ b/src/components/Editor/FreeBusy/RoomAvailabilityModal.vue
@@ -75,6 +75,7 @@ import resourceTimelinePlugin from '@fullcalendar/resource-timeline'
 import FullCalendar from '@fullcalendar/vue3'
 import { NcButton, NcDateTimePickerNative, NcModal, NcPopover } from '@nextcloud/vue'
 import { mapState } from 'pinia'
+import { useId } from 'vue'
 import ChevronLeftIcon from 'vue-material-design-icons/ChevronLeft.vue'
 import ChevronRightIcon from 'vue-material-design-icons/ChevronRight.vue'
 import HelpCircleIcon from 'vue-material-design-icons/HelpCircleOutline.vue'
@@ -137,6 +138,11 @@ export default {
 		},
 	},
 
+	setup() {
+		const uniqueComponentId = useId()
+		return { uniqueComponentId }
+	},
+
 	data() {
 		return {
 			currentDate: this.startDate,
@@ -181,12 +187,12 @@ export default {
 		eventSources() {
 			return [
 				freeBusyResourceEventSource(
-					this._uid,
+					this.uniqueComponentId,
 					this.organizer.attendeeProperty,
 					this.attendees.map((a) => a.attendeeProperty),
 				),
 				freeBusyFakeBlockingEventSource(
-					this._uid,
+					this.uniqueComponentId,
 					this.resources,
 					this.currentStart,
 					this.currentEnd,

--- a/src/components/Editor/Repeat/RepeatFreqMonthlyOptions.vue
+++ b/src/components/Editor/Repeat/RepeatFreqMonthlyOptions.vue
@@ -52,6 +52,7 @@ import {
 	NcButton,
 	NcCheckboxRadioSwitch,
 } from '@nextcloud/vue'
+import { useId } from 'vue'
 import RepeatFirstLastSelect from './RepeatFirstLastSelect.vue'
 import RepeatOnTheSelect from './RepeatOnTheSelect.vue'
 
@@ -81,6 +82,11 @@ export default {
 		},
 	},
 
+	setup() {
+		const radioInputId = useId() + '-radio-select'
+		return { radioInputId }
+	},
+
 	computed: {
 		/**
 		 * @return {object[]}
@@ -104,13 +110,6 @@ export default {
 		 */
 		byMonthDayEnabled() {
 			return this.byMonthDay.length > 0
-		},
-
-		/**
-		 * @return {string}
-		 */
-		radioInputId() {
-			return this._uid + '-radio-select'
 		},
 	},
 

--- a/src/components/Editor/Repeat/RepeatFreqYearlyOptions.vue
+++ b/src/components/Editor/Repeat/RepeatFreqYearlyOptions.vue
@@ -65,6 +65,7 @@ import {
 	NcButton,
 	NcCheckboxRadioSwitch,
 } from '@nextcloud/vue'
+import { useId } from 'vue'
 import RepeatFirstLastSelect from './RepeatFirstLastSelect.vue'
 import RepeatOnTheSelect from './RepeatOnTheSelect.vue'
 
@@ -97,6 +98,11 @@ export default {
 			type: Number,
 			default: null,
 		},
+	},
+
+	setup() {
+		const radioInputId = useId() + '-radio-select'
+		return { radioInputId }
 	},
 
 	computed: {
@@ -133,13 +139,6 @@ export default {
 		 */
 		byMonthDayEnabled() {
 			return this.byMonthDay.length > 0
-		},
-
-		/**
-		 * @return {string}
-		 */
-		radioInputId() {
-			return this._uid + '-radio-select'
 		},
 	},
 


### PR DESCRIPTION
Resolves the browser warning `[Vue warn]: Property "_uid" was accessed during render but is not defined on instance.` None of the changed code caused a known user-facing issue.

`this._uid` was an internal API and is `undefined` since Vue 3. The recommended way to get unique IDs is `useId()`.

---

In some places, I encountered usage of `this._uid` in some suspicious code that might hint at something forgotten during previous refactoring and maybe a bug. I don't want to look into the details there for now, so I left `XXX` comments.