### PR TITLE
 fix(editor): unable to change dates through date picker in free busy dialog

### DIFF
--- a/src/components/Editor/FreeBusy/FreeBusy.vue
+++ b/src/components/Editor/FreeBusy/FreeBusy.vue
@@ -74,7 +74,7 @@
 						<NcDateTimePickerNative
 							:hideLabel="true"
 							:modelValue="currentStart"
-							@input="(date) => handleActions('picker', date)" />
+							@update:modelValue="(date) => handleActions('picker', date)" />
 						<NcButton
 							variant="secondary"
 							:aria-label="isRTL ? t('calendar', 'Next date') : t('calendar', 'Previous date')"
@@ -132,7 +132,7 @@
 						<NcDateTimePickerNative
 							:hideLabel="true"
 							:modelValue="currentStart"
-							@input="(date) => handleActions('picker', date)" />
+							@update:modelValue="(date) => handleActions('picker', date)" />
 						<NcButton
 							variant="secondary"
 							:aria-label="isRTL ? t('calendar', 'Next date') : t('calendar', 'Previous date')"

--- a/src/components/Editor/FreeBusy/FreeBusy.vue
+++ b/src/components/Editor/FreeBusy/FreeBusy.vue
@@ -661,6 +661,10 @@ export default {
 					calendar.next()
 					break
 				case 'picker':
+					// `date` is `null` when the "clear" button of the native date input was used.
+					if (date === null) {
+						return
+					}
 					calendar.gotoDate(date)
 					break
 			}


### PR DESCRIPTION
-  fix(editor): unable to change dates through date picker in free busy dialog
  - before: see #8623
  - after
  
    https://github.com/user-attachments/assets/113b5585-ed44-4247-8193-c4146cd4fe25


-  fix(editor): using clear button breaks date picker in free busy dialog
  - before: same effects as in #8623
  - after

    https://github.com/user-attachments/assets/f52e41ea-9ccf-45fc-8ab9-17b4d6cd25a9


---

I will check the other usages of `NcDateTimePicker` for similar bugs an open separate PRs.

---

Didn't add tests, because do not want to add heavy E2E for it, but setting up component tests is out of scope for this in between bug fix for me.

Resolves #8623