### PR TITLE
 fix(editor): handle closing free-busy dialog correctly

### DIFF
--- a/src/components/Editor/FreeBusy/FreeBusy.vue
+++ b/src/components/Editor/FreeBusy/FreeBusy.vue
@@ -377,6 +377,8 @@ export default {
 		},
 	},
 
+	emits: ['close', 'updateDates', 'addAttendee', 'removeAttendee'],
+
 	setup() {
 		const isMobile = useIsMobile()
 		const uniqueComponentId = useId()
@@ -562,10 +564,6 @@ export default {
 
 		attendees(newVal) {
 			this.updateAttendeeDetails(newVal)
-
-			if (newVal.length === 0) {
-				this.$emit('close:noAttendees')
-			}
 		},
 	},
 

--- a/src/components/Editor/Invitees/InviteesList.vue
+++ b/src/components/Editor/Invitees/InviteesList.vue
@@ -441,16 +441,18 @@ export default {
 				attendee,
 			})
 			this.recentAttendees = this.recentAttendees.filter((a) => a.uri !== attendee.email)
+
+			if (this.calendarObjectInstance.attendees.length === 0) {
+				showWarning(this.$t('calendar', 'Please add at least one attendee to use the "Find a time" feature.'))
+				this.closeFreeBusy()
+			}
 		},
 
 		openFreeBusy() {
 			this.showFreeBusyModel = true
 		},
 
-		closeFreeBusy(showNoAttendeesToast = false) {
-			if (showNoAttendeesToast) {
-				showWarning(this.$t('calendar', 'Please add at least one attendee to use the "Find a time" feature.'))
-			}
+		closeFreeBusy() {
 			this.showFreeBusyModel = false
 		},
 

--- a/src/views/EditFull.vue
+++ b/src/views/EditFull.vue
@@ -9,7 +9,6 @@
 		v-model="showFullModal"
 		class="calendar-edit-full"
 		size="full"
-		labelId="edit-full-modal"
 		:name="t('calendar', 'Edit event')"
 		:dark="false"
 		:noClose="true"

--- a/src/views/EditFull.vue
+++ b/src/views/EditFull.vue
@@ -9,7 +9,7 @@
 		v-model="showFullModal"
 		class="calendar-edit-full"
 		size="full"
-		:name="t('calendar', 'Edit event')"
+		:name="t('calendar', 'Detailed event editor')"
 		:dark="false"
 		:noClose="true"
 		@close="cancel(false)">

--- a/src/views/EditSimple.vue
+++ b/src/views/EditSimple.vue
@@ -7,19 +7,19 @@
 	<div>
 		<div
 			v-if="showPopover && !isViewing"
-			ref="mask"
 			class="modal-mask"
 			:class="{
 				'modal-mask--opaque': dark,
 				'modal-mask--light': lightBackdrop,
 			}"
-			role="dialog"
-			aria-modal="true"
 			tabindex="-1"
 			@click.self="cancel(false)" />
 		<div
 			v-if="showPopover"
 			class="event-popover"
+			role="dialog"
+			aria-modal="true"
+			:aria-label="t('calendar', 'Simple event editor')"
 			:style="{
 				...popoverStyle,
 				pointerEvents: popoverReady ? 'auto' : 'none',

--- a/tests/javascript/e2e/event.spec.ts
+++ b/tests/javascript/e2e/event.spec.ts
@@ -7,16 +7,14 @@ import { expect } from '@playwright/test'
 import { test } from './support/fixtures.ts'
 
 test('create an event', async ({ page, calendarPage }) => {
-	const eventTitle = Math.random().toString(16).slice(2)
-
 	// Create new event with random title
-	await page.getByRole('button', { name: 'Create new event' }).click()
-	await page.getByRole('textbox', { name: 'Title' }).click()
-	await page.getByRole('textbox', { name: 'Title' }).fill(eventTitle)
-	await page.getByRole('button', { name: 'Save' }).click()
+	const eventTitle = Math.random().toString(16).slice(2)
+	const simpleEditor = await calendarPage.createNewEvent()
+	await simpleEditor.fillTitle(eventTitle)
+	await simpleEditor.save()
 
 	// Wait for modal to close
-	await expect(page.getByRole('dialog')).not.toBeVisible()
+	await expect(simpleEditor.locator).not.toBeVisible()
 
 	// Assert that the new event exists
 	await expect(page.getByText(eventTitle)).toBeVisible()

--- a/tests/javascript/e2e/freeBusy.spec.ts
+++ b/tests/javascript/e2e/freeBusy.spec.ts
@@ -1,0 +1,21 @@
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { expect } from '@playwright/test'
+import { test } from './support/fixtures.ts'
+
+test('removing last attendee closes dialog', async ({ page, calendarPage, provisioning }) => {
+	await provisioning.createUser({ displayName: "UserA", email: "userA@example.com" })
+	const simpleEditor = await calendarPage.createNewEvent()
+	await simpleEditor.addAttende("UserA")
+	const detailedEditor = await simpleEditor.openDetailedEditor()
+	const freeBusyDialog = await detailedEditor.openFreeBusyDialog()
+
+	await freeBusyDialog.removeUser("UserA")
+
+	expect(freeBusyDialog.locator).not.toBeVisible()
+	const warning = page.getByText('Please add at least one attendee to use the "Find a time" feature.')
+	expect(warning).toBeVisible()
+})

--- a/tests/javascript/e2e/publicCalendar.spec.ts
+++ b/tests/javascript/e2e/publicCalendar.spec.ts
@@ -11,13 +11,12 @@ test('subscribe to a public calendar', async ({ provisioning, calendarPage, page
 	await provisioning.updateAppConfigValue('calendar', 'publicCalendars', publicCalendarConfValue)
 	// Page needs to be reloaded because the config value is loaded on page load.
 	await page.reload()
-	const dialog = calendarPage.publicCalendarSubscriptionDialog
+	let dialog = await calendarPage.openPublicCalendarSubscriptionDialog()
 
-	await dialog.open()
 	await dialog.subscribeToCalendar(publicCalendarName)
 	await dialog.close()
 
 	await calendarPage.expectCalendarExists(publicCalendarName)
-	await dialog.open()
+	dialog = await calendarPage.openPublicCalendarSubscriptionDialog()
 	await dialog.expectSubscribed(publicCalendarName)
 })

--- a/tests/javascript/e2e/support/pages/CalendarPage.ts
+++ b/tests/javascript/e2e/support/pages/CalendarPage.ts
@@ -5,6 +5,7 @@
 
 import type { Locator, Page } from '@playwright/test'
 
+import { EditSimpleDialog } from './EditSimpleDialog.ts'
 import { PublicCalendarSubscriptionDialog } from './PublicCalendarSubscriptionDialog.ts'
 
 /**
@@ -12,10 +13,8 @@ import { PublicCalendarSubscriptionDialog } from './PublicCalendarSubscriptionDi
  */
 export class CalendarPage {
 	calendarNavigation: Locator
-	publicCalendarSubscriptionDialog: PublicCalendarSubscriptionDialog
 
 	constructor(private readonly page: Page) {
-		this.publicCalendarSubscriptionDialog = new PublicCalendarSubscriptionDialog(page)
 		this.calendarNavigation = page.getByRole('navigation', { name: 'Calendar navigation' })
 	}
 
@@ -25,5 +24,27 @@ export class CalendarPage {
 
 	async expectCalendarExists(calendarName: string) {
 		return this.calendarNavigation.getByRole('link', { name: calendarName }).isVisible()
+	}
+
+	async openPublicCalendarSubscriptionDialog() {
+		await this.page
+			.getByText('My calendarsAdd new')
+			.getByRole('button', { name: 'Actions' })
+			.click()
+		await this.page.getByRole('menuitem', { name: 'Add custom public calendar' }).click()
+
+		return new PublicCalendarSubscriptionDialog(this.page)
+	}
+
+	async createNewEvent() {
+		await this.page.getByRole('button', { name: 'Create new event' }).click()
+
+		// Wait for autofocus (`v-focus`) to complete before continuing with any further actions.
+        // Focus changing suddenly in between other actions can break tests.
+		await this.page.getByRole('textbox', { name: 'Title' })
+			.and(this.page.locator(':focus'))
+			.waitFor({ state: 'attached' })
+
+		return new EditSimpleDialog(this.page)
 	}
 }

--- a/tests/javascript/e2e/support/pages/EditFullDialog.ts
+++ b/tests/javascript/e2e/support/pages/EditFullDialog.ts
@@ -1,0 +1,29 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { type Locator, type Page } from '@playwright/test'
+import { FreeBusyDialog } from './FreeBusyDialog'
+
+/**
+ * Encapsulate interactions with the detailed event editor dialog.
+ */
+export class EditFullDialog {
+	locator: Locator
+
+	constructor(private readonly page: Page) {
+		this.locator = page.getByRole('dialog', { name: 'Detailed event editor' })
+	}
+
+	async addAttende(name: string) {
+		const attendeesInput = this.locator.getByRole('combobox', { name: 'Search for attendees' })
+		await attendeesInput.fill(name)
+		await this.page.getByRole('option', { name: name }).click()
+	}
+
+	async openFreeBusyDialog() {
+		await this.locator.getByRole('button', { name: 'Find a time' }).click()
+		return new FreeBusyDialog(this.page)
+	}
+}

--- a/tests/javascript/e2e/support/pages/EditSimpleDialog.ts
+++ b/tests/javascript/e2e/support/pages/EditSimpleDialog.ts
@@ -1,0 +1,38 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { type Locator, type Page } from '@playwright/test'
+import { EditFullDialog } from './EditFullDialog'
+
+/**
+ * Encapsulate interactions with the simple event editor dialog.
+ */
+export class EditSimpleDialog {
+	locator: Locator
+
+	constructor(private readonly page: Page) {
+		this.locator = page.getByRole('dialog', { name: 'Simple event editor' })
+	}
+
+	async addAttende(name: string) {
+		const attendeesInput = this.locator.getByRole('combobox', { name: 'Search for attendees' })
+		await attendeesInput.fill(name)
+		await this.page.getByRole('option', { name: name }).click()
+	}
+
+	async openDetailedEditor() {
+		await this.page.getByRole('button', { name: 'More Details' }).click()
+		return new EditFullDialog(this.page)
+	}
+
+	async fillTitle(title: string) {
+		await this.locator.getByRole('textbox', { name: 'Title' }).click()
+		await this.locator.getByRole('textbox', { name: 'Title' }).fill(title)
+	}
+
+	async save() {
+		await this.locator.getByRole('button', { name: 'Save' }).click()
+	}
+}

--- a/tests/javascript/e2e/support/pages/FreeBusyDialog.ts
+++ b/tests/javascript/e2e/support/pages/FreeBusyDialog.ts
@@ -1,0 +1,27 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { type Locator, type Page } from '@playwright/test'
+
+/**
+ * Encapsulate interactions with the free-busy dialog.
+ */
+export class FreeBusyDialog {
+	locator: Locator
+
+	constructor(private readonly page: Page) {
+		this.locator = page.getByRole('dialog', { name: 'Availability of attendees, resources and rooms' })
+	}
+
+	async addAttende(name: string) {
+		const attendeesInput = this.locator.getByRole('combobox', { name: 'Search for attendees' })
+		await attendeesInput.fill(name)
+		await this.page.getByRole('option', { name: name }).click()
+	}
+
+	async removeUser(name: string) {
+		this.locator.locator('.option').filter({ hasText: name }).getByRole('button', { name: 'Delete' }).click()
+	}
+}

--- a/tests/javascript/e2e/support/pages/PublicCalendarSubscriptionDialog.ts
+++ b/tests/javascript/e2e/support/pages/PublicCalendarSubscriptionDialog.ts
@@ -9,33 +9,22 @@ import { type Locator, type Page, expect } from '@playwright/test'
  * Encapsulate common interactions with the public calendar subscription dialog.
  */
 export class PublicCalendarSubscriptionDialog {
-	dialog: Locator
+	locator: Locator
 
 	constructor(private readonly page: Page) {
-		this.dialog = page.getByRole('dialog', { name: 'Public calendar subscriptions' })
-	}
-
-	async open() {
-		await this.page
-			.getByText('My calendarsAdd new')
-			.getByRole('button', { name: 'Actions' })
-			.click()
-
-		await this.page.getByRole('menuitem', { name: 'Add custom public calendar' }).click()
-
-		await expect(this.dialog).toBeVisible()
+		this.locator = page.getByRole('dialog', { name: 'Public calendar subscriptions' })
 	}
 
 	async close() {
-		await this.dialog.getByLabel('Close').click()
+		await this.locator.getByLabel('Close').click()
 	}
 
 	async subscribeToCalendar(calendarName: string) {
-		await this.dialog.getByText(calendarName + 'Subscribe').getByRole('button', { name: 'Subscribe' }).click()
+		await this.locator.getByText(calendarName + 'Subscribe').getByRole('button', { name: 'Subscribe' }).click()
 		await this.expectSubscribed(calendarName)
 	}
 
 	async expectSubscribed(calendarName: string) {
-		await expect(this.dialog.getByText(calendarName + 'Subscribed')).toBeVisible()
+		await expect(this.locator.getByText(calendarName + 'Subscribed')).toBeVisible()
 	}
 }

--- a/tests/javascript/e2e/support/provisioning.ts
+++ b/tests/javascript/e2e/support/provisioning.ts
@@ -37,17 +37,26 @@ export class ProvisioningFacade {
 		return this.api
 	}
 
-	async createUser() {
+	async createUser({
+		displayName = 'userDefault',
+		email = 'userDefault@example.com'
+	} = {}) {
 		const user = {
 			userId: `user-${crypto.randomUUID()}`,
 			password: DEFAULT_USER_PASSWORD,
+		}
+		const userRequestData = {
+			userid: user.userId,
+			password: user.password,
+			displayName: displayName,
+			email: email
 		}
 		const api = await this.getAPI()
 
 		// NOTE Possible improvement: Generate client from OpenAPI spec
 		// See https://docs.nextcloud.com/server/stable/developer_manual/_static/openapi.html#/operations/provisioning_api-users-add-user
 		const res = await api.post('/ocs/v2.php/cloud/users', {
-			data: { userid: user.userId, password: user.password },
+			data: userRequestData,
 		})
 
 		if (!res.ok()) {


### PR DESCRIPTION
Fixes #8590

Additionally, for adding clean E2E tests small a11y related thing where improved. The changes have their separate commits.

### Case A: Close (Using X in top right corner)

#### Before

Getting warning that makes no sense.

https://github.com/user-attachments/assets/b413e97b-d036-4e5b-bacd-71e243556cb9

#### After

Not getting a warning.

https://github.com/user-attachments/assets/bcbab848-466c-4596-a6c6-a460d8f70a36

### Case B: Automatically close after removing last user

#### Before

Error and overlay remaining.

https://github.com/user-attachments/assets/6eb13f6c-6762-48e2-9119-3448cd22f7e9

#### After

Closing and showing warning as expected.

https://github.com/user-attachments/assets/342f9c1e-3add-4f4c-b14f-7a58662b5b33


