### PR TITLE
fix(email): correct spelling of occurred in error message

### DIFF
--- a/lib/Controller/EmailController.php
+++ b/lib/Controller/EmailController.php
@@ -122,7 +122,7 @@ class EmailController extends Controller {
 
 		if ($calendar === null) {
 			return new JSONResponse([
-				'message' => $this->l10n->t('An error occured during sending email'),
+				'message' => $this->l10n->t('An error occurred during sending email'),
 			], Http::STATUS_BAD_REQUEST);
 		}
 

--- a/tests/php/unit/Controller/EmailControllerTest.php
+++ b/tests/php/unit/Controller/EmailControllerTest.php
@@ -173,7 +173,7 @@ class EmailControllerTest extends TestCase {
 		);
 
 		$this->assertEquals([
-			'message' => 'TRANSLATED: An error occured during sending email'
+			'message' => 'TRANSLATED: An error occurred during sending email'
 		], $response->getData());
 		$this->assertEquals(Http::STATUS_BAD_REQUEST, $response->getStatus());
 	}


### PR DESCRIPTION
## Summary

Fixes a spelling error in the English source string for the email error message.

## Changes

| File | Correction |
|---|---|
| `lib/Controller/EmailController.php` | `occured` → `occurred` |
| `tests/php/unit/Controller/EmailControllerTest.php` | `occured` → `occurred` |

The source string "An error occured during sending email" is the basis for all translations. Fixing it here propagates to all languages.

## AI Assistance

This contribution was made with the help of DeepSeek V4 Pro.

Assisted-by: DeepSeek:V4-Pro