### PR TITLE
refactor: rspack config and extract css

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,6 +85,11 @@ node_modules/
 src/fonts
 *.clover
 
+# CSS extracted from the JS build (CssExtractRspackPlugin)
+css/calendar-*.css
+css/calendar-*.css.map
+css/chunks/
+
 # just sane ignores
 .*.sw[po]
 *.bak

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -87,5 +87,6 @@ class Application extends App implements IBootstrap {
 		// The contacts menu/avatar is potentially shown everywhere so an event based loading
 		// mechanism doesn't make sense here
 		Util::addScript(self::APP_ID, 'calendar-contacts-menu');
+		Util::addStyle(self::APP_ID, 'calendar-contacts-menu');
 	}
 }

--- a/lib/Controller/ProposalPublicController.php
+++ b/lib/Controller/ProposalPublicController.php
@@ -39,6 +39,7 @@ class ProposalPublicController extends Controller {
 	#[UserRateLimit(limit: 10, period: 300)]
 	public function index(string $token): Response {
 		\OCP\Util::addScript(Application::APP_ID, Application::APP_ID . '-proposal-public');
+		\OCP\Util::addStyle(Application::APP_ID, Application::APP_ID . '-proposal-public');
 
 		return new TemplateResponse(Application::APP_ID, 'public', [], TemplateResponse::RENDER_AS_PUBLIC);
 	}

--- a/lib/Listener/CalendarReferenceListener.php
+++ b/lib/Listener/CalendarReferenceListener.php
@@ -33,5 +33,6 @@ class CalendarReferenceListener implements IEventListener {
 
 		$this->calendarInitialStateService->run();
 		Util::addScript(Application::APP_ID, 'calendar-reference');
+		Util::addStyle(Application::APP_ID, 'calendar-reference');
 	}
 }

--- a/package.json
+++ b/package.json
@@ -107,8 +107,7 @@
     "sass": "^1.102.0",
     "sass-loader": "^17.0.0",
     "typescript": "^6.0.3",
-    "vitest": "^4.1.10",
-    "vue-style-loader": "^4.1.3"
+    "vitest": "^4.1.10"
   },
   "optionalDependencies": {
     "fsevents": "^2.3.3"

--- a/rspack.config.js
+++ b/rspack.config.js
@@ -118,16 +118,32 @@ module.exports = defineConfig((env) => {
 				{
 					test: /\.css$/,
 					use: [
-						'vue-style-loader',
+						{
+							loader: CssExtractRspackPlugin.loader,
+						},
 						'css-loader',
 					],
 				},
 				{
 					test: /\.scss$/,
 					use: [
-						'vue-style-loader',
+						{
+							loader: CssExtractRspackPlugin.loader,
+						},
 						'css-loader',
-						'sass-loader',
+						{
+							loader: 'sass-loader',
+							options: {
+								sassOptions: {
+									// Sass emits a BOM for CSS files with non-ASCII characters in production builds by default.
+									// PostCSS (used by css-loader) >=8.5.24 stopped stripping it, so extracted stylesheets end up
+									// with a stray BOM between merged files, breaking the first selector of each one.
+									// Safe to disable since every page already sets <meta charset="utf-8">.
+									// See: https://github.com/nextcloud-libraries/webpack-vue-config/pull/798
+									charset: false,
+								},
+							},
+						},
 					],
 				},
 				{
@@ -211,6 +227,11 @@ module.exports = defineConfig((env) => {
 			new IgnorePlugin({
 				resourceRegExp: /^\.\/locale$/,
 				contextRegExp: /moment$/,
+			}),
+			new CssExtractRspackPlugin({
+				filename: '../css/calendar-[name].css',
+				chunkFilename: '../css/chunks/[id].chunk.css',
+				ignoreOrder: true,
 			}),
 			process.env.RSDOCTOR && new RsdoctorRspackPlugin(),
 		],

--- a/templates/appointments/booking.php
+++ b/templates/appointments/booking.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
  */
 
 script(\OCA\Calendar\AppInfo\Application::APP_ID, 'calendar-appointments-booking');
+style(\OCA\Calendar\AppInfo\Application::APP_ID, 'calendar-appointments-booking');
 
 ?>
 

--- a/templates/appointments/confirmation.php
+++ b/templates/appointments/confirmation.php
@@ -6,6 +6,7 @@ declare(strict_types=1);
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 script(\OCA\Calendar\AppInfo\Application::APP_ID, 'calendar-appointments-confirmation');
+style(\OCA\Calendar\AppInfo\Application::APP_ID, 'calendar-appointments-confirmation');
 
 ?>
 

--- a/templates/appointments/index.php
+++ b/templates/appointments/index.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
  */
 
 script(\OCA\Calendar\AppInfo\Application::APP_ID, 'calendar-appointments-overview');
+style(\OCA\Calendar\AppInfo\Application::APP_ID, 'calendar-appointments-overview');
 
 ?>
 

--- a/templates/main.php
+++ b/templates/main.php
@@ -5,3 +5,4 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 script('calendar', 'calendar-main');
+style('calendar', 'calendar-main');


### PR DESCRIPTION
### Summary
- Added script loading to all entry points
- Removed vue-style-loader dependency
- Modified rspack config

Shaves a good amount of bulk from the entry point js files

Before:
<img width="1516" height="763" alt="image" src="https://github.com/user-attachments/assets/6001c116-b92e-4310-b0d0-2d575e7dbc41" />

After:
<img width="1592" height="876" alt="Screenshot 2026-08-04 130808" src="https://github.com/user-attachments/assets/286b3616-15e5-4f9b-867e-5b74dd691126" />

## 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
