### PR TITLE
[stable6.5] fix: remove min-height for shorter meetings

### DIFF
--- a/css/fullcalendar.scss
+++ b/css/fullcalendar.scss
@@ -282,10 +282,6 @@
 }
 
 .fc-v-event {
-	&.fc-timegrid-event-short {
-		min-height: 2em;
-	}
-
 	.fc-event-title {
 		white-space: initial;
 	}


### PR DESCRIPTION
Manual backport of https://github.com/nextcloud/calendar/pull/8489

## 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
