### PR TITLE
fix(dashboard): honor fixed-offset event timezones

### DIFF
--- a/lib/Dashboard/CalendarWidget.php
+++ b/lib/Dashboard/CalendarWidget.php
@@ -190,8 +190,10 @@ class CalendarWidget implements IAPIWidget, IAPIWidgetV2, IButtonWidget, IIconWi
 		$dateTime = $dateTimeProperty[0];
 		$parameters = $dateTimeProperty[1] ?? [];
 		$tzid = isset($parameters['TZID']) ? (string)$parameters['TZID'] : '';
+		$valueType = isset($parameters['VALUE']) ? (string)$parameters['VALUE'] : '';
 
-		if (preg_match('/^UTC([+-])(\d{2}):?(\d{2})$/i', $tzid, $matches) !== 1) {
+		if (strcasecmp($valueType, 'DATE') === 0
+			|| preg_match('/^UTC([+-])(\d{2}):?(\d{2})$/i', $tzid, $matches) !== 1) {
 			return $dateTime;
 		}
 

--- a/lib/Dashboard/CalendarWidget.php
+++ b/lib/Dashboard/CalendarWidget.php
@@ -11,6 +11,7 @@ namespace OCA\Calendar\Dashboard;
 use DateInterval;
 use DateTime;
 use DateTimeImmutable;
+use DateTimeZone;
 use OCA\Calendar\AppInfo\Application;
 use OCA\Calendar\Service\JSDataService;
 use OCP\AppFramework\Services\IInitialState;
@@ -146,16 +147,17 @@ class CalendarWidget implements IAPIWidget, IAPIWidgetV2, IButtonWidget, IIconWi
 			foreach ($searchResult as $calendarEvent) {
 				// Find first recurrence in the future
 				$recurrence = null;
+				$startDate = null;
 				foreach ($calendarEvent['objects'] as $object) {
-					/** @var DateTimeImmutable $startDate */
-					$startDate = $object['DTSTART'][0];
-					if ($startDate->getTimestamp() >= $dateTime->getTimestamp()) {
+					$objectStartDate = $this->normalizeFixedOffsetDateTime($object['DTSTART']);
+					if ($objectStartDate->getTimestamp() >= $dateTime->getTimestamp()) {
 						$recurrence = $object;
+						$startDate = $objectStartDate;
 						break;
 					}
 				}
 
-				if ($recurrence === null) {
+				if ($recurrence === null || $startDate === null) {
 					continue;
 				}
 
@@ -175,6 +177,38 @@ class CalendarWidget implements IAPIWidget, IAPIWidgetV2, IButtonWidget, IIconWi
 		});
 
 		return $widgetItems;
+	}
+
+	/**
+	 * Sabre VObject falls back to PHP's default timezone when it cannot resolve
+	 * non-IANA fixed-offset TZIDs such as UTC-04:00. Preserve the parsed wall
+	 * clock and attach the explicit offset before the widget emits a timestamp.
+	 *
+	 * @param array{0: DateTimeImmutable, 1?: array<string, mixed>} $dateTimeProperty
+	 */
+	private function normalizeFixedOffsetDateTime(array $dateTimeProperty): DateTimeImmutable {
+		$dateTime = $dateTimeProperty[0];
+		$parameters = $dateTimeProperty[1] ?? [];
+		$tzid = isset($parameters['TZID']) ? (string)$parameters['TZID'] : '';
+
+		if (preg_match('/^UTC([+-])(\d{2}):?(\d{2})$/i', $tzid, $matches) !== 1) {
+			return $dateTime;
+		}
+
+		$hours = (int)$matches[2];
+		$minutes = (int)$matches[3];
+		if ($hours > 23 || $minutes > 59) {
+			return $dateTime;
+		}
+
+		$timeZone = new DateTimeZone(sprintf('%s%02d:%02d', $matches[1], $hours, $minutes));
+		$normalized = DateTimeImmutable::createFromFormat(
+			'!Y-m-d H:i:s.u',
+			$dateTime->format('Y-m-d H:i:s.u'),
+			$timeZone,
+		);
+
+		return $normalized ?: $dateTime;
 	}
 
 	private function getCalendarDotIconUrl(?string $color): string {

--- a/tests/php/unit/Dashbaord/CalendarWidgetTest.php
+++ b/tests/php/unit/Dashbaord/CalendarWidgetTest.php
@@ -234,6 +234,8 @@ class CalendarWidgetTest extends TestCase {
 		$this->assertCount(1, $widgets);
 		$this->assertSame((string)$expectedStart->getTimestamp(), $widgets[0]->getSinceId());
 		$this->assertSame('in 10 hours', $widgets[0]->getSubtitle());
+		$this->assertSame($backendStart, $result['objects'][0]['DTSTART'][0]);
+		$this->assertSame('UTC-04:00', $result['objects'][0]['DTSTART'][1]['TZID']);
 	}
 
 	public function testGetItemsCachesCalendarDotPerRequest(): void {

--- a/tests/php/unit/Dashbaord/CalendarWidgetTest.php
+++ b/tests/php/unit/Dashbaord/CalendarWidgetTest.php
@@ -175,6 +175,67 @@ class CalendarWidgetTest extends TestCase {
 		$this->assertEquals($widgets[0], $widget);
 	}
 
+	public function testGetItemsNormalizesFixedOffsetTimeZone(): void {
+		$userId = 'admin';
+		$calendar = $this->createMock(ITestCalendar::class);
+		$time = (new DateTimeImmutable('2026-07-28 04:30:00 UTC'))->getTimestamp();
+		$rangeStart = (new DateTimeImmutable())->setTimestamp($time);
+		$backendStart = new DateTimeImmutable('2026-07-28 11:15:00 UTC');
+		$expectedStart = new DateTimeImmutable('2026-07-28 11:15:00 -04:00');
+		$options = [
+			'timerange' => [
+				'start' => $rangeStart,
+				'end' => $rangeStart->add(new \DateInterval('P14D')),
+			],
+		];
+		$result = [
+			'id' => '3601',
+			'uid' => 'fixed-offset-event',
+			'uri' => 'fixed-offset-event.ics',
+			'objects' => [[
+				'DTSTART' => [
+					$backendStart,
+					['TZID' => 'UTC-04:00'],
+				],
+				'SUMMARY' => ['Fixed offset event'],
+			]],
+		];
+
+		$this->calendarManager->expects(self::once())
+			->method('getCalendarsForPrincipal')
+			->with('principals/users/' . $userId)
+			->willReturn([$calendar]);
+		$this->timeFactory->expects(self::once())
+			->method('getTime')
+			->willReturn($time);
+		$calendar->expects(self::once())
+			->method('isEnabled')
+			->willReturn(true);
+		$calendar->expects(self::once())
+			->method('isDeleted')
+			->willReturn(false);
+		$calendar->expects(self::once())
+			->method('search')
+			->with('', [], $options, 7)
+			->willReturn([$result]);
+		$calendar->expects(self::once())
+			->method('getDisplayColor')
+			->willReturn('#ffffff');
+		$this->dateTimeFormatter->expects(self::once())
+			->method('formatTimeSpan')
+			->with(self::callback(static fn (\DateTime $dateTime): bool => $dateTime->getTimestamp() === $expectedStart->getTimestamp()))
+			->willReturn('in 10 hours');
+		$this->urlGenerator->expects(self::once())
+			->method('getAbsoluteURL')
+			->willReturn('fixed-offset-event');
+
+		$widgets = $this->widget->getItems($userId);
+
+		$this->assertCount(1, $widgets);
+		$this->assertSame((string)$expectedStart->getTimestamp(), $widgets[0]->getSinceId());
+		$this->assertSame('in 10 hours', $widgets[0]->getSubtitle());
+	}
+
 	public function testGetItemsCachesCalendarDotPerRequest(): void {
 		$userId = 'admin';
 		$calendarA = $this->createMock(ITestCalendar::class);

--- a/tests/php/unit/Dashbaord/CalendarWidgetTest.php
+++ b/tests/php/unit/Dashbaord/CalendarWidgetTest.php
@@ -238,6 +238,19 @@ class CalendarWidgetTest extends TestCase {
 		$this->assertSame('UTC-04:00', $result['objects'][0]['DTSTART'][1]['TZID']);
 	}
 
+	public function testFixedOffsetNormalizationLeavesAllDayValueUnchanged(): void {
+		$start = new DateTimeImmutable('2026-07-28 00:00:00 UTC');
+		$normalized = self::invokePrivate($this->widget, 'normalizeFixedOffsetDateTime', [[
+			$start,
+			[
+				'TZID' => 'UTC-04:00',
+				'VALUE' => 'DATE',
+			],
+		]]);
+
+		$this->assertSame($start, $normalized);
+	}
+
 	public function testGetItemsCachesCalendarDotPerRequest(): void {
 		$userId = 'admin';
 		$calendarA = $this->createMock(ITestCalendar::class);


### PR DESCRIPTION
## Summary

- normalize valid `UTC+/-HH:MM` and `UTC+/-HHMM` TZID values before the dashboard widget compares or formats event start times
- preserve the event wall clock while attaching its explicit fixed offset
- leave UTC, IANA TZIDs, floating values, all-day values, and source event data unchanged

## Problem

Sabre VObject falls back to PHP's default timezone when a non-IANA fixed-offset TZID such as `UTC-04:00` cannot be resolved. The Calendar view can still render the wall time correctly, but `CalendarWidget` receives a `DateTimeImmutable` carrying the fallback timezone and emits the wrong `sinceId` and relative subtitle.

For example, `DTSTART;TZID="UTC-04:00":20260728T111500` can be emitted by the dashboard as 11:15 UTC instead of 11:15 at -04:00.

## Validation

- added a full widget regression covering fixed-offset normalization
- asserted the original search result and TZID remain unchanged
- PHP 8.4 syntax checks pass for the implementation and test

The change is display-only and performs no calendar write.
