### PR TITLE
fix: allways allow duplicaiton

### DIFF
--- a/src/fullcalendar/interaction/eventClick.js
+++ b/src/fullcalendar/interaction/eventClick.js
@@ -11,7 +11,8 @@ import useSettingsStore from '@/store/settings.js'
 import useWidgetStore from '@/store/widget.js'
 import {
 	getPrefixedRoute,
-	isPublicOrEmbeddedRoute,
+	getViewMode,
+	ViewMode,
 } from '@/utils/router.js'
 
 /**
@@ -99,7 +100,7 @@ function handleEventClick(event, router, route, window, isWidget = false) {
 function handleToDoClick(event, route, window, isWidget = false) {
 	const settingsStore = useSettingsStore()
 
-	if (isWidget || isPublicOrEmbeddedRoute(route.name)) {
+	if (getViewMode(route.name, isWidget) !== ViewMode.USER) {
 		return
 	}
 

--- a/src/mixins/EditorMixin.js
+++ b/src/mixins/EditorMixin.js
@@ -20,7 +20,7 @@ import { removeMailtoPrefix } from '@/utils/attendee.js'
 import { uidToHexColor } from '@/utils/color.js'
 import { dateFactory } from '@/utils/date.js'
 import logger from '@/utils/logger.js'
-import { getPrefixedRoute } from '@/utils/router.js'
+import { getPrefixedRoute, getViewMode, ViewMode } from '@/utils/router.js'
 
 /**
  * This is a mixin for the editor. It contains common Vue stuff, that is
@@ -292,6 +292,21 @@ export default {
 				return null
 			}
 			return this.principalsStore.getPrincipalByUrl(this.selectedCalendar.delegatorUrl)?.userId ?? null
+		},
+		/**
+		 * Returns the mode the editor is currently rendered in
+		 * (authenticated user, public share, embedded share, or widget).
+		 *
+		 * @return {string} One of ViewMode
+		 */
+		viewMode() {
+			return getViewMode(this.$route?.name, this.isWidget)
+		},
+		/**
+		 * @return {boolean}
+		 */
+		canDuplicate() {
+			return this.viewMode === ViewMode.USER
 		},
 		/**
 		 * Returns whether or not the user is allowed to delete this event
@@ -645,7 +660,7 @@ export default {
 		keyboardDuplicateEvent(event) {
 			if (event.key === 'd' && event.ctrlKey === true) {
 				event.preventDefault()
-				if (!this.isNew && !this.isReadOnly && !this.canCreateRecurrenceException) {
+				if (!this.isNew && this.canDuplicate) {
 					this.duplicateEvent()
 				}
 			}
@@ -701,12 +716,24 @@ export default {
 		},
 
 		/**
-		 * Duplicates a calendar-object and saves it
+		 * Duplicates the calendar-object. If the source calendar is
+		 * read-only, the duplicate is created in the first writable calendar.
 		 *
 		 * @return {Promise<void>}
 		 */
 		async duplicateEvent() {
-			await this.calendarObjectInstanceStore.duplicateCalendarObjectInstance()
+			if (!this.canDuplicate) {
+				return
+			}
+
+			const calendarId = this.isReadOnly
+				? (this.calendarsStore.sortedCalendars[0]?.id ?? null)
+				: (this.calendarObject?.calendarId ?? null)
+			await this.calendarObjectInstanceStore.duplicateCalendarObjectInstance({ calendarId })
+
+			// The editor's calendar picker is driven by this.calendarId, which is
+			// separate from the store's calendarObject.calendarId.
+			this.calendarId = this.calendarObject?.calendarId ?? null
 		},
 
 		/**

--- a/src/models/event.js
+++ b/src/models/event.js
@@ -191,18 +191,6 @@ function mapEventComponentToEventObject(eventComponent) {
 function copyCalendarObjectInstanceIntoEventComponent(eventObject, eventComponent) {
 	const sourceEventComponent = eventObject.eventComponent
 
-	const unexpectedRecurrenceProperties = new Set([
-		'RRULE',
-		'EXRULE',
-		'RDATE',
-		'EXDATE',
-	])
-	for (const property of sourceEventComponent.getPropertyIterator()) {
-		if (unexpectedRecurrenceProperties.has(property.name)) {
-			throw new Error(`Illegal argument: Event objects has recurrence related property ${property.name}.`)
-		}
-	}
-
 	const propertiesExcludedFromCopying = new Set([
 		// These properties are regenerated for the new copy.
 		'UID',
@@ -213,10 +201,48 @@ function copyCalendarObjectInstanceIntoEventComponent(eventObject, eventComponen
 		// Currently only copying as exact occurrences.
 		// Therefore, do not preserve any RECURRENCE-ID.
 		'RECURRENCE-ID',
+		// A duplicate is always a single, standalone event. If the source is
+		// the master item of a recurring series (e.g. when duplicating its
+		// first occurrence, calendar-js returns the master item itself),
+		// its recurrence-defining properties must not carry over.
+		'RRULE',
+		'EXRULE',
+		'RDATE',
+		'EXDATE',
 	])
+
+	// Properties that must not occur more than once on a VEVENT (RFC 5545
+	// section 3.6.1) but that the source may legitimately carry a value for.
+	const propertiesReplacedWhenCopying = new Set([
+		'DTSTART',
+		'DTEND',
+		'DURATION',
+		'CLASS',
+		'DESCRIPTION',
+		'GEO',
+		'LOCATION',
+		'ORGANIZER',
+		'PRIORITY',
+		'STATUS',
+		'SUMMARY',
+		'TRANSP',
+		'URL',
+	])
+
+	// DTEND and DURATION are mutually exclusive. If the source uses DURATION,
+	// a pre-existing target DTEND (or vice versa) would otherwise be left
+	// behind alongside it, which is invalid.
+	if (sourceEventComponent.hasProperty('DTEND') || sourceEventComponent.hasProperty('DURATION')) {
+		eventComponent.deleteAllProperties('DTEND')
+		eventComponent.deleteAllProperties('DURATION')
+	}
+
 	for (const property of sourceEventComponent.getPropertyIterator()) {
 		if (propertiesExcludedFromCopying.has(property.name)) {
 			continue
+		}
+		if (propertiesReplacedWhenCopying.has(property.name)) {
+			eventComponent.deleteAllProperties(property.name)
 		}
 		const successful = eventComponent.addProperty(property.clone())
 		if (!successful) {

--- a/src/store/calendarObjectInstance.js
+++ b/src/store/calendarObjectInstance.js
@@ -1425,9 +1425,11 @@ export default defineStore('calendarObjectInstance', {
 		/**
 		 * Duplicate calendar-object-instance
 		 *
+		 * @param {object} data The destructuring object
+		 * @param {string} data.calendarId The id of the calendar to duplicate the event into. Must be a writable calendar
 		 * @return {Promise<void>}
 		 */
-		async duplicateCalendarObjectInstance() {
+		async duplicateCalendarObjectInstance({ calendarId }) {
 			const calendarObjectsStore = useCalendarObjectsStore()
 
 			const oldCalendarObjectInstance = this.calendarObjectInstance
@@ -1439,7 +1441,7 @@ export default defineStore('calendarObjectInstance', {
 				end: endDate.unixTime,
 				timezoneId: oldEventComponent.startDate.timezoneId,
 				isAllDay: oldEventComponent.isAllDay(),
-				calendarId: this.calendarObject?.calendarId ?? null,
+				calendarId,
 			})
 			const eventComponent = getObjectAtRecurrenceId(calendarObject, startDate.jsDate)
 			copyCalendarObjectInstanceIntoEventComponent(oldCalendarObjectInstance, eventComponent)

--- a/src/utils/router.js
+++ b/src/utils/router.js
@@ -93,11 +93,42 @@ export function getPrefixedRoute(currentRouteName, toRouteName) {
 }
 
 /**
- * Checks whether a routeName represents a public / embedded route
- *
- * @param {string} routeName Name of the route
- * @return {boolean}
+ * The different modes the calendar app can be rendered in.
+ * This is the single source of truth for what "public", "embedded"
+ * and "widget" mean across the app - components should derive their
+ * behaviour from this instead of re-deriving it from route names or
+ * calendar permissions.
  */
-export function isPublicOrEmbeddedRoute(routeName) {
-	return routeName.startsWith('Embed') || routeName.startsWith('Public')
+export const ViewMode = Object.freeze({
+	// A normal, authenticated user viewing their own calendars
+	USER: 'user',
+	// A public share link (/p/:tokens/...)
+	PUBLIC: 'public',
+	// An embedded share link (/embed/:tokens/...)
+	EMBEDDED: 'embedded',
+	// A dashboard / Talk / Text reference widget (no vue-router present)
+	WIDGET: 'widget',
+})
+
+/**
+ * Determines the view mode the calendar is currently rendered in.
+ *
+ * @param {string|undefined|null} routeName Name of the current vue-router route, if any
+ * @param {boolean} isWidget Whether the calendar is rendered as a reference widget
+ * @return {string} One of ViewMode
+ */
+export function getViewMode(routeName, isWidget = false) {
+	if (isWidget) {
+		return ViewMode.WIDGET
+	}
+
+	if (routeName?.startsWith('Embed')) {
+		return ViewMode.EMBEDDED
+	}
+
+	if (routeName?.startsWith('Public')) {
+		return ViewMode.PUBLIC
+	}
+
+	return ViewMode.USER
 }

--- a/src/views/Calendar.vue
+++ b/src/views/Calendar.vue
@@ -147,6 +147,7 @@ import {
 import logger from '@/utils/logger.js'
 import loadMomentLocalization from '@/utils/moment.js'
 import { isAfterVersion } from '@/utils/nextcloudVersion.ts'
+import { getViewMode, ViewMode } from '@/utils/router.js'
 
 import '@nextcloud/dialogs/style.css'
 
@@ -237,35 +238,36 @@ export default {
 			return getYYYYMMDDFromFirstdayParam(this.$route?.params?.firstDay ?? 'now')
 		},
 
+		// The mode this calendar is currently rendered in. This is the single
+		// source of truth for public/embedded/widget state
+		viewMode() {
+			if (this.isWidget) {
+				return this.isPublic ? ViewMode.PUBLIC : ViewMode.WIDGET
+			}
+			return getViewMode(this.$route?.name)
+		},
+
 		isEditable() {
 			// We do not allow drag and drop when the editor is open.
-			return !this.isPublicShare
-				&& !this.isEmbedded
-				&& !this.isWidget
+			return this.isAuthenticatedUser
 				&& this.$route?.name !== 'EditPopoverView'
 				&& this.$route?.name !== 'EditFullView'
 		},
 
 		isSelectable() {
-			return !this.isPublicShare && !this.isEmbedded && !this.isWidget
+			return this.isAuthenticatedUser
 		},
 
 		isAuthenticatedUser() {
-			return !this.isPublicShare && !this.isEmbedded && !this.isWidget
+			return this.viewMode === ViewMode.USER
 		},
 
 		isPublicShare() {
-			if (this.isWidget) {
-				return false
-			}
-			return this.$route.name.startsWith('Public')
+			return this.viewMode === ViewMode.PUBLIC
 		},
 
 		isEmbedded() {
-			if (this.isWidget) {
-				return false
-			}
-			return this.$route.name.startsWith('Embed')
+			return this.viewMode === ViewMode.EMBEDDED
 		},
 
 		showWidgetEventDetails() {
@@ -348,7 +350,7 @@ export default {
 		})
 		this.settingsStore.initializeCalendarJsConfig()
 
-		if (this.$route?.name.startsWith('Public') || this.$route?.name.startsWith('Embed') || this.isPublic) {
+		if (this.viewMode === ViewMode.PUBLIC || this.viewMode === ViewMode.EMBEDDED) {
 			await initializeClientForPublicView()
 			const tokens = this.isWidget ? [this.referenceToken] : this.$route.params.tokens.split('-')
 			const calendars = await this.calendarsStore.getPublicCalendars({ tokens })

--- a/src/views/EditFull.vue
+++ b/src/views/EditFull.vue
@@ -69,7 +69,7 @@
 									</template>
 									{{ $t('calendar', 'Export') }}
 								</NcActionLink>
-								<NcActionButton v-if="!canCreateRecurrenceException && !isReadOnly && !isNew" @click="duplicateEvent()">
+								<NcActionButton v-if="!isNew" @click="duplicateEvent()">
 									<template #icon>
 										<ContentDuplicate :size="20" decorative />
 									</template>

--- a/src/views/EditFull.vue
+++ b/src/views/EditFull.vue
@@ -69,7 +69,7 @@
 									</template>
 									{{ $t('calendar', 'Export') }}
 								</NcActionLink>
-								<NcActionButton v-if="!canCreateRecurrenceException && !isReadOnly && !isNew" @click="duplicateEvent()">
+								<NcActionButton v-if="!isNew && canDuplicate" @click="duplicateEvent()">
 									<template #icon>
 										<ContentDuplicate :size="20" decorative />
 									</template>

--- a/src/views/EditSimple.vue
+++ b/src/views/EditSimple.vue
@@ -82,7 +82,7 @@
 								</template>
 								{{ $t('calendar', 'Export') }}
 							</ActionLink>
-							<ActionButton v-if="!canCreateRecurrenceException && !isReadOnly" @click="duplicateEvent()">
+							<ActionButton @click="duplicateEvent()">
 								<template #icon>
 									<ContentDuplicate :size="20" decorative />
 								</template>

--- a/src/views/EditSimple.vue
+++ b/src/views/EditSimple.vue
@@ -82,7 +82,7 @@
 								</template>
 								{{ $t('calendar', 'Export') }}
 							</ActionLink>
-							<ActionButton v-if="!canCreateRecurrenceException && !isReadOnly" @click="duplicateEvent()">
+							<ActionButton v-if="canDuplicate" @click="duplicateEvent()">
 								<template #icon>
 									<ContentDuplicate :size="20" decorative />
 								</template>

--- a/tests/javascript/unit/fullcalendar/interaction/eventClick.test.js
+++ b/tests/javascript/unit/fullcalendar/interaction/eventClick.test.js
@@ -11,7 +11,8 @@ import EditorMixin from '@/mixins/EditorMixin.js'
 import useSettingsStore from '@/store/settings.js'
 import {
 	getPrefixedRoute,
-	isPublicOrEmbeddedRoute,
+	getViewMode,
+	ViewMode,
 } from '@/utils/router.js'
 
 vi.mock('@/utils/router.js')
@@ -22,7 +23,10 @@ vi.mock('@nextcloud/dialogs')
 describe('fullcalendar/eventClick test suite', () => {
 	beforeEach(() => {
 		getPrefixedRoute.mockClear()
-		isPublicOrEmbeddedRoute.mockClear()
+		getViewMode.mockClear()
+		// Default to a normal authenticated view so tests that don't care
+		// about public/embedded/widget behaviour don't need to set this up.
+		getViewMode.mockReturnValue(ViewMode.USER)
 		generateUrl.mockClear()
 		translate.mockClear()
 		showInfo.mockClear()
@@ -349,8 +353,8 @@ describe('fullcalendar/eventClick test suite', () => {
 		}
 		const oldLocation = window.location
 
-		isPublicOrEmbeddedRoute
-			.mockReturnValueOnce(true)
+		getViewMode
+			.mockReturnValueOnce(ViewMode.PUBLIC)
 
 		const eventClickFunction = eventClick(router, route, window)
 		eventClickFunction({ event: {
@@ -362,8 +366,8 @@ describe('fullcalendar/eventClick test suite', () => {
 			},
 		}})
 
-		expect(isPublicOrEmbeddedRoute).toHaveBeenCalledTimes(1)
-		expect(isPublicOrEmbeddedRoute).toHaveBeenNthCalledWith(1, 'EditFullView')
+		expect(getViewMode).toHaveBeenCalledTimes(1)
+		expect(getViewMode).toHaveBeenNthCalledWith(1, 'EditFullView', false)
 
 		expect(generateUrl).toHaveBeenCalledTimes(0)
 		expect(window.location).toEqual(oldLocation)
@@ -391,8 +395,8 @@ describe('fullcalendar/eventClick test suite', () => {
 		}
 		const oldLocation = window.location
 
-		isPublicOrEmbeddedRoute
-			.mockReturnValueOnce(false)
+		getViewMode
+			.mockReturnValueOnce(ViewMode.USER)
 		translate
 			.mockReturnValue('translated hint')
 
@@ -412,8 +416,8 @@ describe('fullcalendar/eventClick test suite', () => {
 		expect(showInfo).toHaveBeenCalledTimes(1)
 		expect(showInfo).toHaveBeenNthCalledWith(1, 'translated hint')
 
-		expect(isPublicOrEmbeddedRoute).toHaveBeenCalledTimes(1)
-		expect(isPublicOrEmbeddedRoute).toHaveBeenNthCalledWith(1, 'EditFullView')
+		expect(getViewMode).toHaveBeenCalledTimes(1)
+		expect(getViewMode).toHaveBeenNthCalledWith(1, 'EditFullView', false)
 
 		expect(generateUrl).toHaveBeenCalledTimes(0)
 		expect(window.location).toEqual(oldLocation)

--- a/tests/javascript/unit/mixins/EditorMixin.test.js
+++ b/tests/javascript/unit/mixins/EditorMixin.test.js
@@ -2,9 +2,105 @@
  * SPDX-FileCopyrightText: 2019 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
+import EditorMixin from '../../../../src/mixins/EditorMixin.js'
+import { ViewMode } from '../../../../src/utils/router.js'
 
 describe('mixins/EditorMixin test suite', () => {
-	it('should be true', () => {
-		expect(true).toEqual(true)
+	describe('viewMode', () => {
+		it('is WIDGET whenever rendered as a widget, regardless of route', () => {
+			const vm = { isWidget: true, $route: { name: 'PublicCalendarView' } }
+			expect(EditorMixin.computed.viewMode.call(vm)).toEqual(ViewMode.WIDGET)
+		})
+
+		it('is derived from the route name otherwise', () => {
+			expect(EditorMixin.computed.viewMode.call({ isWidget: false, $route: { name: 'PublicEditPopoverView' } })).toEqual(ViewMode.PUBLIC)
+			expect(EditorMixin.computed.viewMode.call({ isWidget: false, $route: { name: 'EmbedEditFullView' } })).toEqual(ViewMode.EMBEDDED)
+			expect(EditorMixin.computed.viewMode.call({ isWidget: false, $route: { name: 'EditPopoverView' } })).toEqual(ViewMode.USER)
+		})
+	})
+
+	describe('canDuplicate', () => {
+		it('is true only in USER mode', () => {
+			expect(EditorMixin.computed.canDuplicate.call({ viewMode: ViewMode.USER })).toEqual(true)
+			expect(EditorMixin.computed.canDuplicate.call({ viewMode: ViewMode.PUBLIC })).toEqual(false)
+			expect(EditorMixin.computed.canDuplicate.call({ viewMode: ViewMode.EMBEDDED })).toEqual(false)
+			expect(EditorMixin.computed.canDuplicate.call({ viewMode: ViewMode.WIDGET })).toEqual(false)
+		})
+	})
+
+	describe('duplicateEvent', () => {
+		it('does nothing when duplication is not allowed in the current view (e.g. public/embedded/widget)', async () => {
+			const duplicateCalendarObjectInstance = vi.fn()
+			const vm = {
+				canDuplicate: false,
+				calendarObjectInstanceStore: { duplicateCalendarObjectInstance },
+			}
+
+			await EditorMixin.methods.duplicateEvent.call(vm)
+
+			expect(duplicateCalendarObjectInstance).not.toHaveBeenCalled()
+		})
+
+		it('duplicates into the current calendar when it is writable', async () => {
+			const duplicateCalendarObjectInstance = vi.fn()
+			const vm = {
+				canDuplicate: true,
+				isReadOnly: false,
+				calendarObject: { calendarId: 'calendar-1' },
+				calendarObjectInstanceStore: { duplicateCalendarObjectInstance },
+				calendarsStore: { sortedCalendars: [] },
+			}
+
+			await EditorMixin.methods.duplicateEvent.call(vm)
+
+			expect(duplicateCalendarObjectInstance).toHaveBeenCalledWith({ calendarId: 'calendar-1' })
+		})
+
+		it('falls back to the first writable calendar when the source calendar is read-only', async () => {
+			const duplicateCalendarObjectInstance = vi.fn()
+			const vm = {
+				canDuplicate: true,
+				isReadOnly: true,
+				calendarObject: { calendarId: 'calendar-1' },
+				calendarObjectInstanceStore: { duplicateCalendarObjectInstance },
+				calendarsStore: { sortedCalendars: [{ id: 'calendar-2' }] },
+			}
+
+			await EditorMixin.methods.duplicateEvent.call(vm)
+
+			expect(duplicateCalendarObjectInstance).toHaveBeenCalledWith({ calendarId: 'calendar-2' })
+		})
+	})
+
+	describe('keyboardDuplicateEvent', () => {
+		it('does not trigger a duplication when it is not allowed in the current view', () => {
+			const duplicateEvent = vi.fn()
+			const vm = {
+				isNew: false,
+				canCreateRecurrenceException: false,
+				canDuplicate: false,
+				duplicateEvent,
+			}
+			const event = { key: 'd', ctrlKey: true, preventDefault: vi.fn() }
+
+			EditorMixin.methods.keyboardDuplicateEvent.call(vm, event)
+
+			expect(duplicateEvent).not.toHaveBeenCalled()
+		})
+
+		it('triggers a duplication when allowed', () => {
+			const duplicateEvent = vi.fn()
+			const vm = {
+				isNew: false,
+				canCreateRecurrenceException: false,
+				canDuplicate: true,
+				duplicateEvent,
+			}
+			const event = { key: 'd', ctrlKey: true, preventDefault: vi.fn() }
+
+			EditorMixin.methods.keyboardDuplicateEvent.call(vm, event)
+
+			expect(duplicateEvent).toHaveBeenCalled()
+		})
 	})
 })

--- a/tests/javascript/unit/models/event.test.js
+++ b/tests/javascript/unit/models/event.test.js
@@ -967,6 +967,55 @@ describe('Test suite: Event model (models/event.js)', () => {
 		expect(targetEventComponent.getFirstPropertyFirstValue('A-CUSTOM-PROPERTY')).toBe('TRUE')
 	})
 
+	it('should replace, not duplicate, DTSTART/DTEND in the new event component', () => {
+		// Given
+		// The target already has its own DTSTART/DTEND set from the occurrence
+		// it was created for. Simply appending the source's on top would leave
+		// the component with duplicate DTSTART/DTEND properties, which servers
+		// reject as invalid iCalendar - so the target's own values must be
+		// replaced by the source's, not added alongside them.
+		const sourceRecurrenceId = DateTimeValue.fromJSDate(new Date(Date.UTC(2016, 7, 16, 7, 0, 0)), true)
+		const sourceEventComponent = getEventComponentFromAsset('vcalendars/vcalendar-event-timed', sourceRecurrenceId)
+		const sourceEventObject = mapEventComponentToEventObject(sourceEventComponent)
+
+		const targetRecurrenceId = DateTimeValue.fromJSDate(new Date(Date.UTC(2016, 7, 16, 9, 0, 0)), true)
+		const targetEventComponent = getEventComponentFromAsset('vcalendars/vcalendar-event-minimal', targetRecurrenceId)
+
+		// When
+		copyCalendarObjectInstanceIntoEventComponent(sourceEventObject, targetEventComponent)
+
+		// Then
+		expect([...targetEventComponent.getPropertyIterator('DTSTART')]).toHaveLength(1)
+		expect([...targetEventComponent.getPropertyIterator('DTEND')]).toHaveLength(1)
+		expect(targetEventComponent.startDate.unixTime).toEqual(sourceEventComponent.startDate.unixTime)
+		expect(targetEventComponent.endDate.unixTime).toEqual(sourceEventComponent.endDate.unixTime)
+	})
+
+	it('should not leave a stale DTEND when the source uses DURATION instead', () => {
+		// Given
+		// DTEND and DURATION are mutually exclusive on a VEVENT. The target
+		// (created via calendar-js's createEvent()) always has a DTEND, so if
+		// the source describes its length with DURATION instead, the target's
+		// DTEND must still be cleared - not just left behind alongside the
+		// newly-added DURATION.
+		const sourceRecurrenceId = DateTimeValue.fromJSDate(new Date(Date.UTC(2016, 7, 16, 7, 0, 0)), true)
+		const sourceEventComponent = getEventComponentFromAsset('vcalendars/vcalendar-event-timed', sourceRecurrenceId)
+		sourceEventComponent.deleteAllProperties('DTEND')
+		sourceEventComponent.updatePropertyWithValue('DURATION', DurationValue.fromSeconds(3600))
+		const sourceEventObject = mapEventComponentToEventObject(sourceEventComponent)
+
+		const targetRecurrenceId = DateTimeValue.fromJSDate(new Date(Date.UTC(2016, 7, 16, 9, 0, 0)), true)
+		const targetEventComponent = getEventComponentFromAsset('vcalendars/vcalendar-event-minimal', targetRecurrenceId)
+		expect(targetEventComponent.hasProperty('DTEND')).toBe(true)
+
+		// When
+		copyCalendarObjectInstanceIntoEventComponent(sourceEventObject, targetEventComponent)
+
+		// Then
+		expect([...targetEventComponent.getPropertyIterator('DTEND')]).toHaveLength(0)
+		expect([...targetEventComponent.getPropertyIterator('DURATION')]).toHaveLength(1)
+	})
+
 	it('should not copy recurrence ID into a new event component', () => {
 		// Given
 		const sourceRecurrenceId = DateTimeValue.fromJSDate(new Date(Date.UTC(2020, 2, 8, 14, 0, 0)), true)
@@ -983,8 +1032,12 @@ describe('Test suite: Event model (models/event.js)', () => {
 		expect(targetEventComponent.hasProperty('RECURRENCE-ID')).toBeFalsy()
 	})
 
-	it('should not copy recurring events into a new event component', () => {
+	it('should not copy recurrence-defining properties into a new event component', () => {
 		// Given
+		// The first occurrence's recurrence-id matches the master item's own DTSTART,
+		// so calendar-js returns the master item itself here (RRULE and all) instead
+		// of a forked occurrence. A duplicate must still come out as a single,
+		// non-recurring event rather than throwing or inheriting the recurrence rule.
 		const sourceRecurrenceId = DateTimeValue.fromJSDate(new Date(Date.UTC(2020, 2, 1, 14, 0, 0)), true)
 		const sourceEventComponent = getEventComponentFromAsset('vcalendars/vcalendar-event-recurring', sourceRecurrenceId)
 		const sourceEventObject = mapEventComponentToEventObject(sourceEventComponent)
@@ -993,8 +1046,15 @@ describe('Test suite: Event model (models/event.js)', () => {
 		const targetEventComponent = getEventComponentFromAsset('vcalendars/vcalendar-event-minimal', targetRecurrenceId)
 
 		// When
-		expect(() => copyCalendarObjectInstanceIntoEventComponent(sourceEventObject, targetEventComponent))
-			.toThrow('Illegal argument: Event objects has recurrence related property RRULE.')
+		copyCalendarObjectInstanceIntoEventComponent(sourceEventObject, targetEventComponent)
+
+		// Then
+		expect(targetEventComponent.hasProperty('RRULE')).toBeFalsy()
+		expect(targetEventComponent.hasProperty('EXRULE')).toBeFalsy()
+		expect(targetEventComponent.hasProperty('RDATE')).toBeFalsy()
+		expect(targetEventComponent.hasProperty('EXDATE')).toBeFalsy()
+		// Non-recurrence properties from the source are still copied as usual.
+		expect(targetEventComponent.title).toEqual(sourceEventComponent.title)
 	})
 
 	it('should copy subcomponents into a new event component', () => {

--- a/tests/javascript/unit/store/calendarObjectInstance.test.ts
+++ b/tests/javascript/unit/store/calendarObjectInstance.test.ts
@@ -1,0 +1,75 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+import { createPinia, setActivePinia } from 'pinia'
+import { describe, expect, it, vi } from 'vitest'
+import { copyCalendarObjectInstanceIntoEventComponent, mapEventComponentToEventObject } from '@/models/event.js'
+import useCalendarObjectInstanceStore from '@/store/calendarObjectInstance.js'
+import useCalendarObjectsStore from '@/store/calendarObjects.js'
+import { getObjectAtRecurrenceId } from '@/utils/calendarObject.js'
+
+vi.mock('@/models/event.js')
+vi.mock('@/utils/calendarObject.js')
+
+const mockedCopyCalendarObjectInstanceIntoEventComponent = vi.mocked(copyCalendarObjectInstanceIntoEventComponent)
+const mockedMapEventComponentToEventObject = vi.mocked(mapEventComponentToEventObject)
+const mockedGetObjectAtRecurrenceId = vi.mocked(getObjectAtRecurrenceId)
+
+describe('store/calendarObjectInstance test suite', () => {
+	beforeEach(() => {
+		setActivePinia(createPinia())
+
+		mockedCopyCalendarObjectInstanceIntoEventComponent.mockReset()
+		mockedMapEventComponentToEventObject.mockReset().mockReturnValue({ eventComponent: {} })
+		mockedGetObjectAtRecurrenceId.mockReset().mockReturnValue({})
+	})
+
+	describe('duplicateCalendarObjectInstance', () => {
+		/**
+		 * @param store The calendarObjectInstance store
+		 * @param calendarId The id of the calendar the source event lives in
+		 */
+		function setUpSourceEvent(store: ReturnType<typeof useCalendarObjectInstanceStore>, calendarId: string) {
+			store.calendarObject = { calendarId }
+			store.calendarObjectInstance = {
+				eventComponent: {
+					startDate: {
+						timezoneId: 'UTC',
+						getInUTC: () => ({ unixTime: 1000, jsDate: new Date(1000 * 1000) }),
+					},
+					endDate: {
+						getInUTC: () => ({ unixTime: 2000 }),
+					},
+					isAllDay: () => false,
+				},
+			}
+		}
+
+		it('duplicates into the explicitly given calendar instead of the source calendar', async () => {
+			const store = useCalendarObjectInstanceStore()
+			const calendarObjectsStore = useCalendarObjectsStore()
+			setUpSourceEvent(store, 'readonly-calendar')
+			vi.spyOn(calendarObjectsStore, 'createNewEvent').mockResolvedValue({ calendarComponent: {} })
+
+			await store.duplicateCalendarObjectInstance({ calendarId: 'writable-calendar' })
+
+			expect(calendarObjectsStore.createNewEvent).toHaveBeenCalledWith(
+				expect.objectContaining({ calendarId: 'writable-calendar' }),
+			)
+		})
+
+		it('marks the duplicated event as a new, unsaved calendar-object', async () => {
+			const store = useCalendarObjectInstanceStore()
+			const calendarObjectsStore = useCalendarObjectsStore()
+			setUpSourceEvent(store, 'source-calendar')
+			const newCalendarObject = { calendarComponent: {} }
+			vi.spyOn(calendarObjectsStore, 'createNewEvent').mockResolvedValue(newCalendarObject)
+
+			await store.duplicateCalendarObjectInstance({ calendarId: 'writable-calendar' })
+
+			expect(store.isNew).toBe(true)
+			expect(store.calendarObject).toStrictEqual(newCalendarObject)
+		})
+	})
+})

--- a/tests/javascript/unit/utils/router.test.js
+++ b/tests/javascript/unit/utils/router.test.js
@@ -7,7 +7,8 @@ import {
 	getInitialView,
 	getPreferredEditorRoute,
 	getPrefixedRoute,
-	isPublicOrEmbeddedRoute,
+	getViewMode,
+	ViewMode,
 } from '@/utils/router.js'
 
 vi.mock('@nextcloud/initial-state')
@@ -77,14 +78,26 @@ describe('utils/router test suite', () => {
 		expect(getPrefixedRoute('EditPopoverView', 'CalendarView')).toEqual('CalendarView')
 	})
 
-	it('should check whether a route is public or embedded', () => {
-		expect(isPublicOrEmbeddedRoute('PublicCalendarView')).toEqual(true)
-		expect(isPublicOrEmbeddedRoute('PublicEditPopoverView')).toEqual(true)
+	it('should always report widget mode when isWidget is true, regardless of route', () => {
+		expect(getViewMode('PublicCalendarView', true)).toEqual(ViewMode.WIDGET)
+		expect(getViewMode('EmbedCalendarView', true)).toEqual(ViewMode.WIDGET)
+		expect(getViewMode('CalendarView', true)).toEqual(ViewMode.WIDGET)
+		expect(getViewMode(undefined, true)).toEqual(ViewMode.WIDGET)
+	})
 
-		expect(isPublicOrEmbeddedRoute('EmbedCalendarView')).toEqual(true)
-		expect(isPublicOrEmbeddedRoute('EmbedEditPopoverView')).toEqual(true)
+	it('should derive the view mode from the route name when not a widget', () => {
+		expect(getViewMode('PublicCalendarView')).toEqual(ViewMode.PUBLIC)
+		expect(getViewMode('PublicEditPopoverView')).toEqual(ViewMode.PUBLIC)
 
-		expect(isPublicOrEmbeddedRoute('CalendarView')).toEqual(false)
-		expect(isPublicOrEmbeddedRoute('EditPopoverView')).toEqual(false)
+		expect(getViewMode('EmbedCalendarView')).toEqual(ViewMode.EMBEDDED)
+		expect(getViewMode('EmbedEditFullView')).toEqual(ViewMode.EMBEDDED)
+
+		expect(getViewMode('CalendarView')).toEqual(ViewMode.USER)
+		expect(getViewMode('EditPopoverView')).toEqual(ViewMode.USER)
+	})
+
+	it('should default to user mode when there is no route name', () => {
+		expect(getViewMode(undefined)).toEqual(ViewMode.USER)
+		expect(getViewMode(null)).toEqual(ViewMode.USER)
 	})
 })


### PR DESCRIPTION
### Summary
- Resolves: https://github.com/nextcloud/calendar/issues/8608
- Removed the isReadOnly (User should be able to duplicate any event, this is no different then exporting then importing)
- Removed the canCreateRecurrenceException (This is used to control changing recurring events, so it makes no sense on duplication)
- Fixed broken copy logic in copyCalendarObjectInstanceIntoEventComponent
- Added proper view mode detection