### PR TITLE
fix(editor): show resource heading always together with search

### DIFF
--- a/css/app-full.scss
+++ b/css/app-full.scss
@@ -130,10 +130,30 @@
 	gap: calc(var(--default-grid-baseline) * 4);
 }
 
-.invitees-list {
+.invitees-list,
+.resource-list {
 	display: flex;
 	flex-direction: column;
 	gap: calc(var(--default-grid-baseline) * 2);
+
+	&__header {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		min-height: calc(var(--default-grid-baseline) * 9);
+
+		&__title {
+			display: flex;
+			gap: calc(var(--default-grid-baseline) * 2);
+			font-size: calc(var(--default-font-size) * 1.2);
+			align-items: center;
+			font-weight: bold;
+
+			&__text {
+				margin-inline-start: calc(var(--default-grid-baseline) * 2);
+			}
+		}
+	}
 }
 
 .resource-search {
@@ -318,10 +338,6 @@
 	align-items: center;
 	min-height: 44px;
 
-	&__displayname {
-		margin-inline-start: calc(var(--default-grid-baseline) * 2);
-	}
-
 	&__actions {
 		margin-inline-start: auto;
 	}
@@ -334,7 +350,8 @@
 }
 
 .invitees-search__vselect {
-	margin-inline-start: calc(var(--default-grid-baseline) * 4 + 20px);
+	// !important because needs to override selector styles set by selector .v-select.select
+	margin-bottom: 0 !important;
 }
 
 .resource-search-list-item,

--- a/src/components/Editor/Invitees/InviteesList.vue
+++ b/src/components/Editor/Invitees/InviteesList.vue
@@ -22,10 +22,9 @@
 				</NcButton>
 			</div>
 
-			<div v-if="!hideButtons" class="invitees-list-button-group">
+			<template v-if="!hideButtons">
 				<NcButton
 					v-if="!isReadOnly"
-					class="invitees-list-button-group__button"
 					:disabled="isListEmpty || !isOrganizer"
 					@click="openFreeBusy">
 					{{ $t('calendar', 'Find a time') }}
@@ -43,10 +42,10 @@
 					@addAttendee="addAttendee"
 					@updateDates="saveNewDate"
 					@close="closeFreeBusy" />
-			</div>
+			</template>
 		</div>
 
-		<div class="invitees-list__subtitle">
+		<div v-if="statusHeader" class="invitees-list__subtitle">
 			{{ statusHeader }}
 		</div>
 
@@ -498,28 +497,6 @@ export default {
 
 <style lang="scss" scoped>
 .invitees-list {
-	&__header {
-		display: flex;
-		gap: calc(var(--default-grid-baseline) * 6);
-		align-items: center;
-
-		&__title {
-			display: flex;
-			gap: calc(var(--default-grid-baseline) * 2);
-			font-size: calc(var(--default-font-size) * 1.2);
-			align-items: center;
-			font-weight: bold;
-
-			div {
-				box-sizing: border-box;
-			}
-
-			&__text {
-				margin-inline-start: calc(var(--default-grid-baseline) * 2);
-			}
-		}
-	}
-
 	&__subtitle {
 		color: var(--color-text-maxcontrast);
 		margin-inline-start: calc(var(--default-grid-baseline) * 9);
@@ -528,22 +505,6 @@ export default {
 	&__more {
 		padding: calc(var(--default-grid-baseline) * 4) 0 0 calc(var(--default-grid-baseline) * 11);
 		opacity: 0.75;
-	}
-
-	.invitees-list-button-group {
-		display: flex;
-		flex-wrap: wrap;
-		gap: 5px;
-
-		&__button {
-			flex: 1 0 100px;
-
-			:deep(.button-vue__text) {
-				white-space: unset !important;
-				overflow: unset !important;
-				text-overflow: unset !important;
-			}
-		}
 	}
 }
 </style>

--- a/src/components/Editor/Invitees/OrganizerListItem.vue
+++ b/src/components/Editor/Invitees/OrganizerListItem.vue
@@ -153,13 +153,6 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-.invitees-list-item__displayname {
-	margin-bottom: 13px;
-	text-overflow: ellipsis;
-	overflow: hidden;
-	white-space: nowrap;
-}
-
 .invitees-list-item__organizer-hint {
 	margin-bottom: 14px;
 }

--- a/src/components/Editor/Resources/ResourceList.vue
+++ b/src/components/Editor/Resources/ResourceList.vue
@@ -4,8 +4,26 @@
 -->
 
 <template>
-	<div>
-		<span v-if="!(!resources.length && !suggestedRooms.length)" class="app-full-subtitle"> <MapMarker :size="20" /> {{ t('calendar', 'Resources') }}</span>
+	<div v-if="resources.length > 0 || suggestedRooms.length > 0 || resourceBookingEnabled" class="resource-list">
+		<div class="resource-list__header">
+			<span class="resource-list__header__title">
+				<DoorOpenIcon :size="20" />
+				<span class="resource-list__header__title__text">{{ t('calendar', 'Resources') }}</span>
+			</span>
+
+			<NcButton
+				v-if="!isReadOnly && hasUserEmailAddress && resourceBookingEnabled"
+				class="resource-list__header__button"
+				@click="openRoomAvailability">
+				{{ $t('calendar', 'Show rooms') }}
+			</NcButton>
+		</div>
+
+		<RoomAvailabilityList
+			v-if="showRoomAvailabilityModal"
+			:showDialog="showRoomAvailabilityModal"
+			:calendarObjectInstance="calendarObjectInstance"
+			@update:showDialog="setShowRoomAvailabilityModal" />
 
 		<ResourceListSearch
 			v-if="!isReadOnly && hasUserEmailAddress && resourceBookingEnabled"
@@ -13,31 +31,33 @@
 			:calendarObjectInstance="calendarObjectInstance"
 			@addResource="addResource" />
 
-		<div class="resource-list">
-			<ResourceListItem
-				v-for="resource in resources"
-				:key="resource.email"
-				:resource="resource"
-				:organizerDisplayName="organizerDisplayName"
-				:isViewedByOrganizer="isViewedByOrganizer"
-				@removeResource="removeResource" />
+		<ResourceListItem
+			v-for="resource in resources"
+			:key="resource.email"
+			:resource="resource"
+			:organizerDisplayName="organizerDisplayName"
+			:isViewedByOrganizer="isViewedByOrganizer"
+			@removeResource="removeResource" />
 
-			<ResourceListItem
-				v-for="room in suggestedRooms"
-				:key="room.email + '-suggested'"
-				:resource="room"
-				:organizerDisplayName="organizerDisplayName"
-				:isSuggestion="true"
-				:isViewedByOrganizer="isViewedByOrganizer"
-				@addSuggestion="addResource" />
-		</div>
+		<ResourceListItem
+			v-for="room in suggestedRooms"
+			:key="room.email + '-suggested'"
+			:resource="room"
+			:organizerDisplayName="organizerDisplayName"
+			:isSuggestion="true"
+			:isViewedByOrganizer="isViewedByOrganizer"
+			@addSuggestion="addResource" />
 	</div>
 </template>
 
 <script>
 import { loadState } from '@nextcloud/initial-state'
+import {
+	NcButton,
+} from '@nextcloud/vue'
 import { mapStores } from 'pinia'
-import MapMarker from 'vue-material-design-icons/MapMarker.vue'
+import DoorOpenIcon from 'vue-material-design-icons/DoorOpen.vue'
+import RoomAvailabilityList from '../FreeBusy/RoomAvailabilityList.vue'
 import ResourceListItem from './ResourceListItem.vue'
 import ResourceListSearch from './ResourceListSearch.vue'
 import { advancedPrincipalPropertySearch } from '../../../services/caldavService.js'
@@ -46,13 +66,14 @@ import useCalendarObjectInstanceStore from '../../../store/calendarObjectInstanc
 import usePrincipalsStore from '../../../store/principals.js'
 import { organizerDisplayName, removeMailtoPrefix } from '../../../utils/attendee.js'
 import logger from '../../../utils/logger.js'
-
 export default {
 	name: 'ResourceList',
 	components: {
 		ResourceListItem,
 		ResourceListSearch,
-		MapMarker,
+		NcButton,
+		DoorOpenIcon,
+		RoomAvailabilityList,
 	},
 
 	props: {
@@ -70,6 +91,7 @@ export default {
 	data() {
 		return {
 			suggestedRooms: [],
+			showRoomAvailabilityModal: false,
 		}
 	},
 
@@ -224,18 +246,14 @@ export default {
 				location,
 			})
 		},
+
+		openRoomAvailability() {
+			this.showRoomAvailabilityModal = true
+		},
+
+		setShowRoomAvailabilityModal(value) {
+			this.showRoomAvailabilityModal = value
+		},
 	},
 }
 </script>
-
-<style lang="scss" scoped>
-.resource-list {
-		margin-top: calc(var(--default-grid-baseline) * 4);
-}
-
-.app-full-subtitle {
-	font-size: calc(var(--default-font-size) * 1.2);
-	display: flex;
-	gap: calc(var(--default-grid-baseline) * 4);
-}
-</style>

--- a/src/components/Editor/Resources/ResourceListSearch.vue
+++ b/src/components/Editor/Resources/ResourceListSearch.vue
@@ -5,15 +5,6 @@
 
 <template>
 	<div class="resource-search">
-		<NcButton class="button availability" @click="openRoomAvailability">
-			{{ $t('calendar', 'Show all rooms') }}
-		</NcButton>
-
-		<RoomAvailabilityList
-			v-if="showRoomAvailabilityModal"
-			:showDialog="showRoomAvailabilityModal"
-			:calendarObjectInstance="calendarObjectInstance"
-			@update:showDialog="setShowRoomAvailabilityModal" />
 		<NcSelect
 			v-model="selectedResource"
 			class="resource-search__multiselect"
@@ -78,12 +69,10 @@ import {
 	NcActionCheckbox as ActionCheckbox,
 	NcActions as Actions,
 	NcAvatar as Avatar,
-	NcButton,
 	NcSelect,
 } from '@nextcloud/vue'
 import debounce from 'debounce'
 import { mapStores } from 'pinia'
-import RoomAvailabilityList from '../FreeBusy/RoomAvailabilityList.vue'
 import ResourceRoomType from './ResourceRoomType.vue'
 import ResourceSeatingCapacity from './ResourceSeatingCapacity.vue'
 import { advancedPrincipalPropertySearch } from '../../../services/caldavService.js'
@@ -93,9 +82,7 @@ import logger from '../../../utils/logger.js'
 export default {
 	name: 'ResourceListSearch',
 	components: {
-		RoomAvailabilityList,
 		Avatar,
-		NcButton,
 		NcSelect,
 		ResourceSeatingCapacity,
 		Actions,
@@ -128,7 +115,6 @@ export default {
 			isAccessible: false,
 			hasProjector: false,
 			hasWhiteboard: false,
-			showRoomAvailabilityModal: false,
 			selectedResource: null,
 			rooms: [],
 		}
@@ -171,13 +157,6 @@ export default {
 	},
 
 	methods: {
-		openRoomAvailability() {
-			this.showRoomAvailabilityModal = true
-		},
-
-		setShowRoomAvailabilityModal(value) {
-			this.showRoomAvailabilityModal = value
-		},
 
 		findResources: debounce(async function(query) {
 			this.isLoading = true
@@ -286,9 +265,3 @@ export default {
 	},
 }
 </script>
-
-<style lang="scss" scoped>
-.button.availability {
-      margin-bottom: 8px;
-}
-</style>


### PR DESCRIPTION
Fixes that the subheading "Resources" only appeared after some rooms (or resources where added). This is the transition from state A to B. 

| State | Before | After |
|------|--------|-------|
| A: No room added yet | <img width="2786" height="1733" alt="image" src="https://github.com/user-attachments/assets/48055fe9-2a70-4641-b450-7aa10847f6a0" /> | <img width="2786" height="1733" alt="image" src="https://github.com/user-attachments/assets/9ad3cb45-bbc2-45db-8bd0-4095686c4ef8" /> |
| B: Room added| <img width="2786" height="1733" alt="image" src="https://github.com/user-attachments/assets/5e761dd6-55ac-48b3-92d6-c1026f71b8da" /> | <img width="2786" height="1733" alt="image" src="https://github.com/user-attachments/assets/9970553f-5b1f-4faa-a733-2a7a8d8b989d" /> |

Also fixes some UI issues arising from showing the subheading:

- Visual alignment with the "Attendees" inputs
  -  Button now also in subheading
    - Change to shorter button name to fit better
  - Align buttons to the right
- Replace map-marker-icon with door-open-icon because it already used for "Location"
  - The duplication was previously not too apparent, because "Resources" subheading was often hidden
