### PR TITLE
chore: add support for test written in TypeScript

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -6,6 +6,8 @@
 import { recommended } from '@nextcloud/eslint-config'
 import pluginVue from 'eslint-plugin-vue'
 import tseslint from 'typescript-eslint'
+import vitest from '@vitest/eslint-plugin'
+import jsdoc from 'eslint-plugin-jsdoc'
 
 export default [
 	...recommended,
@@ -14,6 +16,7 @@ export default [
 		plugins: {
 			vue: pluginVue,
 			'@typescript-eslint': tseslint.plugin,
+			'jsdoc': jsdoc,
 		},
 		rules: {
 			// Relax some rules for now. Can be improved later on (baseline).
@@ -29,6 +32,20 @@ export default [
 			'jsdoc/require-param': ['warn', { enableFixer: false }],
 			// Forbid empty JSDocs
 			'jsdoc/no-blank-blocks': ['error', { enableFixer: true }],
+		},
+	},
+	{
+		files: ['tests/**'],
+		plugins: {
+			vitest,
+		},
+		rules: {
+			...vitest.configs.recommended.rules,
+		},
+		languageOptions: {
+			globals: {
+				...vitest.environments.env.globals,
+			},
 		},
 	},
 ]

--- a/package-lock.json
+++ b/package-lock.json
@@ -65,6 +65,7 @@
         "@types/node": "^26.1.1",
         "@vitejs/plugin-vue": "^6.0.7",
         "@vitest/coverage-v8": "^4.1.10",
+        "@vitest/eslint-plugin": "^1.6.23",
         "@vue/compiler-sfc": "^3.5.40",
         "@vue/test-utils": "^2.4.11",
         "css-loader": "^7.1.4",
@@ -2629,7 +2630,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2643,7 +2643,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2657,7 +2656,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2671,7 +2669,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2685,7 +2682,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2699,7 +2695,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2713,7 +2708,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2727,7 +2721,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2741,7 +2734,6 @@
       "cpu": [
         "wasm32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -2754,7 +2746,6 @@
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
       "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -2766,7 +2757,6 @@
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
       "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -2777,7 +2767,6 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
       "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -2791,7 +2780,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2805,7 +2793,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2819,7 +2806,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3672,6 +3658,37 @@
       },
       "peerDependenciesMeta": {
         "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/eslint-plugin": {
+      "version": "1.6.23",
+      "resolved": "https://registry.npmjs.org/@vitest/eslint-plugin/-/eslint-plugin-1.6.23.tgz",
+      "integrity": "sha512-CbrXxQpIUMbeyylGlxaxTgnWYM44et4Nx58swl7+vrTyC9Ttx+hQoy8BGCregbbZ08K5qFhRHeoad1VvERUbkg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "^8.58.0",
+        "@typescript-eslint/utils": "^8.58.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/eslint-plugin": "*",
+        "eslint": ">=8.57.0",
+        "typescript": ">=5.0.0",
+        "vitest": "*"
+      },
+      "peerDependenciesMeta": {
+        "@typescript-eslint/eslint-plugin": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        },
+        "vitest": {
           "optional": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -99,6 +99,7 @@
     "@types/node": "^26.1.1",
     "@vitejs/plugin-vue": "^6.0.7",
     "@vitest/coverage-v8": "^4.1.10",
+    "@vitest/eslint-plugin": "^1.6.23",
     "@vue/compiler-sfc": "^3.5.40",
     "@vue/test-utils": "^2.4.11",
     "css-loader": "^7.1.4",

--- a/src/components/AppNavigation/EditCalendarModal/SharingSearch.vue
+++ b/src/components/AppNavigation/EditCalendarModal/SharingSearch.vue
@@ -58,7 +58,7 @@ import AccountMultiple from 'vue-material-design-icons/AccountMultiple.vue'
 import { principalPropertySearchByDisplaynameOrEmail } from '../../../services/caldavService.js'
 import useCalendarsStore from '../../../store/calendars.js'
 import usePrincipalsStore from '../../../store/principals.js'
-import { urldecode } from '../../../utils/url.js'
+import { urldecode } from '@/utils/url.ts'
 
 export default {
 	name: 'SharingSearch',

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -7,9 +7,9 @@
  * Works like urldecode() from php
  *
  * @see https://www.php.net/manual/en/function.urldecode.php
- * @param {string} url The url to be decoded
- * @return {string} The decoded url
+ * @param url - The url to be decoded
+ * @return The decoded url
  */
-export function urldecode(url) {
+export function urldecode(url: string) {
 	return decodeURIComponent(url.replace(/\+/g, ' '))
 }

--- a/tests/javascript/unit/setup.js
+++ b/tests/javascript/unit/setup.js
@@ -68,3 +68,8 @@ globalThis.OC = {
 		version: '34.0.0',
 	},
 }
+
+// To disable warning: [ERROR] @nextcloud/vue: The `@nextcloud/vue` library was used without setting / replacing the `appName`. { app: '@nextcloud/vue', level: 2 }
+globalThis.appName = 'calendar'
+// To disable warning: [ERROR] @nextcloud/vue: The `@nextcloud/vue` library was used without setting / replacing the `appVersion`. { app: '@nextcloud/vue', level: 2 }
+globalThis.appVersion = '0.0.0'

--- a/tests/javascript/unit/utils/url.test.ts
+++ b/tests/javascript/unit/utils/url.test.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-import { urldecode } from '../../../../src/utils/url'
+import { urldecode } from '@/utils/url'
 
 describe('utils/url test suite', () => {
 	it('should decode urls encoded by php', () => {

--- a/tests/tsconfig.json
+++ b/tests/tsconfig.json
@@ -1,0 +1,8 @@
+{
+	"extends": "../tsconfig.json",
+    "include": ["**/*.ts", "**/*.vue"],
+	"compilerOptions": {
+		"rootDir": "..",
+		"types": ["vitest/globals"]
+	},
+}

--- a/tests/tsconfig.json.license
+++ b/tests/tsconfig.json.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,7 @@
 		"allowSyntheticDefaultImports": true,
 		"paths": {
 			"@/*": ["./src/*"]
-		}
+		},
 	},
 	"vueCompilerOptions": {
 		"target": "2.7"

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -3,15 +3,15 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-import { defineConfig } from 'vitest/config'
 import vue from '@vitejs/plugin-vue'
 import { fileURLToPath } from 'node:url'
+import { defineConfig } from 'vitest/config'
 
 export default defineConfig({
 	plugins: [vue()],
 	resolve: {
 		alias: {
-			'@': fileURLToPath(new URL('./src', import.meta.url))
+			'@': fileURLToPath(new URL('./src', import.meta.url)),
 		},
 	},
 	test: {
@@ -26,6 +26,14 @@ export default defineConfig({
 		pool: 'vmForks',
 		// Increase timeouts for slow CI environments
 		testTimeout: 300000, // 2 minutes per test
-		hookTimeout: 60000,  // 60 seconds for hooks
+		hookTimeout: 60000, // 60 seconds for hooks,
+		server: {
+			deps: {
+				// Workaround "SyntaxError: Cannot use import statement outside a module"
+				// caused by "import { Picker, Emoji, EmojiIndex } from 'emoji-mart-vue-fast/src'"
+				// in NcEmojiPicker.vue
+				inline: '@nextcloud/vue',
+			},
+		},
 	},
-});
+})


### PR DESCRIPTION
- configure Vitest, TypeScript and ESLint
- convert `tests/javascript/unit/utils/url.test.ts` as an example
