### PR TITLE
chore: add support for server version 35

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -44,7 +44,7 @@
 	<screenshot>https://raw.githubusercontent.com/nextcloud/calendar/main/screenshots/week_sidebar.png</screenshot>
 	<dependencies>
 		<php min-version="8.1" max-version="8.5" />
-		<nextcloud min-version="32" max-version="34" />
+		<nextcloud min-version="32" max-version="35" />
 		<backend>caldav</backend>
 	</dependencies>
 	<background-jobs>


### PR DESCRIPTION
### Support
- Modified app info to allow use with nextcloud version 35