### PR TITLE
fix(editor): time input for relative reminders to all day events

### DIFF
--- a/src/components/Shared/TimePicker.vue
+++ b/src/components/Shared/TimePicker.vue
@@ -5,11 +5,11 @@
 
 <template>
 	<DateTimePicker
-		:value="date"
+		v-model="internalValue"
 		type="time"
 		:hideLabel="true"
 		v-bind="$attrs"
-		@input="change" />
+		@blur="restoreClearedInput" />
 </template>
 
 <script>
@@ -32,17 +32,43 @@ export default {
 
 	data() {
 		return {
+			cleared: false,
 		}
+	},
+
+	computed: {
+		/**
+		 * Value displayed and manipulated by the wrapped NcDateTimePickerNative.
+		 * Coordinates passing the `date` and emitting changes to it
+		 * while tracking an intermediate state where NcDateTimePickerNative is cleared.
+		 */
+		internalValue: {
+			get() {
+				if (this.cleared) {
+					return null
+				}
+				return this.date
+			},
+
+			set(newValue) {
+				if (newValue === null) {
+					this.cleared = true
+					return
+				}
+				this.cleared = false
+				if (this.date.getHours() !== newValue.getHours() || this.date.getMinutes() !== newValue.getMinutes()) {
+					this.$emit('change', newValue)
+				}
+			},
+		},
 	},
 
 	methods: {
 		/**
-		 * Emits a change event for the Date
-		 *
-		 * @param {Date} date The new Date object
+		 * Restores last valid date into a input, if input is cleared.
 		 */
-		change(date) {
-			this.$emit('change', date)
+		restoreClearedInput() {
+			this.cleared = false
 		},
 	},
 }

--- a/tests/javascript/unit/components/shared/TimePicker.test.js
+++ b/tests/javascript/unit/components/shared/TimePicker.test.js
@@ -1,0 +1,85 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { mount } from '@vue/test-utils'
+import { describe, expect, it } from 'vitest'
+import { nextTick } from 'vue'
+import TimePicker from '@/components/Shared/TimePicker.vue'
+
+describe('TimePicker', () => {
+	it('displays provided date', async () => {
+		const wrapper = mount(TimePicker, {
+			props: {
+				date: new Date('2026-07-11T09:00:00Z'),
+			},
+		})
+
+		expect(wrapper.html()).toContain('09:00')
+	})
+
+	it('emits change', async () => {
+		const wrapper = mount(TimePicker, {
+			props: {
+				date: new Date('2026-07-11T09:00:00Z'),
+			},
+		})
+
+		const input = wrapper.get('input[type="time"]')
+		await input.setValue('11:30')
+
+		expect(wrapper.emitted('change')).toEqual([[new Date('2026-07-11T11:30:00Z')]])
+	})
+
+	it('does not emit change after inputing same time', async () => {
+		const wrapper = mount(TimePicker, {
+			props: {
+				date: new Date('2026-07-11T09:00:00Z'),
+			},
+		})
+
+		const input = wrapper.get('input[type="time"]')
+		await input.setValue('')
+		await input.setValue('09:00')
+
+		expect(wrapper.html()).toContain('09:00')
+		expect(wrapper.emitted('change')).toBeUndefined()
+	})
+
+	it('does cleared input without emmiting change', async () => {
+		const wrapper = mount(TimePicker, {
+			props: {
+				date: new Date('2026-07-11T09:00:00Z'),
+			},
+		})
+
+		const input = wrapper.get('input[type="time"]')
+		await input.setValue('')
+
+		expect(wrapper.html()).not.toContain('09:00')
+		// We do not expect to see a change event for a cleared input.
+		// A cleared input is just an intermediate state.
+		expect(wrapper.emitted('change')).toBeUndefined()
+	})
+
+	it('resets cleared input after losing focus', async () => {
+		const wrapper = mount(TimePicker, {
+			attachTo: document.body,
+			props: {
+				date: new Date('2026-07-11T09:00:00Z'),
+			},
+		})
+		const input = wrapper.get('input[type="time"]')
+		input.element.focus()
+		await input.setValue('')
+
+		input.element.blur()
+		await nextTick()
+
+		expect(wrapper.html()).toContain('09:00')
+		// We do not expect to see a change event for restoring a cleared input.
+		// A cleared input was just an intermediate state.
+		expect(wrapper.emitted('change')).toBeUndefined()
+	})
+})


### PR DESCRIPTION
#### Before

- Time is not shown initially
- Time cannot be editing

https://github.com/user-attachments/assets/86b10a8e-42ca-48d7-9793-995c69d2f646

#### After

- Time is shown initially
- Time can be edited and saved
-  Clearing the time input is handled by restoring the last valid value on changing focus
  - Clearing cannot be disabled with native inputs
  - Clearing in general makes sense to have an intermediate input state
    - But in some cases user might continue without inputting a new value

https://github.com/user-attachments/assets/01cf70ba-81ec-44c3-9b99-8c137d88af1e