### PR TITLE
fix(editor): only show a warning about required attendees if the free-busy modal was opened

### DIFF
--- a/src/components/Editor/Invitees/InviteesList.vue
+++ b/src/components/Editor/Invitees/InviteesList.vue
@@ -443,7 +443,7 @@ export default {
 			})
 			this.recentAttendees = this.recentAttendees.filter((a) => a.uri !== attendee.email)
 
-			if (this.calendarObjectInstance.attendees.length === 0) {
+			if (this.showFreeBusyModel && this.calendarObjectInstance.attendees.length === 0) {
 				showWarning(this.$t('calendar', 'Please add at least one attendee to use the "Find a time" feature.'))
 				this.closeFreeBusy()
 			}


### PR DESCRIPTION

### Before: Warning in top right corner at the end)

https://github.com/user-attachments/assets/c09d3d52-d61c-4d20-a76b-1a479ad6f91a


### After: No warning in top right corner at the end)

https://github.com/user-attachments/assets/246f8f46-e90d-4416-81eb-43a31b1ed855


