### PR TITLE
fix(editor): using clear button breaks date picker in room availability modal

### DIFF
--- a/src/components/Editor/FreeBusy/RoomAvailabilityModal.vue
+++ b/src/components/Editor/FreeBusy/RoomAvailabilityModal.vue
@@ -310,6 +310,10 @@ export default {
 					calendar.next()
 					break
 				case 'picker':
+					// `date` is `null` when the "clear" button of the native date input was used.
+					if (date === null) {
+						return
+					}
 					calendar.gotoDate(date)
 					break
 			}

--- a/src/components/Editor/FreeBusy/RoomAvailabilityModal.vue
+++ b/src/components/Editor/FreeBusy/RoomAvailabilityModal.vue
@@ -263,7 +263,6 @@ export default {
 				...getFullCalendarLocale(),
 				// Rendering
 				height: 'auto',
-				loading: this.loading,
 				headerToolbar: false,
 				resourceAreaColumns: [
 					{
@@ -283,8 +282,6 @@ export default {
 					day: 'numeric',
 					weekday: 'long',
 				},
-
-				dateClick: this.findFreeSlots(),
 			}
 		},
 


### PR DESCRIPTION
- fix(editor): using clear button breaks date picker in room availability modal
  - Before: 
     - Click "Clear"
     - Get JS error because of unexpected `null` value and broken UI.
   Similar to fix in https://github.com/nextcloud/calendar/pull/8624
  - After: User can clear date, and after the still navigate to another date again.
 
  

     https://github.com/user-attachments/assets/0f4fd5ca-88f0-4bf0-8cde-a9f397061b17


   
- fix(editor): resolve console warnings about unused properties in room availability modal
   - See commit message for resolved warnings