### PR TITLE
refactor: stop passing redundant `calendarObjectInstance`

### DIFF
--- a/src/components/Editor/AddTalkModal.vue
+++ b/src/components/Editor/AddTalkModal.vue
@@ -198,7 +198,6 @@ export default {
 
 				if ((this.calendarObjectInstance.location ?? '').trim() === '') {
 					this.calendarObjectInstanceStore.changeLocation({
-						calendarObjectInstance: this.calendarObjectInstance,
 						location: url,
 					})
 					showSuccess(this.$t('calendar', 'Successfully added Talk conversation link to location.'))
@@ -209,7 +208,6 @@ export default {
 						: url
 
 					this.calendarObjectInstanceStore.changeDescription({
-						calendarObjectInstance: this.calendarObjectInstance,
 						description: updatedDescription,
 					})
 					showSuccess(this.$t('calendar', 'Successfully added Talk conversation link to description.'))

--- a/src/components/Editor/AddTalkModal.vue
+++ b/src/components/Editor/AddTalkModal.vue
@@ -90,7 +90,7 @@ import {
 	NcModal,
 } from '@nextcloud/vue'
 import md5 from 'md5'
-import { mapStores } from 'pinia'
+import { mapState } from 'pinia'
 import IconAdd from 'vue-material-design-icons/Plus.vue'
 import { addParticipantAsModerator, createRoom, generateRoomUrl, listRooms } from '@/services/talkService'
 import useCalendarObjectInstanceStore from '@/store/calendarObjectInstance.js'
@@ -121,11 +121,6 @@ export default {
 	},
 
 	props: {
-		calendarObjectInstance: {
-			type: Object,
-			required: true,
-		},
-
 		delegatorUserId: {
 			type: String,
 			default: null,
@@ -151,7 +146,7 @@ export default {
 	},
 
 	computed: {
-		...mapStores(useCalendarObjectInstanceStore, ['calendarObjectInstance']),
+		...mapState(useCalendarObjectInstanceStore, ['calendarObjectInstance']),
 		/**
 		 * @return {object[]} Talk conversations sorted by most recent activity
 		 */

--- a/src/components/Editor/Alarm/AlarmList.vue
+++ b/src/components/Editor/Alarm/AlarmList.vue
@@ -62,7 +62,6 @@ export default {
 		 */
 		addAlarm(totalSeconds) {
 			this.calendarObjectInstanceStore.addAlarmToCalendarObjectInstance({
-				calendarObjectInstance: this.calendarObjectInstance,
 				type: this.forceEventAlarmType || 'DISPLAY',
 				totalSeconds,
 			})
@@ -75,7 +74,6 @@ export default {
 		 */
 		removeAlarm(alarm) {
 			this.calendarObjectInstanceStore.removeAlarmFromCalendarObjectInstance({
-				calendarObjectInstance: this.calendarObjectInstance,
 				alarm,
 			})
 		},

--- a/src/components/Editor/Alarm/AlarmList.vue
+++ b/src/components/Editor/Alarm/AlarmList.vue
@@ -15,7 +15,6 @@
 			v-for="(alarm, index) in alarms"
 			:key="index"
 			:alarm="alarm"
-			:calendarObjectInstance="calendarObjectInstance"
 			:isReadOnly="isReadOnly"
 			@removeAlarm="removeAlarm" />
 	</div>
@@ -40,15 +39,11 @@ export default {
 			type: Boolean,
 			required: true,
 		},
-
-		calendarObjectInstance: {
-			type: Object,
-			required: true,
-		},
 	},
 
 	computed: {
 		...mapStores(useCalendarObjectInstanceStore),
+		...mapState(useCalendarObjectInstanceStore, ['calendarObjectInstance']),
 		...mapState(useSettingsStore, ['forceEventAlarmType']),
 		alarms() {
 			return this.calendarObjectInstance.alarms.slice().sort((a, b) => {

--- a/src/components/Editor/Alarm/AlarmListItem.vue
+++ b/src/components/Editor/Alarm/AlarmListItem.vue
@@ -193,11 +193,6 @@ export default {
 			required: true,
 		},
 
-		calendarObjectInstance: {
-			type: Object,
-			required: true,
-		},
-
 		isReadOnly: {
 			type: Boolean,
 			required: true,
@@ -215,6 +210,7 @@ export default {
 
 	computed: {
 		...mapStores(useCalendarObjectInstanceStore, useSettingsStore),
+		...mapState(useCalendarObjectInstanceStore, ['calendarObjectInstance']),
 		...mapState(useSettingsStore, {
 			locale: 'momentLocale',
 			forceEventAlarmType: 'forceEventAlarmType',

--- a/src/components/Editor/Alarm/AlarmListItem.vue
+++ b/src/components/Editor/Alarm/AlarmListItem.vue
@@ -385,7 +385,6 @@ export default {
 			}
 
 			this.calendarObjectInstanceStore.changeAlarmFromAbsoluteToRelative({
-				calendarObjectInstance: this.calendarObjectInstance,
 				alarm: this.alarm,
 			})
 
@@ -401,7 +400,6 @@ export default {
 			}
 
 			this.calendarObjectInstanceStore.changeAlarmFromRelativeToAbsolute({
-				calendarObjectInstance: this.calendarObjectInstance,
 				alarm: this.alarm,
 			})
 

--- a/src/components/Editor/Attachments/AttachmentsList.vue
+++ b/src/components/Editor/Attachments/AttachmentsList.vue
@@ -88,7 +88,7 @@ import {
 	NcDialog,
 	NcListItem,
 } from '@nextcloud/vue'
-import { mapStores } from 'pinia'
+import { mapState, mapStores } from 'pinia'
 import { parseXML } from 'webdav'
 import Close from 'vue-material-design-icons/Close.vue'
 import Folder from 'vue-material-design-icons/FolderOutline.vue'
@@ -119,11 +119,6 @@ export default {
 	},
 
 	props: {
-		calendarObjectInstance: {
-			type: Object,
-			required: true,
-		},
-
 		isReadOnly: {
 			type: Boolean,
 			default: true,
@@ -141,6 +136,7 @@ export default {
 
 	computed: {
 		...mapStores(usePrincipalsStore, useSettingsStore, useCalendarObjectInstanceStore),
+		...mapState(useCalendarObjectInstanceStore, ['calendarObjectInstance']),
 		currentUser() {
 			return this.principalsStore.getCurrentUserPrincipal
 		},

--- a/src/components/Editor/Attachments/AttachmentsList.vue
+++ b/src/components/Editor/Attachments/AttachmentsList.vue
@@ -156,7 +156,6 @@ export default {
 
 		deleteAttachmentFromEvent(attachment) {
 			this.calendarObjectInstanceStore.deleteAttachment({
-				calendarObjectInstance: this.calendarObjectInstance,
 				attachment,
 			})
 		},

--- a/src/components/Editor/FreeBusy/RoomAvailabilityList.vue
+++ b/src/components/Editor/FreeBusy/RoomAvailabilityList.vue
@@ -58,9 +58,10 @@
 
 <script>
 import { NcButton, NcDialog } from '@nextcloud/vue'
-import { mapStores } from 'pinia'
+import { mapState, mapStores } from 'pinia'
 import RoomAvailabilityModal from '@/components/Editor/FreeBusy/RoomAvailabilityModal.vue'
 import { mapPrincipalObjectToAttendeeObject } from '@/models/attendee.js'
+import useCalendarObjectInstanceStore from '@/store/calendarObjectInstance.js'
 import usePrincipalsStore from '@/store/principals.js'
 
 export default {
@@ -72,11 +73,6 @@ export default {
 	},
 
 	props: {
-		calendarObjectInstance: {
-			type: Object,
-			required: true,
-		},
-
 		showDialog: {
 			type: Boolean,
 			default: true,
@@ -94,6 +90,8 @@ export default {
 
 	computed: {
 		...mapStores(usePrincipalsStore),
+		...mapState(useCalendarObjectInstanceStore, ['calendarObjectInstance']),
+
 		rooms() {
 			return this.principalsStore.getRoomPrincipals
 		},

--- a/src/components/Editor/Invitees/InviteesList.vue
+++ b/src/components/Editor/Invitees/InviteesList.vue
@@ -132,11 +132,6 @@ export default {
 			required: true,
 		},
 
-		calendarObjectInstance: {
-			type: Object,
-			required: true,
-		},
-
 		showHeader: {
 			type: Boolean,
 			required: true,
@@ -170,6 +165,7 @@ export default {
 
 	computed: {
 		...mapStores(usePrincipalsStore, useCalendarsStore, useCalendarObjectInstanceStore),
+		...mapState(useCalendarObjectInstanceStore, ['calendarObjectInstance']),
 		...mapState(useSettingsStore, ['talkEnabled']),
 		noInviteesMessage() {
 			return this.$t('calendar', 'No attendees yet')

--- a/src/components/Editor/Invitees/InviteesList.vue
+++ b/src/components/Editor/Invitees/InviteesList.vue
@@ -377,7 +377,6 @@ export default {
 			}
 			// set new organizer
 			this.calendarObjectInstanceStore.setOrganizer({
-				calendarObjectInstance: this.calendarObjectInstance,
 				commonName: label,
 				email: address,
 			})
@@ -399,7 +398,6 @@ export default {
 			if (modifiedMember) {
 				const group = modifiedMember.attendeeProperty.member
 				this.calendarObjectInstanceStore.removeAttendee({
-					calendarObjectInstance: this.calendarObjectInstance,
 					attendee: modifiedMember,
 				})
 				member = member.split(',')
@@ -407,7 +405,6 @@ export default {
 			}
 
 			this.calendarObjectInstanceStore.addAttendee({
-				calendarObjectInstance: this.calendarObjectInstance,
 				commonName,
 				uri: email,
 				calendarUserType,
@@ -433,7 +430,6 @@ export default {
 				})
 			}
 			this.calendarObjectInstanceStore.removeAttendee({
-				calendarObjectInstance: this.calendarObjectInstance,
 				attendee,
 			})
 			this.recentAttendees = this.recentAttendees.filter((a) => a.uri !== attendee.email)

--- a/src/components/Editor/Repeat/Repeat.vue
+++ b/src/components/Editor/Repeat/Repeat.vue
@@ -70,7 +70,6 @@
 					@changeToByMonthDay="changeToByDayYearly" />
 				<RepeatEndRepeat
 					v-if="isRepeating && !isRecurrenceException && !isReadOnly"
-					:calendarObjectInstance="calendarObjectInstance"
 					:until="recurrenceRule.until"
 					:count="recurrenceRule.count"
 					@setInfinite="setInfinite"
@@ -94,7 +93,7 @@
 
 <script>
 import { NcActionButton as ActionButton, NcActions as Actions, NcButton, NcModal } from '@nextcloud/vue'
-import { mapStores } from 'pinia'
+import { mapState, mapStores } from 'pinia'
 import Check from 'vue-material-design-icons/Check.vue'
 import Pencil from 'vue-material-design-icons/PencilOutline.vue'
 import RepeatIcon from 'vue-material-design-icons/Repeat.vue'
@@ -129,22 +128,6 @@ export default {
 	},
 
 	props: {
-		/**
-		 * The calendar-object instance
-		 */
-		calendarObjectInstance: {
-			type: Object,
-			required: true,
-		},
-
-		/**
-		 * The recurrence-rule to display
-		 */
-		recurrenceRule: {
-			type: Object,
-			required: true,
-		},
-
 		/**
 		 * Whether or not the event is read-only
 		 */
@@ -183,6 +166,11 @@ export default {
 
 	computed: {
 		...mapStores(useCalendarObjectInstanceStore),
+		...mapState(useCalendarObjectInstanceStore, ['calendarObjectInstance']),
+		recurrenceRule() {
+			return this.calendarObjectInstance.recurrenceRule
+		},
+
 		/**
 		 * Whether or not this event is recurring
 		 *

--- a/src/components/Editor/Repeat/Repeat.vue
+++ b/src/components/Editor/Repeat/Repeat.vue
@@ -253,7 +253,6 @@ export default {
 		 */
 		changeFrequency(frequency) {
 			this.calendarObjectInstanceStore.changeRecurrenceFrequency({
-				calendarObjectInstance: this.calendarObjectInstance,
 				recurrenceRule: this.recurrenceRule,
 				frequency,
 			})
@@ -372,7 +371,6 @@ export default {
 		 */
 		changeToBySetPositionMonthly() {
 			this.calendarObjectInstanceStore.changeMonthlyRecurrenceFromByDayToBySetPosition({
-				calendarObjectInstance: this.calendarObjectInstance,
 				recurrenceRule: this.recurrenceRule,
 			})
 			this.modified()
@@ -384,7 +382,6 @@ export default {
 		 */
 		changeToByDayMonthly() {
 			this.calendarObjectInstanceStore.changeMonthlyRecurrenceFromBySetPositionToByDay({
-				calendarObjectInstance: this.calendarObjectInstance,
 				recurrenceRule: this.recurrenceRule,
 			})
 			this.modified()
@@ -396,7 +393,6 @@ export default {
 		 */
 		changeToBySetPositionYearly() {
 			this.calendarObjectInstanceStore.changeYearlyRecurrenceFromByDayToBySetPosition({
-				calendarObjectInstance: this.calendarObjectInstance,
 				recurrenceRule: this.recurrenceRule,
 			})
 			this.modified()
@@ -408,7 +404,6 @@ export default {
 		 */
 		changeToByDayYearly() {
 			this.calendarObjectInstanceStore.changeYearlyRecurrenceFromBySetPositionToByDay({
-				calendarObjectInstance: this.calendarObjectInstance,
 				recurrenceRule: this.recurrenceRule,
 			})
 			this.modified()
@@ -426,7 +421,6 @@ export default {
 
 		changeToUntil() {
 			this.calendarObjectInstanceStore.enableRecurrenceLimitByUntil({
-				calendarObjectInstance: this.calendarObjectInstance,
 				recurrenceRule: this.recurrenceRule,
 			})
 			this.modified()
@@ -441,7 +435,6 @@ export default {
 		 */
 		setUntil(until) {
 			this.calendarObjectInstanceStore.changeRecurrenceUntil({
-				calendarObjectInstance: this.calendarObjectInstance,
 				recurrenceRule: this.recurrenceRule,
 				until,
 			})

--- a/src/components/Editor/Repeat/RepeatEndRepeat.vue
+++ b/src/components/Editor/Repeat/RepeatEndRepeat.vue
@@ -36,8 +36,9 @@
 
 <script>
 import { NcSelect, NcTextField } from '@nextcloud/vue'
-import { mapStores } from 'pinia'
+import { mapState, mapStores } from 'pinia'
 import DatePicker from '@/components/Shared/DatePicker.vue'
+import useCalendarObjectInstanceStore from '@/store/calendarObjectInstance.js'
 import useDavRestrictionsStore from '@/store/davRestrictions.js'
 
 export default {
@@ -49,14 +50,6 @@ export default {
 	},
 
 	props: {
-		/**
-		 * The calendar-object instance
-		 */
-		calendarObjectInstance: {
-			type: Object,
-			required: true,
-		},
-
 		count: {
 			type: Number,
 			default: null,
@@ -72,6 +65,7 @@ export default {
 
 	computed: {
 		...mapStores(useDavRestrictionsStore),
+		...mapState(useCalendarObjectInstanceStore, ['calendarObjectInstance']),
 		/**
 		 * The minimum date the user can select in the until date-picker
 		 *

--- a/src/components/Editor/Resources/ResourceList.vue
+++ b/src/components/Editor/Resources/ResourceList.vue
@@ -22,13 +22,11 @@
 		<RoomAvailabilityList
 			v-if="showRoomAvailabilityModal"
 			:showDialog="showRoomAvailabilityModal"
-			:calendarObjectInstance="calendarObjectInstance"
 			@update:showDialog="setShowRoomAvailabilityModal" />
 
 		<ResourceListSearch
 			v-if="!isReadOnly && hasUserEmailAddress && resourceBookingEnabled"
 			:alreadyInvitedEmails="alreadyInvitedEmails"
-			:calendarObjectInstance="calendarObjectInstance"
 			@addResource="addResource" />
 
 		<ResourceListItem
@@ -57,7 +55,7 @@ import {
 	NcButton,
 } from '@nextcloud/vue'
 import debounce from 'debounce'
-import { mapStores } from 'pinia'
+import { mapState, mapStores } from 'pinia'
 import DoorOpenIcon from 'vue-material-design-icons/DoorOpen.vue'
 import RoomAvailabilityList from '@/components/Editor/FreeBusy/RoomAvailabilityList.vue'
 import ResourceListItem from '@/components/Editor/Resources/ResourceListItem.vue'
@@ -83,11 +81,6 @@ export default {
 			type: Boolean,
 			required: true,
 		},
-
-		calendarObjectInstance: {
-			type: Object,
-			required: true,
-		},
 	},
 
 	data() {
@@ -103,6 +96,7 @@ export default {
 
 	computed: {
 		...mapStores(usePrincipalsStore, useCalendarObjectInstanceStore),
+		...mapState(useCalendarObjectInstanceStore, ['calendarObjectInstance']),
 		resources() {
 			return this.calendarObjectInstance.attendees.filter((attendee) => {
 				return ['ROOM', 'RESOURCE'].includes(attendee.attendeeProperty.userType)
@@ -241,6 +235,10 @@ export default {
 		 * Recurring events are only probed for the edited occurrence.
 		 */
 		async checkPendingResourceAvailability() {
+			if (!this.calendarObjectInstance) {
+				// Do not continue if event editor was closed in the meantime.
+				return
+			}
 			if (this.isReadOnly || !this.isViewedByOrganizer || !this.resourceBookingEnabled) {
 				return
 			}
@@ -286,6 +284,10 @@ export default {
 		},
 
 		async loadRoomSuggestions() {
+			if (!this.calendarObjectInstance) {
+				// Do not continue if event editor was closed in the meantime.
+				return
+			}
 			if (!this.resourceBookingEnabled) {
 				return
 			}
@@ -316,6 +318,10 @@ export default {
 					}
 				})
 
+				if (!this.calendarObjectInstance) {
+					// Do not continue if event editor was closed in the meantime.
+					return
+				}
 				await checkResourceAvailability(
 					results,
 					this.principalsStore.getCurrentUserPrincipalEmail,

--- a/src/components/Editor/Resources/ResourceList.vue
+++ b/src/components/Editor/Resources/ResourceList.vue
@@ -197,7 +197,6 @@ export default {
 	methods: {
 		addResource({ commonName, email, calendarUserType, language, timezoneId, roomAddress }) {
 			this.calendarObjectInstanceStore.addAttendee({
-				calendarObjectInstance: this.calendarObjectInstance,
 				commonName,
 				uri: email,
 				calendarUserType,
@@ -213,7 +212,6 @@ export default {
 
 		removeResource(resource) {
 			this.calendarObjectInstanceStore.removeAttendee({
-				calendarObjectInstance: this.calendarObjectInstance,
 				attendee: resource,
 			})
 		},
@@ -362,7 +360,6 @@ export default {
 			}
 
 			this.calendarObjectInstanceStore.changeLocation({
-				calendarObjectInstance: this.calendarObjectInstance,
 				location,
 			})
 		},

--- a/src/components/Editor/Resources/ResourceListSearch.vue
+++ b/src/components/Editor/Resources/ResourceListSearch.vue
@@ -72,11 +72,12 @@ import {
 	NcSelect,
 } from '@nextcloud/vue'
 import debounce from 'debounce'
-import { mapStores } from 'pinia'
+import { mapState, mapStores } from 'pinia'
 import ResourceRoomType from '@/components/Editor/Resources/ResourceRoomType.vue'
 import ResourceSeatingCapacity from '@/components/Editor/Resources/ResourceSeatingCapacity.vue'
 import { advancedPrincipalPropertySearch } from '@/services/caldavService.js'
 import { checkResourceAvailability } from '@/services/freeBusyService.js'
+import useCalendarObjectInstanceStore from '@/store/calendarObjectInstance.js'
 import usePrincipalsStore from '@/store/principals.js'
 import logger from '@/utils/logger.js'
 export default {
@@ -93,11 +94,6 @@ export default {
 	props: {
 		alreadyInvitedEmails: {
 			type: Array,
-			required: true,
-		},
-
-		calendarObjectInstance: {
-			type: Object,
 			required: true,
 		},
 	},
@@ -125,6 +121,7 @@ export default {
 
 	computed: {
 		...mapStores(usePrincipalsStore),
+		...mapState(useCalendarObjectInstanceStore, ['calendarObjectInstance']),
 		placeholder() {
 			return this.$t('calendar', 'Search for resources or rooms')
 		},
@@ -162,6 +159,10 @@ export default {
 	methods: {
 
 		findResources: debounce(async function(query) {
+			if (!this.calendarObjectInstance) {
+				// Do not continue if event editor was closed in the meantime.
+				return
+			}
 			this.isLoading = true
 			let matches = []
 
@@ -192,6 +193,10 @@ export default {
 			} catch (error) {
 				logger.debug('Could not find resources', { error })
 				return []
+			}
+			if (!this.calendarObjectInstance) {
+				// Do not continue if event editor was closed in the meantime.
+				return
 			}
 
 			// Build options

--- a/src/mixins/EditorMixin.js
+++ b/src/mixins/EditorMixin.js
@@ -554,7 +554,6 @@ export default {
 
 			if (!this.calendarObjectInstance.organizer) {
 				this.calendarObjectInstanceStore.setOrganizer({
-					calendarObjectInstance: this.calendarObjectInstance,
 					commonName: delegatorPrincipal.displayname,
 					email: delegatorPrincipal.emailAddress,
 				})
@@ -780,7 +779,6 @@ export default {
 		 */
 		updateDescription(description) {
 			this.calendarObjectInstanceStore.changeDescription({
-				calendarObjectInstance: this.calendarObjectInstance,
 				description,
 			})
 		},
@@ -791,7 +789,6 @@ export default {
 		 */
 		updateLocation(location) {
 			this.calendarObjectInstanceStore.changeLocation({
-				calendarObjectInstance: this.calendarObjectInstance,
 				location,
 			})
 		},
@@ -838,7 +835,6 @@ export default {
 			}
 
 			this.calendarObjectInstanceStore.changeStartTimezone({
-				calendarObjectInstance: this.calendarObjectInstance,
 				startTimezone,
 			})
 		},
@@ -882,7 +878,6 @@ export default {
 			}
 
 			this.calendarObjectInstanceStore.changeEndTimezone({
-				calendarObjectInstance: this.calendarObjectInstance,
 				endTimezone,
 			})
 		},

--- a/src/mixins/EditorMixin.js
+++ b/src/mixins/EditorMixin.js
@@ -1027,7 +1027,7 @@ export default {
 			const timezoneId = this.settingsStore.getResolvedTimezone
 
 			await this.loadingCalendars()
-			await this.calendarObjectInstanceStore.updateCalendarObjectInstanceForNewEvent({ isAllDay, start, end, timezoneId })
+			this.calendarObjectInstanceStore.updateCalendarObjectInstanceForNewEvent({ isAllDay, start, end, timezoneId })
 			next()
 		} else {
 			// If both the objectId and recurrenceId remained the same

--- a/src/mixins/EditorMixin.js
+++ b/src/mixins/EditorMixin.js
@@ -770,7 +770,6 @@ export default {
 			}
 
 			this.calendarObjectInstanceStore.changeTitle({
-				calendarObjectInstance: this.calendarObjectInstance,
 				title,
 			})
 		},
@@ -811,7 +810,6 @@ export default {
 			)
 
 			this.calendarObjectInstanceStore.changeStartDate({
-				calendarObjectInstance: this.calendarObjectInstance,
 				startDate: combinedStartDate,
 				onlyTime: false,
 				changeEndDate: true,
@@ -824,7 +822,6 @@ export default {
 		 */
 		updateStartTime(startDate) {
 			this.calendarObjectInstanceStore.changeStartDate({
-				calendarObjectInstance: this.calendarObjectInstance,
 				startDate,
 				onlyTime: true,
 				changeEndDate: true,
@@ -860,7 +857,6 @@ export default {
 			)
 
 			this.calendarObjectInstanceStore.changeEndDate({
-				calendarObjectInstance: this.calendarObjectInstance,
 				endDate: combinedEndDate,
 			})
 		},
@@ -871,7 +867,6 @@ export default {
 		 */
 		updateEndTime(endDate) {
 			this.calendarObjectInstanceStore.changeEndDate({
-				calendarObjectInstance: this.calendarObjectInstance,
 				endDate,
 				onlyTime: true,
 			})
@@ -895,9 +890,7 @@ export default {
 		 * Toggles the event between all-day and timed
 		 */
 		toggleAllDay() {
-			this.calendarObjectInstanceStore.toggleAllDay({
-				calendarObjectInstance: this.calendarObjectInstance,
-			})
+			this.calendarObjectInstanceStore.toggleAllDay()
 
 			updateDefaultAlarm(this.calendarObject.calendarId, this.calendarObjectInstance)
 		},

--- a/src/store/calendarObjectInstance.js
+++ b/src/store/calendarObjectInstance.js
@@ -35,17 +35,13 @@ import {
 import logger from '@/utils/logger.js'
 import { getBySetPositionAndBySetFromDate, getWeekDayFromDate } from '@/utils/recurrence.js'
 
-// XXX "_" is used for marking actions and state.
-// A better way would be to use helper functions not exposed in `actions`.
-// "_" is still used because it maked refactoring easier to do and to understand.
-
 export default defineStore('calendarObjectInstance', {
 	state: () => {
 		return {
-			_isNew: null,
+			isNew: null,
 			calendarObject: null,
 			calendarObjectInstance: null,
-			_existingEvent: {
+			existingEvent: {
 				objectId: null,
 				recurrenceId: null,
 			},
@@ -61,17 +57,17 @@ export default defineStore('calendarObjectInstance', {
 		 * @param {string} data.objectId The objectId of the calendar-object
 		 * @param {number} data.recurrenceId The recurrence-id of the calendar-object-instance
 		 */
-		_setCalendarObjectInstanceForExistingEvent({
+		setCalendarObjectInstanceForExistingEvent({
 			calendarObject,
 			calendarObjectInstance,
 			objectId,
 			recurrenceId,
 		}) {
-			this._isNew = false
+			this.isNew = false
 			this.calendarObject = calendarObject
 			this.calendarObjectInstance = calendarObjectInstance
-			this._existingEvent.objectId = objectId
-			this._existingEvent.recurrenceId = recurrenceId
+			this.existingEvent.objectId = objectId
+			this.existingEvent.recurrenceId = recurrenceId
 
 			if (this.calendarObjectInstance.eventComponent) {
 				this.calendarObjectInstance.eventComponent = markRaw(this.calendarObjectInstance.eventComponent)
@@ -85,15 +81,15 @@ export default defineStore('calendarObjectInstance', {
 		 * @param {object} data.calendarObject The calendar-object currently being created
 		 * @param {object} data.calendarObjectInstance The calendar-object-instance currently being crated
 		 */
-		_setCalendarObjectInstanceForNewEvent({
+		setCalendarObjectInstanceForNewEvent({
 			calendarObject,
 			calendarObjectInstance,
 		}) {
-			this._isNew = true
+			this.isNew = true
 			this.calendarObject = calendarObject
 			this.calendarObjectInstance = calendarObjectInstance
-			this._existingEvent.objectId = null
-			this._existingEvent.recurrenceId = null
+			this.existingEvent.objectId = null
+			this.existingEvent.recurrenceId = null
 
 			if (this.calendarObjectInstance.eventComponent) {
 				this.calendarObjectInstance.eventComponent = markRaw(this.calendarObjectInstance.eventComponent)
@@ -101,11 +97,11 @@ export default defineStore('calendarObjectInstance', {
 		},
 
 		resetCalendarObjectInstanceObjectIdAndRecurrenceId() {
-			this._isNew = false
+			this.isNew = false
 			this.calendarObject = null
 			this.calendarObjectInstance = null
-			this._existingEvent.objectId = null
-			this._existingEvent.recurrenceId = null
+			this.existingEvent.objectId = null
+			this.existingEvent.recurrenceId = null
 		},
 
 		/**
@@ -125,7 +121,7 @@ export default defineStore('calendarObjectInstance', {
 		 * @param {object} data The destructuring object
 		 * @param {Date} data.startDate New start date to set
 		 */
-		_changeStartDateMutation({
+		changeStartDateMutation({
 			startDate,
 		}) {
 			this.calendarObjectInstance.eventComponent.startDate.year = startDate.getFullYear()
@@ -167,7 +163,7 @@ export default defineStore('calendarObjectInstance', {
 		 * @param {object} data The destructuring object
 		 * @param {string} data.startTimezone New timezone to set for start
 		 */
-		_changeStartTimezoneMutation({
+		changeStartTimezoneMutation({
 			startTimezone,
 		}) {
 			const timezone = getTimezoneManager().getTimezoneForId(startTimezone)
@@ -187,7 +183,7 @@ export default defineStore('calendarObjectInstance', {
 		 * @param {object} data The destructuring object
 		 * @param {Date} data.endDate New end date to set
 		 */
-		_changeEndDateMutation({
+		changeEndDateMutation({
 			endDate,
 		}) {
 			// If the event is using DURATION, endDate is dynamically generated.
@@ -243,7 +239,7 @@ export default defineStore('calendarObjectInstance', {
 		 * @param {object} data The destructuring object
 		 * @param {string} data.endTimezone New timezone to set for end
 		 */
-		_changeEndTimezoneMutation({
+		changeEndTimezoneMutation({
 			endTimezone,
 		}) {
 			const timezone = getTimezoneManager().getTimezoneForId(endTimezone)
@@ -260,7 +256,7 @@ export default defineStore('calendarObjectInstance', {
 		/**
 		 * Switch from a timed event to allday or vice versa
 		 */
-		_toggleAllDayMutation() {
+		toggleAllDayMutation() {
 			if (!this.calendarObjectInstance.eventComponent.canModifyAllDay() && this.calendarObject.existsOnServer) {
 				return
 			}
@@ -281,7 +277,7 @@ export default defineStore('calendarObjectInstance', {
 		/**
 		 * Changes the time of a timed event to the default values
 		 */
-		_changeTimeToDefaultForTimedEvents() {
+		changeTimeToDefaultForTimedEvents() {
 			const startDate = this.calendarObjectInstance.eventComponent.startDate
 			const endDate = this.calendarObjectInstance.eventComponent.endDate
 			if (startDate.hour === 0 && startDate.minute === 0 && endDate.hour === 0 && endDate.minute === 0) {
@@ -626,7 +622,7 @@ export default defineStore('calendarObjectInstance', {
 		 * @param {object} data.recurrenceRule The recurrenceRule object to modify
 		 * @param {string} data.frequency The new frequency to set
 		 */
-		_changeRecurrenceFrequencyMutation({
+		changeRecurrenceFrequencyMutation({
 			recurrenceRule,
 			frequency,
 		}) {
@@ -705,7 +701,7 @@ export default defineStore('calendarObjectInstance', {
 		 * @param {object} data The destructuring object
 		 * @param {object} data.recurrenceRule The recurrenceRule object to modify
 		 */
-		_resetRecurrenceByParts({ recurrenceRule }) {
+		resetRecurrenceByParts({ recurrenceRule }) {
 			if (recurrenceRule.recurrenceRuleValue) {
 				const parts = [
 					'BYSECOND',
@@ -744,7 +740,7 @@ export default defineStore('calendarObjectInstance', {
 		 * @param {object} data The destructuring object
 		 * @param {object} data.recurrenceRule The recurrenceRule object to modify
 		 */
-		_setDefaultRecurrenceByPartsForMonthlyBySetPosition({
+		setDefaultRecurrenceByPartsForMonthlyBySetPosition({
 			recurrenceRule,
 		}) {
 			if (recurrenceRule.recurrenceRuleValue) {
@@ -767,7 +763,7 @@ export default defineStore('calendarObjectInstance', {
 		 * @param {object} data The destructuring object
 		 * @param {object} data.recurrenceRule The recurrenceRule object to modify
 		 */
-		_setDefaultRecurrenceByPartsForYearlyBySetPosition({
+		setDefaultRecurrenceByPartsForYearlyBySetPosition({
 			recurrenceRule,
 		}) {
 			if (recurrenceRule.recurrenceRuleValue) {
@@ -1073,7 +1069,7 @@ export default defineStore('calendarObjectInstance', {
 		 * @param {object} data The destructuring object
 		 * @param {object} data.alarm The alarm object
 		 */
-		_updateAlarmAllDayParts({ alarm }) {
+		updateAlarmAllDayParts({ alarm }) {
 			if (alarm.alarmComponent) {
 				const totalSeconds = alarm.alarmComponent.trigger.value.totalSeconds
 				const allDayParts = getAmountHoursMinutesAndUnitForAllDayEvents(totalSeconds)
@@ -1090,7 +1086,7 @@ export default defineStore('calendarObjectInstance', {
 		 * @param {object} data The destructuring object
 		 * @param {object} data.alarm The alarm object
 		 */
-		_updateAlarmTimedParts({ alarm }) {
+		updateAlarmTimedParts({ alarm }) {
 			if (alarm.alarmComponent) {
 				const totalSeconds = alarm.alarmComponent.trigger.value.totalSeconds
 				const timedParts = getAmountAndUnitForTimedEvents(totalSeconds)
@@ -1270,7 +1266,7 @@ export default defineStore('calendarObjectInstance', {
 			recurrenceId,
 		}) {
 			const calendarsStore = useCalendarsStore()
-			if (this._existingEvent.objectId === objectId && this._existingEvent.recurrenceId === recurrenceId) {
+			if (this.existingEvent.objectId === objectId && this.existingEvent.recurrenceId === recurrenceId) {
 				return
 			}
 
@@ -1282,7 +1278,7 @@ export default defineStore('calendarObjectInstance', {
 			}
 
 			const calendarObjectInstance = mapEventComponentToEventObject(eventComponent)
-			this._setCalendarObjectInstanceForExistingEvent({
+			this.setCalendarObjectInstanceForExistingEvent({
 				calendarObject,
 				calendarObjectInstance,
 				objectId,
@@ -1308,7 +1304,7 @@ export default defineStore('calendarObjectInstance', {
 		}) {
 			const calendarObjectsStore = useCalendarObjectsStore()
 
-			if (this._isNew === true) {
+			if (this.isNew === true) {
 				return
 			}
 
@@ -1340,7 +1336,7 @@ export default defineStore('calendarObjectInstance', {
 
 			calendarObjectInstance.eventComponent.status = status
 
-			this._setCalendarObjectInstanceForNewEvent({
+			this.setCalendarObjectInstanceForNewEvent({
 				calendarObject,
 				calendarObjectInstance,
 			})
@@ -1363,13 +1359,13 @@ export default defineStore('calendarObjectInstance', {
 			end,
 			timezoneId,
 		}) {
-			this._updateTimeOfNewEvent({
+			this.updateTimeOfNewEvent({
 				start,
 				end,
 				isAllDay,
 				timezoneId,
 			})
-			this._setCalendarObjectInstanceForNewEvent({
+			this.setCalendarObjectInstanceForNewEvent({
 				calendarObject: this.calendarObject,
 				calendarObjectInstance: this.calendarObjectInstance,
 			})
@@ -1449,7 +1445,7 @@ export default defineStore('calendarObjectInstance', {
 			copyCalendarObjectInstanceIntoEventComponent(oldCalendarObjectInstance, eventComponent)
 			const calendarObjectInstance = mapEventComponentToEventObject(eventComponent)
 
-			this._setCalendarObjectInstanceForNewEvent({
+			this.setCalendarObjectInstanceForNewEvent({
 				calendarObject,
 				calendarObjectInstance,
 			})
@@ -1495,14 +1491,14 @@ export default defineStore('calendarObjectInstance', {
 				startDate.setFullYear(this.calendarObjectInstance.startDate.getFullYear(), this.calendarObjectInstance.startDate.getMonth(), this.calendarObjectInstance.startDate.getDate())
 			}
 
-			this._changeStartDateMutation({
+			this.changeStartDateMutation({
 				startDate,
 			})
 
 			// When changing time, preserve the original duration
 			if (changeEndDate) {
 				const newEndDate = new Date(startDate.getTime() + oldDuration)
-				this._changeEndDateMutation({
+				this.changeEndDateMutation({
 					endDate: newEndDate,
 				})
 			}
@@ -1517,13 +1513,13 @@ export default defineStore('calendarObjectInstance', {
 		changeStartTimezone({
 			startTimezone,
 		}) {
-			this._changeStartTimezoneMutation({
+			this.changeStartTimezoneMutation({
 				startTimezone,
 			})
 
 			// Simulate a change of the start time to trigger the comparison
 			// of start and end and trigger an update of end if necessary
-			this._changeStartDateMutation({
+			this.changeStartDateMutation({
 				startDate: this.calendarObjectInstance.startDate,
 			})
 		},
@@ -1542,7 +1538,7 @@ export default defineStore('calendarObjectInstance', {
 				endDate.setFullYear(this.calendarObjectInstance.endDate.getFullYear(), this.calendarObjectInstance.endDate.getMonth(), this.calendarObjectInstance.endDate.getDate())
 			}
 
-			this._changeEndDateMutation({
+			this.changeEndDateMutation({
 				endDate,
 			})
 		},
@@ -1556,13 +1552,13 @@ export default defineStore('calendarObjectInstance', {
 		changeEndTimezone({
 			endTimezone,
 		}) {
-			this._changeEndTimezoneMutation({
+			this.changeEndTimezoneMutation({
 				endTimezone,
 			})
 
 			// Simulate a change of the end time to trigger the comparison
 			// of start and end and trigger an update of start if necessary
-			this._changeEndDateMutation({
+			this.changeEndDateMutation({
 				endDate: this.calendarObjectInstance.endDate,
 			})
 		},
@@ -1586,8 +1582,8 @@ export default defineStore('calendarObjectInstance', {
 				this.calendarObjectInstance.eventComponent.addProperty(recurrenceProperty)
 				this.calendarObjectInstance.recurrenceRule.recurrenceRuleValue = recurrenceValue
 
-				this._resetRecurrenceByParts({ recurrenceRule })
-				this._changeRecurrenceFrequencyMutation({
+				this.resetRecurrenceByParts({ recurrenceRule })
+				this.changeRecurrenceFrequencyMutation({
 					recurrenceRule: this.calendarObjectInstance.recurrenceRule,
 					frequency,
 				})
@@ -1598,7 +1594,7 @@ export default defineStore('calendarObjectInstance', {
 				this.changeRecurrenceToInfinite({
 					recurrenceRule: this.calendarObjectInstance.recurrenceRule,
 				})
-				this._setDefaultRecurrenceByParts({
+				this.setDefaultRecurrenceByParts({
 					recurrenceRule,
 					frequency,
 				})
@@ -1616,12 +1612,12 @@ export default defineStore('calendarObjectInstance', {
 				}
 			} else {
 				// Change frequency of existing recurrence-rule
-				this._resetRecurrenceByParts({ recurrenceRule })
-				this._changeRecurrenceFrequencyMutation({
+				this.resetRecurrenceByParts({ recurrenceRule })
+				this.changeRecurrenceFrequencyMutation({
 					recurrenceRule: this.calendarObjectInstance.recurrenceRule,
 					frequency,
 				})
-				this._setDefaultRecurrenceByParts({
+				this.setDefaultRecurrenceByParts({
 					recurrenceRule,
 					frequency,
 				})
@@ -1634,7 +1630,7 @@ export default defineStore('calendarObjectInstance', {
 		 * @param {object} data.recurrenceRule The recurrenceRule object to modify
 		 * @param {string} data.frequency The new frequency to set
 		 */
-		_setDefaultRecurrenceByParts({
+		setDefaultRecurrenceByParts({
 			recurrenceRule,
 			frequency,
 		}) {
@@ -1684,8 +1680,8 @@ export default defineStore('calendarObjectInstance', {
 			recurrenceRule,
 		}) {
 			logger.debug('changeMonthlyRecurrenceFromByDayToBySetPosition')
-			this._resetRecurrenceByParts({ recurrenceRule })
-			this._setDefaultRecurrenceByPartsForMonthlyBySetPosition({
+			this.resetRecurrenceByParts({ recurrenceRule })
+			this.setDefaultRecurrenceByPartsForMonthlyBySetPosition({
 				recurrenceRule,
 			})
 		},
@@ -1699,7 +1695,7 @@ export default defineStore('calendarObjectInstance', {
 			recurrenceRule,
 		}) {
 			logger.debug('changeMonthlyRecurrenceFromBySetPositionToByDay')
-			this._resetRecurrenceByParts({ recurrenceRule })
+			this.resetRecurrenceByParts({ recurrenceRule })
 
 			if (recurrenceRule.recurrenceRuleValue) {
 				const byMonthDay = this.calendarObjectInstance.startDate.getDate()
@@ -1718,8 +1714,8 @@ export default defineStore('calendarObjectInstance', {
 		changeYearlyRecurrenceFromByDayToBySetPosition({
 			recurrenceRule,
 		}) {
-			this._resetRecurrenceByParts({ recurrenceRule })
-			this._setDefaultRecurrenceByPartsForYearlyBySetPosition({
+			this.resetRecurrenceByParts({ recurrenceRule })
+			this.setDefaultRecurrenceByPartsForYearlyBySetPosition({
 				recurrenceRule,
 			})
 		},
@@ -1732,7 +1728,7 @@ export default defineStore('calendarObjectInstance', {
 		changeYearlyRecurrenceFromBySetPositionToByDay({
 			recurrenceRule,
 		}) {
-			this._resetRecurrenceByParts({ recurrenceRule })
+			this.resetRecurrenceByParts({ recurrenceRule })
 
 			if (recurrenceRule.recurrenceRuleValue) {
 				const byMonth = this.calendarObjectInstance.startDate.getMonth() + 1 // Javascript months are zero-based
@@ -1829,7 +1825,7 @@ export default defineStore('calendarObjectInstance', {
 
 				logger.debug(alarm.alarmComponent.toICALJs().toString())
 			}
-			this._updateAlarmAllDayParts({ alarm })
+			this.updateAlarmAllDayParts({ alarm })
 		},
 
 		changeAlarmUnitTimed({
@@ -1845,7 +1841,7 @@ export default defineStore('calendarObjectInstance', {
 
 				logger.debug(alarm.alarmComponent.toICALJs().toString())
 			}
-			this._updateAlarmAllDayParts({ alarm })
+			this.updateAlarmAllDayParts({ alarm })
 		},
 
 		changeAlarmAmountAllDay({
@@ -1867,7 +1863,7 @@ export default defineStore('calendarObjectInstance', {
 				logger.debug(alarm.alarmComponent.toICALJs().toString())
 			}
 
-			this._updateAlarmTimedParts({ alarm })
+			this.updateAlarmTimedParts({ alarm })
 		},
 
 		changeAlarmUnitAllDay({
@@ -1889,7 +1885,7 @@ export default defineStore('calendarObjectInstance', {
 				logger.debug(alarm.alarmComponent.toICALJs().toString())
 			}
 
-			this._updateAlarmTimedParts({ alarm })
+			this.updateAlarmTimedParts({ alarm })
 		},
 
 		changeAlarmHoursMinutesAllDay({
@@ -1913,7 +1909,7 @@ export default defineStore('calendarObjectInstance', {
 				logger.debug(alarm.alarmComponent.toICALJs().toString())
 			}
 
-			this._updateAlarmTimedParts({ alarm })
+			this.updateAlarmTimedParts({ alarm })
 		},
 
 		changeAlarmFromRelativeToAbsolute({
@@ -1958,8 +1954,8 @@ export default defineStore('calendarObjectInstance', {
 				alarm.relativeTrigger = duration.totalSeconds
 			}
 
-			this._updateAlarmAllDayParts({ alarm })
-			this._updateAlarmTimedParts({ alarm })
+			this.updateAlarmAllDayParts({ alarm })
+			this.updateAlarmTimedParts({ alarm })
 
 			alarm.absoluteDate = null
 			alarm.absoluteTimezoneId = null
@@ -1967,17 +1963,17 @@ export default defineStore('calendarObjectInstance', {
 
 		toggleAllDay() {
 			const settingsStore = useSettingsStore()
-			this._toggleAllDayMutation()
+			this.toggleAllDayMutation()
 
 			if (!this.calendarObjectInstance.isAllDay) {
 				if (this.calendarObjectInstance.startTimezoneId === 'floating') {
 					const startTimezone = settingsStore.getResolvedTimezone
-					this._changeStartTimezoneMutation({
+					this.changeStartTimezoneMutation({
 						startTimezone,
 					})
 				}
 
-				this._changeTimeToDefaultForTimedEvents()
+				this.changeTimeToDefaultForTimedEvents()
 			}
 		},
 
@@ -1990,13 +1986,13 @@ export default defineStore('calendarObjectInstance', {
 		 * @param {string} data.timezoneId asd
 		 * @param {boolean} data.isAllDay foo
 		 */
-		_updateTimeOfNewEvent({ start, end, timezoneId, isAllDay }) {
+		updateTimeOfNewEvent({ start, end, timezoneId, isAllDay }) {
 			const isDirty = this.calendarObjectInstance.eventComponent.isDirty()
 			const startDate = new Date(start * 1000)
 			const endDate = new Date(end * 1000)
 
 			if (this.calendarObjectInstance.isAllDay !== isAllDay) {
-				this._toggleAllDayMutation()
+				this.toggleAllDayMutation()
 			}
 
 			this.changeStartTimezone({
@@ -2006,18 +2002,18 @@ export default defineStore('calendarObjectInstance', {
 				endTimezone: timezoneId,
 			})
 
-			this._changeStartDateMutation({
+			this.changeStartDateMutation({
 				startDate,
 			})
 
 			if (isAllDay) {
 				// The full-calendar end date is exclusive, but the end-date
 				// that changeEndDate expects is inclusive, so we have to deduct one day.
-				this._changeEndDateMutation({
+				this.changeEndDateMutation({
 					endDate: new Date(endDate.getTime() - 24 * 60 * 60 * 1000),
 				})
 			} else {
-				this._changeEndDateMutation({
+				this.changeEndDateMutation({
 					endDate,
 				})
 			}

--- a/src/store/calendarObjectInstance.js
+++ b/src/store/calendarObjectInstance.js
@@ -1340,7 +1340,7 @@ export default defineStore('calendarObjectInstance', {
 		 * @param {object} data The destructuring object
 		 * @param {string} data.objectId The objectId of the calendar-object to edit
 		 * @param {number} data.recurrenceId The recurrence-id to edit
-		 * @return {Promise<{calendarObject: object, calendarObjectInstance: object}>}
+		 * @return {Promise<void>}
 		 */
 		async getCalendarObjectInstanceByObjectIdAndRecurrenceId({
 			objectId,
@@ -1348,10 +1348,7 @@ export default defineStore('calendarObjectInstance', {
 		}) {
 			const calendarsStore = useCalendarsStore()
 			if (this._existingEvent.objectId === objectId && this._existingEvent.recurrenceId === recurrenceId) {
-				return Promise.resolve({
-					calendarObject: this.calendarObject,
-					calendarObjectInstance: this.calendarObjectInstance,
-				})
+				return
 			}
 
 			const recurrenceIdDate = new Date(recurrenceId * 1000)
@@ -1368,11 +1365,6 @@ export default defineStore('calendarObjectInstance', {
 				objectId,
 				recurrenceId,
 			})
-
-			return {
-				calendarObject,
-				calendarObjectInstance,
-			}
 		},
 
 		/**
@@ -1383,7 +1375,7 @@ export default defineStore('calendarObjectInstance', {
 		 * @param {number} data.start The start of the new event (unixtime)
 		 * @param {number} data.end The end of the new event (unixtime)
 		 * @param {string} data.timezoneId The timezoneId of the new event
-		 * @return {Promise<{calendarObject: object, calendarObjectInstance: object}>}
+		 * @return {Promise<void>}
 		 */
 		async getCalendarObjectInstanceForNewEvent({
 			isAllDay,
@@ -1394,10 +1386,7 @@ export default defineStore('calendarObjectInstance', {
 			const calendarObjectsStore = useCalendarObjectsStore()
 
 			if (this._isNew === true) {
-				return Promise.resolve({
-					calendarObject: this.calendarObject,
-					calendarObjectInstance: this.calendarObjectInstance,
-				})
+				return
 			}
 
 			const calendarObject = await calendarObjectsStore.createNewEvent({
@@ -1434,11 +1423,6 @@ export default defineStore('calendarObjectInstance', {
 			})
 
 			calendarObjectInstance.eventComponent.undirtify()
-
-			return {
-				calendarObject,
-				calendarObjectInstance,
-			}
 		},
 
 		/**
@@ -1449,7 +1433,6 @@ export default defineStore('calendarObjectInstance', {
 		 * @param {number} data.start The start of the new event (unixtime)
 		 * @param {number} data.end The end of the new event (unixtime)
 		 * @param {string} data.timezoneId The timezoneId of the new event
-		 * @return {Promise<{calendarObject: object, calendarObjectInstance: object}>}
 		 */
 		updateCalendarObjectInstanceForNewEvent({
 			isAllDay,
@@ -1468,11 +1451,6 @@ export default defineStore('calendarObjectInstance', {
 				calendarObject: this.calendarObject,
 				calendarObjectInstance: this.calendarObjectInstance,
 			})
-
-			return {
-				calendarObject: this.calendarObject,
-				calendarObjectInstance: this.calendarObjectInstance,
-			}
 		},
 
 		/**

--- a/src/store/calendarObjectInstance.js
+++ b/src/store/calendarObjectInstance.js
@@ -112,12 +112,11 @@ export default defineStore('calendarObjectInstance', {
 		 * Change the title of the event
 		 *
 		 * @param {object} data The destructuring object
-		 * @param {object} data.calendarObjectInstance The calendarObjectInstance object
 		 * @param {string} data.title The new Title
 		 */
-		changeTitle({ calendarObjectInstance, title }) {
-			calendarObjectInstance.eventComponent.title = title
-			calendarObjectInstance.title = title
+		changeTitle({ title }) {
+			this.calendarObjectInstance.eventComponent.title = title
+			this.calendarObjectInstance.title = title
 		},
 
 		/**
@@ -292,19 +291,16 @@ export default defineStore('calendarObjectInstance', {
 
 		/**
 		 * Changes the time of a timed event to the default values
-		 *
-		 * @param {object} data The destructuring object
-		 * @param {object} data.calendarObjectInstance The calendarObjectInstance object
 		 */
-		_changeTimeToDefaultForTimedEvents({ calendarObjectInstance }) {
-			const startDate = calendarObjectInstance.eventComponent.startDate
-			const endDate = calendarObjectInstance.eventComponent.endDate
+		_changeTimeToDefaultForTimedEvents() {
+			const startDate = this.calendarObjectInstance.eventComponent.startDate
+			const endDate = this.calendarObjectInstance.eventComponent.endDate
 			if (startDate.hour === 0 && startDate.minute === 0 && endDate.hour === 0 && endDate.minute === 0) {
 				startDate.hour = 10
 				endDate.hour = 11
 
-				calendarObjectInstance.startDate = getDateFromDateTimeValue(startDate)
-				calendarObjectInstance.endDate = getDateFromDateTimeValue(endDate)
+				this.calendarObjectInstance.startDate = getDateFromDateTimeValue(startDate)
+				this.calendarObjectInstance.endDate = getDateFromDateTimeValue(endDate)
 			}
 		},
 
@@ -356,61 +352,56 @@ export default defineStore('calendarObjectInstance', {
 		 * Change the access class of an event
 		 *
 		 * @param {object} data The destructuring object
-		 * @param {object} data.calendarObjectInstance The calendarObjectInstance object
 		 * @param {string} data.accessClass New access class to set
 		 */
-		changeAccessClass({ calendarObjectInstance, accessClass }) {
-			calendarObjectInstance.eventComponent.accessClass = accessClass
-			calendarObjectInstance.accessClass = accessClass
+		changeAccessClass({ accessClass }) {
+			this.calendarObjectInstance.eventComponent.accessClass = accessClass
+			this.calendarObjectInstance.accessClass = accessClass
 		},
 
 		/**
 		 * Change the status of an event
 		 *
 		 * @param {object} data The destructuring object
-		 * @param {object} data.calendarObjectInstance The calendarObjectInstance object
 		 * @param {string} data.status New status to set
 		 */
-		changeStatus({ calendarObjectInstance, status }) {
-			calendarObjectInstance.eventComponent.status = status
-			calendarObjectInstance.status = status
+		changeStatus({ status }) {
+			this.calendarObjectInstance.eventComponent.status = status
+			this.calendarObjectInstance.status = status
 		},
 
 		/**
 		 * Change the time-transparency of an event
 		 *
 		 * @param {object} data The destructuring object
-		 * @param {object} data.calendarObjectInstance The calendarObjectInstance object
 		 * @param {string} data.timeTransparency New time-transparency to set
 		 */
-		changeTimeTransparency({ calendarObjectInstance, timeTransparency }) {
-			calendarObjectInstance.eventComponent.timeTransparency = timeTransparency
-			calendarObjectInstance.timeTransparency = timeTransparency
+		changeTimeTransparency({ timeTransparency }) {
+			this.calendarObjectInstance.eventComponent.timeTransparency = timeTransparency
+			this.calendarObjectInstance.timeTransparency = timeTransparency
 		},
 
 		/**
 		 * Change the invitation-forwarding property of an event
 		 *
 		 * @param {object} data The destructuring object
-		 * @param {object} data.calendarObjectInstance The calendarObjectInstance object
 		 * @param {string} data.invitationForwarding Invitation forwarding value
 		 */
-		changeInvitationForwarding({ calendarObjectInstance, invitationForwarding }) {
-			calendarObjectInstance.eventComponent.updatePropertyWithValue('X-NC-INVITATION-FORWARDING', invitationForwarding)
-			calendarObjectInstance.invitationForwarding = invitationForwarding
+		changeInvitationForwarding({ invitationForwarding }) {
+			this.calendarObjectInstance.eventComponent.updatePropertyWithValue('X-NC-INVITATION-FORWARDING', invitationForwarding)
+			this.calendarObjectInstance.invitationForwarding = invitationForwarding
 		},
 
 		/**
 		 * Change the customized color of an event
 		 *
 		 * @param {object} data The destructuring object
-		 * @param {object} data.calendarObjectInstance The calendarObjectInstance object
 		 * @param {string | null} data.customColor New color to set
 		 */
-		changeCustomColor({ calendarObjectInstance, customColor }) {
+		changeCustomColor({ customColor }) {
 			if (customColor === null) {
-				calendarObjectInstance.eventComponent.deleteAllProperties('COLOR')
-				calendarObjectInstance.customColor = null
+				this.calendarObjectInstance.eventComponent.deleteAllProperties('COLOR')
+				this.calendarObjectInstance.customColor = null
 				return
 			}
 
@@ -423,8 +414,8 @@ export default defineStore('calendarObjectInstance', {
 				return
 			}
 
-			calendarObjectInstance.eventComponent.color = cssColorName
-			calendarObjectInstance.customColor = hexColorOfCssName
+			this.calendarObjectInstance.eventComponent.color = cssColorName
+			this.calendarObjectInstance.customColor = hexColorOfCssName
 		},
 
 		/**
@@ -611,24 +602,23 @@ export default defineStore('calendarObjectInstance', {
 		 * @param {object} data.calendarObjectInstance The calendarObjectInstance object
 		 * @param {string} data.category Category to add
 		 */
-		addCategory({ calendarObjectInstance, category }) {
-			calendarObjectInstance.eventComponent.addCategory(category)
-			calendarObjectInstance.categories.push(category)
+		addCategory({ category }) {
+			this.calendarObjectInstance.eventComponent.addCategory(category)
+			this.calendarObjectInstance.categories.push(category)
 		},
 
 		/**
 		 * Removes a category from the event
 		 *
 		 * @param {object} data The destructuring object
-		 * @param {object} data.calendarObjectInstance The calendarObjectInstance object
 		 * @param {string} data.category Category to remove
 		 */
-		removeCategory({ calendarObjectInstance, category }) {
-			calendarObjectInstance.eventComponent.removeCategory(category)
+		removeCategory({ category }) {
+			this.calendarObjectInstance.eventComponent.removeCategory(category)
 
-			const index = calendarObjectInstance.categories.indexOf(category)
+			const index = this.calendarObjectInstance.categories.indexOf(category)
 			if (index !== -1) {
-				calendarObjectInstance.categories.splice(index, 1)
+				this.calendarObjectInstance.categories.splice(index, 1)
 			}
 		},
 
@@ -1591,26 +1581,24 @@ export default defineStore('calendarObjectInstance', {
 		/**
 		 *
 		 * @param {object} data The destructuring object for data
-		 * @param {object} data.calendarObjectInstance The calendarObjectInstance object
 		 * @param {Date} data.startDate The new start-date
 		 * @param {boolean} data.onlyTime Only update time
 		 * @param {boolean=} data.changeEndDate Whether to also shift the end-date to preserve the duration
 		 */
 		changeStartDate({
-			calendarObjectInstance,
 			startDate,
 			onlyTime = false,
 			changeEndDate = true,
 		}) {
 			// Calculate current duration between start and end
-			const oldDuration = calendarObjectInstance.endDate.getTime() - calendarObjectInstance.startDate.getTime()
+			const oldDuration = this.calendarObjectInstance.endDate.getTime() - this.calendarObjectInstance.startDate.getTime()
 
 			if (onlyTime) {
-				startDate.setFullYear(calendarObjectInstance.startDate.getFullYear(), calendarObjectInstance.startDate.getMonth(), calendarObjectInstance.startDate.getDate())
+				startDate.setFullYear(this.calendarObjectInstance.startDate.getFullYear(), this.calendarObjectInstance.startDate.getMonth(), this.calendarObjectInstance.startDate.getDate())
 			}
 
 			this.changeStartDateMutation({
-				calendarObjectInstance,
+				calendarObjectInstance: this.calendarObjectInstance,
 				startDate,
 			})
 
@@ -1618,7 +1606,7 @@ export default defineStore('calendarObjectInstance', {
 			if (changeEndDate) {
 				const newEndDate = new Date(startDate.getTime() + oldDuration)
 				this.changeEndDateMutation({
-					calendarObjectInstance,
+					calendarObjectInstance: this.calendarObjectInstance,
 					endDate: newEndDate,
 				})
 			}
@@ -1651,21 +1639,19 @@ export default defineStore('calendarObjectInstance', {
 		/**
 		 *
 		 * @param {object} data The destructuring object for data
-		 * @param {object} data.calendarObjectInstance The calendarObjectInstance object
 		 * @param {Date} data.endDate The new end-date
 		 * @param {boolean} data.onlyTime Only update time
 		 */
 		changeEndDate({
-			calendarObjectInstance,
 			endDate,
 			onlyTime = false,
 		}) {
 			if (onlyTime) {
-				endDate.setFullYear(calendarObjectInstance.endDate.getFullYear(), calendarObjectInstance.endDate.getMonth(), calendarObjectInstance.endDate.getDate())
+				endDate.setFullYear(this.calendarObjectInstance.endDate.getFullYear(), this.calendarObjectInstance.endDate.getMonth(), this.calendarObjectInstance.endDate.getDate())
 			}
 
 			this.changeEndDateMutation({
-				calendarObjectInstance,
+				calendarObjectInstance: this.calendarObjectInstance,
 				endDate,
 			})
 		},
@@ -2116,20 +2102,20 @@ export default defineStore('calendarObjectInstance', {
 			alarm.absoluteTimezoneId = null
 		},
 
-		toggleAllDay({ calendarObjectInstance }) {
+		toggleAllDay() {
 			const settingsStore = useSettingsStore()
-			this.toggleAllDayMutation({ calendarObjectInstance })
+			this.toggleAllDayMutation({ calendarObjectInstance: this.calendarObjectInstance })
 
-			if (!calendarObjectInstance.isAllDay) {
-				if (calendarObjectInstance.startTimezoneId === 'floating') {
+			if (!this.calendarObjectInstance.isAllDay) {
+				if (this.calendarObjectInstance.startTimezoneId === 'floating') {
 					const startTimezone = settingsStore.getResolvedTimezone
 					this._changeStartTimezoneMutation({
-						calendarObjectInstance,
+						calendarObjectInstance: this.calendarObjectInstance,
 						startTimezone,
 					})
 				}
 
-				this._changeTimeToDefaultForTimedEvents({ calendarObjectInstance })
+				this._changeTimeToDefaultForTimedEvents()
 			}
 		},
 	},

--- a/src/store/calendarObjectInstance.js
+++ b/src/store/calendarObjectInstance.js
@@ -125,7 +125,7 @@ export default defineStore('calendarObjectInstance', {
 		 * @param {object} data The destructuring object
 		 * @param {Date} data.startDate New start date to set
 		 */
-		changeStartDateMutation({
+		_changeStartDateMutation({
 			startDate,
 		}) {
 			this.calendarObjectInstance.eventComponent.startDate.year = startDate.getFullYear()
@@ -187,7 +187,7 @@ export default defineStore('calendarObjectInstance', {
 		 * @param {object} data The destructuring object
 		 * @param {Date} data.endDate New end date to set
 		 */
-		changeEndDateMutation({
+		_changeEndDateMutation({
 			endDate,
 		}) {
 			// If the event is using DURATION, endDate is dynamically generated.
@@ -260,7 +260,7 @@ export default defineStore('calendarObjectInstance', {
 		/**
 		 * Switch from a timed event to allday or vice versa
 		 */
-		toggleAllDayMutation() {
+		_toggleAllDayMutation() {
 			if (!this.calendarObjectInstance.eventComponent.canModifyAllDay() && this.calendarObject.existsOnServer) {
 				return
 			}
@@ -767,7 +767,7 @@ export default defineStore('calendarObjectInstance', {
 		 * @param {object} data The destructuring object
 		 * @param {object} data.recurrenceRule The recurrenceRule object to modify
 		 */
-		setDefaultRecurrenceByPartsForYearlyBySetPosition({
+		_setDefaultRecurrenceByPartsForYearlyBySetPosition({
 			recurrenceRule,
 		}) {
 			if (recurrenceRule.recurrenceRuleValue) {
@@ -1073,7 +1073,7 @@ export default defineStore('calendarObjectInstance', {
 		 * @param {object} data The destructuring object
 		 * @param {object} data.alarm The alarm object
 		 */
-		updateAlarmAllDayParts({ alarm }) {
+		_updateAlarmAllDayParts({ alarm }) {
 			if (alarm.alarmComponent) {
 				const totalSeconds = alarm.alarmComponent.trigger.value.totalSeconds
 				const allDayParts = getAmountHoursMinutesAndUnitForAllDayEvents(totalSeconds)
@@ -1090,7 +1090,7 @@ export default defineStore('calendarObjectInstance', {
 		 * @param {object} data The destructuring object
 		 * @param {object} data.alarm The alarm object
 		 */
-		updateAlarmTimedParts({ alarm }) {
+		_updateAlarmTimedParts({ alarm }) {
 			if (alarm.alarmComponent) {
 				const totalSeconds = alarm.alarmComponent.trigger.value.totalSeconds
 				const timedParts = getAmountAndUnitForTimedEvents(totalSeconds)
@@ -1495,14 +1495,14 @@ export default defineStore('calendarObjectInstance', {
 				startDate.setFullYear(this.calendarObjectInstance.startDate.getFullYear(), this.calendarObjectInstance.startDate.getMonth(), this.calendarObjectInstance.startDate.getDate())
 			}
 
-			this.changeStartDateMutation({
+			this._changeStartDateMutation({
 				startDate,
 			})
 
 			// When changing time, preserve the original duration
 			if (changeEndDate) {
 				const newEndDate = new Date(startDate.getTime() + oldDuration)
-				this.changeEndDateMutation({
+				this._changeEndDateMutation({
 					endDate: newEndDate,
 				})
 			}
@@ -1523,7 +1523,7 @@ export default defineStore('calendarObjectInstance', {
 
 			// Simulate a change of the start time to trigger the comparison
 			// of start and end and trigger an update of end if necessary
-			this.changeStartDateMutation({
+			this._changeStartDateMutation({
 				startDate: this.calendarObjectInstance.startDate,
 			})
 		},
@@ -1542,7 +1542,7 @@ export default defineStore('calendarObjectInstance', {
 				endDate.setFullYear(this.calendarObjectInstance.endDate.getFullYear(), this.calendarObjectInstance.endDate.getMonth(), this.calendarObjectInstance.endDate.getDate())
 			}
 
-			this.changeEndDateMutation({
+			this._changeEndDateMutation({
 				endDate,
 			})
 		},
@@ -1562,7 +1562,7 @@ export default defineStore('calendarObjectInstance', {
 
 			// Simulate a change of the end time to trigger the comparison
 			// of start and end and trigger an update of start if necessary
-			this.changeEndDateMutation({
+			this._changeEndDateMutation({
 				endDate: this.calendarObjectInstance.endDate,
 			})
 		},
@@ -1598,7 +1598,7 @@ export default defineStore('calendarObjectInstance', {
 				this.changeRecurrenceToInfinite({
 					recurrenceRule: this.calendarObjectInstance.recurrenceRule,
 				})
-				this.setDefaultRecurrenceByParts({
+				this._setDefaultRecurrenceByParts({
 					recurrenceRule,
 					frequency,
 				})
@@ -1621,7 +1621,7 @@ export default defineStore('calendarObjectInstance', {
 					recurrenceRule: this.calendarObjectInstance.recurrenceRule,
 					frequency,
 				})
-				this.setDefaultRecurrenceByParts({
+				this._setDefaultRecurrenceByParts({
 					recurrenceRule,
 					frequency,
 				})
@@ -1634,7 +1634,7 @@ export default defineStore('calendarObjectInstance', {
 		 * @param {object} data.recurrenceRule The recurrenceRule object to modify
 		 * @param {string} data.frequency The new frequency to set
 		 */
-		setDefaultRecurrenceByParts({
+		_setDefaultRecurrenceByParts({
 			recurrenceRule,
 			frequency,
 		}) {
@@ -1719,7 +1719,7 @@ export default defineStore('calendarObjectInstance', {
 			recurrenceRule,
 		}) {
 			this._resetRecurrenceByParts({ recurrenceRule })
-			this.setDefaultRecurrenceByPartsForYearlyBySetPosition({
+			this._setDefaultRecurrenceByPartsForYearlyBySetPosition({
 				recurrenceRule,
 			})
 		},
@@ -1829,7 +1829,7 @@ export default defineStore('calendarObjectInstance', {
 
 				logger.debug(alarm.alarmComponent.toICALJs().toString())
 			}
-			this.updateAlarmAllDayParts({ alarm })
+			this._updateAlarmAllDayParts({ alarm })
 		},
 
 		changeAlarmUnitTimed({
@@ -1845,7 +1845,7 @@ export default defineStore('calendarObjectInstance', {
 
 				logger.debug(alarm.alarmComponent.toICALJs().toString())
 			}
-			this.updateAlarmAllDayParts({ alarm })
+			this._updateAlarmAllDayParts({ alarm })
 		},
 
 		changeAlarmAmountAllDay({
@@ -1867,7 +1867,7 @@ export default defineStore('calendarObjectInstance', {
 				logger.debug(alarm.alarmComponent.toICALJs().toString())
 			}
 
-			this.updateAlarmTimedParts({ alarm })
+			this._updateAlarmTimedParts({ alarm })
 		},
 
 		changeAlarmUnitAllDay({
@@ -1889,7 +1889,7 @@ export default defineStore('calendarObjectInstance', {
 				logger.debug(alarm.alarmComponent.toICALJs().toString())
 			}
 
-			this.updateAlarmTimedParts({ alarm })
+			this._updateAlarmTimedParts({ alarm })
 		},
 
 		changeAlarmHoursMinutesAllDay({
@@ -1913,7 +1913,7 @@ export default defineStore('calendarObjectInstance', {
 				logger.debug(alarm.alarmComponent.toICALJs().toString())
 			}
 
-			this.updateAlarmTimedParts({ alarm })
+			this._updateAlarmTimedParts({ alarm })
 		},
 
 		changeAlarmFromRelativeToAbsolute({
@@ -1958,8 +1958,8 @@ export default defineStore('calendarObjectInstance', {
 				alarm.relativeTrigger = duration.totalSeconds
 			}
 
-			this.updateAlarmAllDayParts({ alarm })
-			this.updateAlarmTimedParts({ alarm })
+			this._updateAlarmAllDayParts({ alarm })
+			this._updateAlarmTimedParts({ alarm })
 
 			alarm.absoluteDate = null
 			alarm.absoluteTimezoneId = null
@@ -1967,7 +1967,7 @@ export default defineStore('calendarObjectInstance', {
 
 		toggleAllDay() {
 			const settingsStore = useSettingsStore()
-			this.toggleAllDayMutation()
+			this._toggleAllDayMutation()
 
 			if (!this.calendarObjectInstance.isAllDay) {
 				if (this.calendarObjectInstance.startTimezoneId === 'floating') {
@@ -1996,7 +1996,7 @@ export default defineStore('calendarObjectInstance', {
 			const endDate = new Date(end * 1000)
 
 			if (this.calendarObjectInstance.isAllDay !== isAllDay) {
-				this.toggleAllDayMutation()
+				this._toggleAllDayMutation()
 			}
 
 			this.changeStartTimezone({
@@ -2006,18 +2006,18 @@ export default defineStore('calendarObjectInstance', {
 				endTimezone: timezoneId,
 			})
 
-			this.changeStartDateMutation({
+			this._changeStartDateMutation({
 				startDate,
 			})
 
 			if (isAllDay) {
 				// The full-calendar end date is exclusive, but the end-date
 				// that changeEndDate expects is inclusive, so we have to deduct one day.
-				this.changeEndDateMutation({
+				this._changeEndDateMutation({
 					endDate: new Date(endDate.getTime() - 24 * 60 * 60 * 1000),
 				})
 			} else {
-				this.changeEndDateMutation({
+				this._changeEndDateMutation({
 					endDate,
 				})
 			}

--- a/src/store/calendarObjectInstance.js
+++ b/src/store/calendarObjectInstance.js
@@ -1164,45 +1164,6 @@ export default defineStore('calendarObjectInstance', {
 		},
 
 		/**
-		 * @deprecated
-		 * @param {object} data The destructuring object
-		 * @param {object} data.sharedData The shared file data to attach
-		 */
-		addAttachmentBySharedData({
-			sharedData,
-		}) {
-			const attachment = AttachmentProperty.fromLink(sharedData.url)
-			const fileName = sharedData.fileName
-
-			// hot-fix needed temporary, because calendar-js has no fileName get-setter
-			const parameterFileName = new Parameter('FILENAME', fileName)
-			// custom has-preview parameter from dav file
-			const xNcHasPreview = new Parameter('X-NC-HAS-PREVIEW', sharedData['has-preview'].toString())
-			// custom file id parameter from dav file
-			const xNcFileId = new Parameter('X-NC-FILE-ID', sharedData.fileid.toString())
-			// custom share-types parameter from dav file
-			const xNcSharedTypes = new Parameter('X-NC-SHARED-TYPES', sharedData['share-types']['share-type']
-				? sharedData['share-types']['share-type'].join(',')
-				: '')
-			attachment.setParameter(parameterFileName)
-			attachment.setParameter(xNcFileId)
-			attachment.setParameter(xNcHasPreview)
-			attachment.setParameter(xNcSharedTypes)
-			attachment.isNew = true
-			attachment.shareTypes = sharedData['share-types']['share-type']
-				? sharedData['share-types']['share-type'].join(',')
-				: ''
-			attachment.fileName = fileName
-			attachment.xNcFileId = sharedData.fileid
-			attachment.xNcHasPreview = sharedData['has-preview']
-			attachment.formatType = sharedData.getcontenttype
-			attachment.uri = sharedData.url ? sharedData.url : generateUrl(`/f/${sharedData.fileid}`)
-
-			this.calendarObjectInstance.eventComponent.addProperty(attachment)
-			this.calendarObjectInstance.attachments.push(attachment)
-		},
-
-		/**
 		 *
 		 * @param {object} data The destructuring object
 		 * @param {object} data.sharedData The shared file data to attach

--- a/src/store/calendarObjectInstance.js
+++ b/src/store/calendarObjectInstance.js
@@ -49,7 +49,6 @@ export default defineStore('calendarObjectInstance', {
 				objectId: null,
 				recurrenceId: null,
 			},
-			emptyCalendarObjectInstance: null,
 		}
 	},
 	actions: {
@@ -1445,8 +1444,6 @@ export default defineStore('calendarObjectInstance', {
 			})
 
 			calendarObjectInstance.eventComponent.undirtify()
-
-			this.emptyCalendarObjectInstance = { ...calendarObjectInstance }
 
 			return {
 				calendarObject,

--- a/src/store/calendarObjectInstance.js
+++ b/src/store/calendarObjectInstance.js
@@ -35,6 +35,10 @@ import {
 import logger from '@/utils/logger.js'
 import { getBySetPositionAndBySetFromDate, getWeekDayFromDate } from '@/utils/recurrence.js'
 
+// XXX "_" is used for marking actions and state.
+// A better way would be to use helper functions not exposed in `actions`.
+// "_" is still used because it maked refactoring easier to do and to understand.
+
 export default defineStore('calendarObjectInstance', {
 	state: () => {
 		return {
@@ -58,7 +62,7 @@ export default defineStore('calendarObjectInstance', {
 		 * @param {string} data.objectId The objectId of the calendar-object
 		 * @param {number} data.recurrenceId The recurrence-id of the calendar-object-instance
 		 */
-		setCalendarObjectInstanceForExistingEvent({
+		_setCalendarObjectInstanceForExistingEvent({
 			calendarObject,
 			calendarObjectInstance,
 			objectId,
@@ -82,7 +86,7 @@ export default defineStore('calendarObjectInstance', {
 		 * @param {object} data.calendarObject The calendar-object currently being created
 		 * @param {object} data.calendarObjectInstance The calendar-object-instance currently being crated
 		 */
-		setCalendarObjectInstanceForNewEvent({
+		_setCalendarObjectInstanceForNewEvent({
 			calendarObject,
 			calendarObjectInstance,
 		}) {
@@ -168,7 +172,7 @@ export default defineStore('calendarObjectInstance', {
 		 * @param {object} data.calendarObjectInstance The calendarObjectInstance object
 		 * @param {string} data.startTimezone New timezone to set for start
 		 */
-		changeStartTimezoneMutation({
+		_changeStartTimezoneMutation({
 			calendarObjectInstance,
 			startTimezone,
 		}) {
@@ -248,7 +252,7 @@ export default defineStore('calendarObjectInstance', {
 		 * @param {object} data.calendarObjectInstance The calendarObjectInstance object
 		 * @param {string} data.endTimezone New timezone to set for end
 		 */
-		changeEndTimezoneMutation({
+		_changeEndTimezoneMutation({
 			calendarObjectInstance,
 			endTimezone,
 		}) {
@@ -293,7 +297,7 @@ export default defineStore('calendarObjectInstance', {
 		 * @param {object} data The destructuring object
 		 * @param {object} data.calendarObjectInstance The calendarObjectInstance object
 		 */
-		changeTimeToDefaultForTimedEvents({ calendarObjectInstance }) {
+		_changeTimeToDefaultForTimedEvents({ calendarObjectInstance }) {
 			const startDate = calendarObjectInstance.eventComponent.startDate
 			const endDate = calendarObjectInstance.eventComponent.endDate
 			if (startDate.hour === 0 && startDate.minute === 0 && endDate.hour === 0 && endDate.minute === 0) {
@@ -655,7 +659,7 @@ export default defineStore('calendarObjectInstance', {
 		 * @param {object} data.recurrenceRule The recurrenceRule object to modify
 		 * @param {string} data.frequency The new frequency to set
 		 */
-		changeRecurrenceFrequencyMutation({
+		_changeRecurrenceFrequencyMutation({
 			recurrenceRule,
 			frequency,
 		}) {
@@ -736,7 +740,7 @@ export default defineStore('calendarObjectInstance', {
 		 * @param {object} data The destructuring object
 		 * @param {object} data.recurrenceRule The recurrenceRule object to modify
 		 */
-		resetRecurrenceByParts({ recurrenceRule }) {
+		_resetRecurrenceByParts({ recurrenceRule }) {
 			if (recurrenceRule.recurrenceRuleValue) {
 				const parts = [
 					'BYSECOND',
@@ -776,7 +780,7 @@ export default defineStore('calendarObjectInstance', {
 		 * @param {object} data.calendarObjectInstance The calendarObjectInstance object
 		 * @param {object} data.recurrenceRule The recurrenceRule object to modify
 		 */
-		setDefaultRecurrenceByPartsForMonthlyBySetPosition({
+		_setDefaultRecurrenceByPartsForMonthlyBySetPosition({
 			calendarObjectInstance,
 			recurrenceRule,
 		}) {
@@ -1369,7 +1373,7 @@ export default defineStore('calendarObjectInstance', {
 			}
 
 			const calendarObjectInstance = mapEventComponentToEventObject(eventComponent)
-			this.setCalendarObjectInstanceForExistingEvent({
+			this._setCalendarObjectInstanceForExistingEvent({
 				calendarObject,
 				calendarObjectInstance,
 				objectId,
@@ -1435,7 +1439,7 @@ export default defineStore('calendarObjectInstance', {
 
 			calendarObjectInstance.eventComponent.status = status
 
-			this.setCalendarObjectInstanceForNewEvent({
+			this._setCalendarObjectInstanceForNewEvent({
 				calendarObject,
 				calendarObjectInstance,
 			})
@@ -1475,7 +1479,7 @@ export default defineStore('calendarObjectInstance', {
 				isAllDay,
 				timezoneId,
 			})
-			this.setCalendarObjectInstanceForNewEvent({
+			this._setCalendarObjectInstanceForNewEvent({
 				calendarObject: this.calendarObject,
 				calendarObjectInstance: this.calendarObjectInstance,
 			})
@@ -1560,7 +1564,7 @@ export default defineStore('calendarObjectInstance', {
 			copyCalendarObjectInstanceIntoEventComponent(oldCalendarObjectInstance, eventComponent)
 			const calendarObjectInstance = mapEventComponentToEventObject(eventComponent)
 
-			await this.setCalendarObjectInstanceForNewEvent({
+			this._setCalendarObjectInstanceForNewEvent({
 				calendarObject,
 				calendarObjectInstance,
 			})
@@ -1634,7 +1638,7 @@ export default defineStore('calendarObjectInstance', {
 			calendarObjectInstance,
 			startTimezone,
 		}) {
-			this.changeStartTimezoneMutation({
+			this._changeStartTimezoneMutation({
 				calendarObjectInstance,
 				startTimezone,
 			})
@@ -1680,7 +1684,7 @@ export default defineStore('calendarObjectInstance', {
 			calendarObjectInstance,
 			endTimezone,
 		}) {
-			this.changeEndTimezoneMutation({
+			this._changeEndTimezoneMutation({
 				calendarObjectInstance,
 				endTimezone,
 			})
@@ -1714,8 +1718,8 @@ export default defineStore('calendarObjectInstance', {
 				calendarObjectInstance.eventComponent.addProperty(recurrenceProperty)
 				calendarObjectInstance.recurrenceRule.recurrenceRuleValue = recurrenceValue
 
-				this.resetRecurrenceByParts({ recurrenceRule })
-				this.changeRecurrenceFrequencyMutation({
+				this._resetRecurrenceByParts({ recurrenceRule })
+				this._changeRecurrenceFrequencyMutation({
 					calendarObjectInstance,
 					recurrenceRule: calendarObjectInstance.recurrenceRule,
 					frequency,
@@ -1747,8 +1751,8 @@ export default defineStore('calendarObjectInstance', {
 				}
 			} else {
 				// Change frequency of existing recurrence-rule
-				this.resetRecurrenceByParts({ recurrenceRule })
-				this.changeRecurrenceFrequencyMutation({
+				this._resetRecurrenceByParts({ recurrenceRule })
+				this._changeRecurrenceFrequencyMutation({
 					calendarObjectInstance,
 					recurrenceRule: calendarObjectInstance.recurrenceRule,
 					frequency,
@@ -1821,8 +1825,8 @@ export default defineStore('calendarObjectInstance', {
 			recurrenceRule,
 		}) {
 			logger.debug('changeMonthlyRecurrenceFromByDayToBySetPosition')
-			this.resetRecurrenceByParts({ recurrenceRule })
-			this.setDefaultRecurrenceByPartsForMonthlyBySetPosition({
+			this._resetRecurrenceByParts({ recurrenceRule })
+			this._setDefaultRecurrenceByPartsForMonthlyBySetPosition({
 				calendarObjectInstance,
 				recurrenceRule,
 			})
@@ -1839,7 +1843,7 @@ export default defineStore('calendarObjectInstance', {
 			recurrenceRule,
 		}) {
 			logger.debug('changeMonthlyRecurrenceFromBySetPositionToByDay')
-			this.resetRecurrenceByParts({ recurrenceRule })
+			this._resetRecurrenceByParts({ recurrenceRule })
 
 			if (recurrenceRule.recurrenceRuleValue) {
 				const byMonthDay = calendarObjectInstance.startDate.getDate()
@@ -1860,7 +1864,7 @@ export default defineStore('calendarObjectInstance', {
 			calendarObjectInstance,
 			recurrenceRule,
 		}) {
-			this.resetRecurrenceByParts({ recurrenceRule })
+			this._resetRecurrenceByParts({ recurrenceRule })
 			this.setDefaultRecurrenceByPartsForYearlyBySetPosition({
 				calendarObjectInstance,
 				recurrenceRule,
@@ -1877,7 +1881,7 @@ export default defineStore('calendarObjectInstance', {
 			calendarObjectInstance,
 			recurrenceRule,
 		}) {
-			this.resetRecurrenceByParts({ recurrenceRule })
+			this._resetRecurrenceByParts({ recurrenceRule })
 
 			if (recurrenceRule.recurrenceRuleValue) {
 				const byMonth = calendarObjectInstance.startDate.getMonth() + 1 // Javascript months are zero-based
@@ -2122,13 +2126,13 @@ export default defineStore('calendarObjectInstance', {
 			if (!calendarObjectInstance.isAllDay) {
 				if (calendarObjectInstance.startTimezoneId === 'floating') {
 					const startTimezone = settingsStore.getResolvedTimezone
-					this.changeStartTimezoneMutation({
+					this._changeStartTimezoneMutation({
 						calendarObjectInstance,
 						startTimezone,
 					})
 				}
 
-				this.changeTimeToDefaultForTimedEvents({ calendarObjectInstance })
+				this._changeTimeToDefaultForTimedEvents({ calendarObjectInstance })
 			}
 		},
 	},

--- a/src/store/calendarObjectInstance.js
+++ b/src/store/calendarObjectInstance.js
@@ -1451,15 +1451,13 @@ export default defineStore('calendarObjectInstance', {
 		 * @param {string} data.timezoneId The timezoneId of the new event
 		 * @return {Promise<{calendarObject: object, calendarObjectInstance: object}>}
 		 */
-		async updateCalendarObjectInstanceForNewEvent({
+		updateCalendarObjectInstanceForNewEvent({
 			isAllDay,
 			start,
 			end,
 			timezoneId,
 		}) {
-			const calendarObjectsStore = useCalendarObjectsStore()
-
-			await calendarObjectsStore.updateTimeOfNewEvent({
+			this._updateTimeOfNewEvent({
 				calendarObjectInstance: this.calendarObjectInstance,
 				start,
 				end,
@@ -2116,6 +2114,57 @@ export default defineStore('calendarObjectInstance', {
 				}
 
 				this._changeTimeToDefaultForTimedEvents()
+			}
+		},
+
+		/**
+		 * Updates the time of the new calendar object
+		 *
+		 * @param {object} data destructuring object
+		 * @param {number} data.start Timestamp for start of new event
+		 * @param {number} data.end Timestamp for end of new event
+		 * @param {string} data.timezoneId asd
+		 * @param {boolean} data.isAllDay foo
+		 */
+		_updateTimeOfNewEvent({ start, end, timezoneId, isAllDay }) {
+			const isDirty = this.calendarObjectInstance.eventComponent.isDirty()
+			const startDate = new Date(start * 1000)
+			const endDate = new Date(end * 1000)
+
+			if (this.calendarObjectInstance.isAllDay !== isAllDay) {
+				this.toggleAllDayMutation({ calendarObjectInstance: this.calendarObjectInstance })
+			}
+
+			this.changeStartTimezone({
+				calendarObjectInstance: this.calendarObjectInstance,
+				startTimezone: timezoneId,
+			})
+			this.changeEndTimezone({
+				calendarObjectInstance: this.calendarObjectInstance,
+				endTimezone: timezoneId,
+			})
+
+			this.changeStartDateMutation({
+				calendarObjectInstance: this.calendarObjectInstance,
+				startDate,
+			})
+
+			if (isAllDay) {
+				// The full-calendar end date is exclusive, but the end-date
+				// that changeEndDate expects is inclusive, so we have to deduct one day.
+				this.changeEndDateMutation({
+					calendarObjectInstance: this.calendarObjectInstance,
+					endDate: new Date(endDate.getTime() - 24 * 60 * 60 * 1000),
+				})
+			} else {
+				this.changeEndDateMutation({
+					calendarObjectInstance: this.calendarObjectInstance,
+					endDate,
+				})
+			}
+
+			if (!isDirty) {
+				this.eventComponent.undirtify()
 			}
 		},
 	},

--- a/src/store/calendarObjectInstance.js
+++ b/src/store/calendarObjectInstance.js
@@ -42,10 +42,10 @@ import { getBySetPositionAndBySetFromDate, getWeekDayFromDate } from '@/utils/re
 export default defineStore('calendarObjectInstance', {
 	state: () => {
 		return {
-			isNew: null,
+			_isNew: null,
 			calendarObject: null,
 			calendarObjectInstance: null,
-			existingEvent: {
+			_existingEvent: {
 				objectId: null,
 				recurrenceId: null,
 			},
@@ -68,11 +68,11 @@ export default defineStore('calendarObjectInstance', {
 			objectId,
 			recurrenceId,
 		}) {
-			this.isNew = false
+			this._isNew = false
 			this.calendarObject = calendarObject
 			this.calendarObjectInstance = calendarObjectInstance
-			this.existingEvent.objectId = objectId
-			this.existingEvent.recurrenceId = recurrenceId
+			this._existingEvent.objectId = objectId
+			this._existingEvent.recurrenceId = recurrenceId
 
 			if (this.calendarObjectInstance.eventComponent) {
 				this.calendarObjectInstance.eventComponent = markRaw(this.calendarObjectInstance.eventComponent)
@@ -90,11 +90,11 @@ export default defineStore('calendarObjectInstance', {
 			calendarObject,
 			calendarObjectInstance,
 		}) {
-			this.isNew = true
+			this._isNew = true
 			this.calendarObject = calendarObject
 			this.calendarObjectInstance = calendarObjectInstance
-			this.existingEvent.objectId = null
-			this.existingEvent.recurrenceId = null
+			this._existingEvent.objectId = null
+			this._existingEvent.recurrenceId = null
 
 			if (this.calendarObjectInstance.eventComponent) {
 				this.calendarObjectInstance.eventComponent = markRaw(this.calendarObjectInstance.eventComponent)
@@ -102,11 +102,11 @@ export default defineStore('calendarObjectInstance', {
 		},
 
 		resetCalendarObjectInstanceObjectIdAndRecurrenceId() {
-			this.isNew = false
+			this._isNew = false
 			this.calendarObject = null
 			this.calendarObjectInstance = null
-			this.existingEvent.objectId = null
-			this.existingEvent.recurrenceId = null
+			this._existingEvent.objectId = null
+			this._existingEvent.recurrenceId = null
 		},
 
 		/**
@@ -1358,7 +1358,7 @@ export default defineStore('calendarObjectInstance', {
 			recurrenceId,
 		}) {
 			const calendarsStore = useCalendarsStore()
-			if (this.existingEvent.objectId === objectId && this.existingEvent.recurrenceId === recurrenceId) {
+			if (this._existingEvent.objectId === objectId && this._existingEvent.recurrenceId === recurrenceId) {
 				return Promise.resolve({
 					calendarObject: this.calendarObject,
 					calendarObjectInstance: this.calendarObjectInstance,
@@ -1404,7 +1404,7 @@ export default defineStore('calendarObjectInstance', {
 		}) {
 			const calendarObjectsStore = useCalendarObjectsStore()
 
-			if (this.isNew === true) {
+			if (this._isNew === true) {
 				return Promise.resolve({
 					calendarObject: this.calendarObject,
 					calendarObjectInstance: this.calendarObjectInstance,

--- a/src/store/calendarObjectInstance.js
+++ b/src/store/calendarObjectInstance.js
@@ -123,65 +123,61 @@ export default defineStore('calendarObjectInstance', {
 		 * Change the event's start
 		 *
 		 * @param {object} data The destructuring object
-		 * @param {object} data.calendarObjectInstance The calendarObjectInstance object
 		 * @param {Date} data.startDate New start date to set
 		 */
 		changeStartDateMutation({
-			calendarObjectInstance,
 			startDate,
 		}) {
-			calendarObjectInstance.eventComponent.startDate.year = startDate.getFullYear()
-			calendarObjectInstance.eventComponent.startDate.month = startDate.getMonth() + 1
-			calendarObjectInstance.eventComponent.startDate.day = startDate.getDate()
-			calendarObjectInstance.eventComponent.startDate.hour = startDate.getHours()
-			calendarObjectInstance.eventComponent.startDate.minute = startDate.getMinutes()
-			calendarObjectInstance.eventComponent.startDate.second = 0
+			this.calendarObjectInstance.eventComponent.startDate.year = startDate.getFullYear()
+			this.calendarObjectInstance.eventComponent.startDate.month = startDate.getMonth() + 1
+			this.calendarObjectInstance.eventComponent.startDate.day = startDate.getDate()
+			this.calendarObjectInstance.eventComponent.startDate.hour = startDate.getHours()
+			this.calendarObjectInstance.eventComponent.startDate.minute = startDate.getMinutes()
+			this.calendarObjectInstance.eventComponent.startDate.second = 0
 
-			const isAllDay = calendarObjectInstance.eventComponent.isAllDay()
-			const endDateObj = calendarObjectInstance.eventComponent.endDate.clone()
-			const startDateObj = calendarObjectInstance.eventComponent.startDate.clone()
+			const isAllDay = this.calendarObjectInstance.eventComponent.isAllDay()
+			const endDateObj = this.calendarObjectInstance.eventComponent.endDate.clone()
+			const startDateObj = this.calendarObjectInstance.eventComponent.startDate.clone()
 
 			if (isAllDay) {
 				endDateObj.addDuration(DurationValue.fromSeconds(-1 * 60 * 60 * 24))
 
 				if (endDateObj.compare(startDateObj) === -1) {
 					const timezone = getTimezoneManager().getTimezoneForId(endDateObj.timezoneId)
-					calendarObjectInstance.eventComponent.endDate
-						= calendarObjectInstance.eventComponent.startDate.getInTimezone(timezone)
-					calendarObjectInstance.endDate = getDateFromDateTimeValue(calendarObjectInstance.eventComponent.endDate)
-					calendarObjectInstance.eventComponent.endDate.addDuration(DurationValue.fromSeconds(60 * 60 * 24))
+					this.calendarObjectInstance.eventComponent.endDate
+						= this.calendarObjectInstance.eventComponent.startDate.getInTimezone(timezone)
+					this.calendarObjectInstance.endDate = getDateFromDateTimeValue(this.calendarObjectInstance.eventComponent.endDate)
+					this.calendarObjectInstance.eventComponent.endDate.addDuration(DurationValue.fromSeconds(60 * 60 * 24))
 				}
 			} else {
 				if (endDateObj.compare(startDateObj) === -1) {
 					const timezone = getTimezoneManager().getTimezoneForId(endDateObj.timezoneId)
-					calendarObjectInstance.eventComponent.endDate
-						= calendarObjectInstance.eventComponent.startDate.getInTimezone(timezone)
-					calendarObjectInstance.endDate = getDateFromDateTimeValue(calendarObjectInstance.eventComponent.endDate)
+					this.calendarObjectInstance.eventComponent.endDate
+						= this.calendarObjectInstance.eventComponent.startDate.getInTimezone(timezone)
+					this.calendarObjectInstance.endDate = getDateFromDateTimeValue(this.calendarObjectInstance.eventComponent.endDate)
 				}
 			}
 
-			calendarObjectInstance.startDate = startDate
+			this.calendarObjectInstance.startDate = startDate
 		},
 
 		/**
 		 * Change the timezone of the event's start
 		 *
 		 * @param {object} data The destructuring object
-		 * @param {object} data.calendarObjectInstance The calendarObjectInstance object
 		 * @param {string} data.startTimezone New timezone to set for start
 		 */
 		_changeStartTimezoneMutation({
-			calendarObjectInstance,
 			startTimezone,
 		}) {
 			const timezone = getTimezoneManager().getTimezoneForId(startTimezone)
-			calendarObjectInstance.eventComponent.startDate.replaceTimezone(timezone)
-			calendarObjectInstance.startTimezoneId = startTimezone
+			this.calendarObjectInstance.eventComponent.startDate.replaceTimezone(timezone)
+			this.calendarObjectInstance.startTimezoneId = startTimezone
 
 			// Either both are floating or both have a timezone, but it can't be mixed
-			if (startTimezone === 'floating' || calendarObjectInstance.endTimezoneId === 'floating') {
-				calendarObjectInstance.eventComponent.endDate.replaceTimezone(timezone)
-				calendarObjectInstance.endTimezoneId = startTimezone
+			if (startTimezone === 'floating' || this.calendarObjectInstance.endTimezoneId === 'floating') {
+				this.calendarObjectInstance.eventComponent.endDate.replaceTimezone(timezone)
+				this.calendarObjectInstance.endTimezoneId = startTimezone
 			}
 		},
 
@@ -189,39 +185,37 @@ export default defineStore('calendarObjectInstance', {
 		 * Change the event's end
 		 *
 		 * @param {object} data The destructuring object
-		 * @param {object} data.calendarObjectInstance The calendarObjectInstance object
 		 * @param {Date} data.endDate New end date to set
 		 */
 		changeEndDateMutation({
-			calendarObjectInstance,
 			endDate,
 		}) {
 			// If the event is using DURATION, endDate is dynamically generated.
 			// In order to alter it, we need to explicitly set DTEND
-			const endDateObject = calendarObjectInstance.eventComponent.endDate
-			calendarObjectInstance.eventComponent.endDate = endDateObject
+			const endDateObject = this.calendarObjectInstance.eventComponent.endDate
+			this.calendarObjectInstance.eventComponent.endDate = endDateObject
 
-			calendarObjectInstance.eventComponent.endDate.year = endDate.getFullYear()
-			calendarObjectInstance.eventComponent.endDate.month = endDate.getMonth() + 1
-			calendarObjectInstance.eventComponent.endDate.day = endDate.getDate()
-			calendarObjectInstance.eventComponent.endDate.hour = endDate.getHours()
-			calendarObjectInstance.eventComponent.endDate.minute = endDate.getMinutes()
-			calendarObjectInstance.eventComponent.endDate.second = 0
+			this.calendarObjectInstance.eventComponent.endDate.year = endDate.getFullYear()
+			this.calendarObjectInstance.eventComponent.endDate.month = endDate.getMonth() + 1
+			this.calendarObjectInstance.eventComponent.endDate.day = endDate.getDate()
+			this.calendarObjectInstance.eventComponent.endDate.hour = endDate.getHours()
+			this.calendarObjectInstance.eventComponent.endDate.minute = endDate.getMinutes()
+			this.calendarObjectInstance.eventComponent.endDate.second = 0
 
-			const isAllDay = calendarObjectInstance.eventComponent.isAllDay()
-			const endDateObj = calendarObjectInstance.eventComponent.endDate.clone()
-			const startDateObj = calendarObjectInstance.eventComponent.startDate.clone()
+			const isAllDay = this.calendarObjectInstance.eventComponent.isAllDay()
+			const endDateObj = this.calendarObjectInstance.eventComponent.endDate.clone()
+			const startDateObj = this.calendarObjectInstance.eventComponent.startDate.clone()
 
 			if (isAllDay) {
 				if (endDateObj.compare(startDateObj) === -1) {
 					const timezone = getTimezoneManager().getTimezoneForId(startDateObj.timezoneId)
-					calendarObjectInstance.eventComponent.startDate
-						= calendarObjectInstance.eventComponent.endDate.getInTimezone(timezone)
-					calendarObjectInstance.startDate = getDateFromDateTimeValue(calendarObjectInstance.eventComponent.startDate)
+					this.calendarObjectInstance.eventComponent.startDate
+						= this.calendarObjectInstance.eventComponent.endDate.getInTimezone(timezone)
+					this.calendarObjectInstance.startDate = getDateFromDateTimeValue(this.calendarObjectInstance.eventComponent.startDate)
 				}
 
 				// endDate is inclusive, but DTEND needs to be exclusive, so always add one day
-				calendarObjectInstance.eventComponent.endDate.addDuration(DurationValue.fromSeconds(60 * 60 * 24))
+				this.calendarObjectInstance.eventComponent.endDate.addDuration(DurationValue.fromSeconds(60 * 60 * 24))
 			} else {
 				// Is end before start?
 				if (endDateObj.compare(startDateObj) === -1) {
@@ -229,63 +223,58 @@ export default defineStore('calendarObjectInstance', {
 					endDateObj.addDuration(DurationValue.fromSeconds(60 * 60 * 24))
 					if (endDateObj.compare(startDateObj) === -1) {
 						const timezone = getTimezoneManager().getTimezoneForId(startDateObj.timezoneId)
-						calendarObjectInstance.eventComponent.startDate
-							= calendarObjectInstance.eventComponent.endDate.getInTimezone(timezone)
-						calendarObjectInstance.startDate = getDateFromDateTimeValue(calendarObjectInstance.eventComponent.startDate)
+						this.calendarObjectInstance.eventComponent.startDate
+							= this.calendarObjectInstance.eventComponent.endDate.getInTimezone(timezone)
+						this.calendarObjectInstance.startDate = getDateFromDateTimeValue(this.calendarObjectInstance.eventComponent.startDate)
 					} else {
 						// add one day to endDate if the endDate is before the startDate which allows to easily create events that reach over or to 0:00
-						calendarObjectInstance.eventComponent.endDate.addDuration(DurationValue.fromSeconds(60 * 60 * 24))
+						this.calendarObjectInstance.eventComponent.endDate.addDuration(DurationValue.fromSeconds(60 * 60 * 24))
 						endDate = new Date(endDate.getTime() + 24 * 60 * 60 * 1000)
 					}
 				}
 			}
 
-			calendarObjectInstance.endDate = endDate
+			this.calendarObjectInstance.endDate = endDate
 		},
 
 		/**
 		 * Change the timezone of the event's end
 		 *
 		 * @param {object} data The destructuring object
-		 * @param {object} data.calendarObjectInstance The calendarObjectInstance object
 		 * @param {string} data.endTimezone New timezone to set for end
 		 */
 		_changeEndTimezoneMutation({
-			calendarObjectInstance,
 			endTimezone,
 		}) {
 			const timezone = getTimezoneManager().getTimezoneForId(endTimezone)
-			calendarObjectInstance.eventComponent.endDate.replaceTimezone(timezone)
-			calendarObjectInstance.endTimezoneId = endTimezone
+			this.calendarObjectInstance.eventComponent.endDate.replaceTimezone(timezone)
+			this.calendarObjectInstance.endTimezoneId = endTimezone
 
 			// Either both are floating or both have a timezone, but it can't be mixed
-			if (endTimezone === 'floating' || calendarObjectInstance.startTimezoneId === 'floating') {
-				calendarObjectInstance.eventComponent.startDate.replaceTimezone(timezone)
-				calendarObjectInstance.startTimezoneId = endTimezone
+			if (endTimezone === 'floating' || this.calendarObjectInstance.startTimezoneId === 'floating') {
+				this.calendarObjectInstance.eventComponent.startDate.replaceTimezone(timezone)
+				this.calendarObjectInstance.startTimezoneId = endTimezone
 			}
 		},
 
 		/**
 		 * Switch from a timed event to allday or vice versa
-		 *
-		 * @param {object} data The destructuring object
-		 * @param {object} data.calendarObjectInstance The calendarObjectInstance object
 		 */
-		toggleAllDayMutation({ calendarObjectInstance }) {
-			if (!calendarObjectInstance.eventComponent.canModifyAllDay() && this.calendarObject.existsOnServer) {
+		toggleAllDayMutation() {
+			if (!this.calendarObjectInstance.eventComponent.canModifyAllDay() && this.calendarObject.existsOnServer) {
 				return
 			}
 
-			const isAllDay = calendarObjectInstance.eventComponent.isAllDay()
-			calendarObjectInstance.eventComponent.startDate.isDate = !isAllDay
-			calendarObjectInstance.eventComponent.endDate.isDate = !isAllDay
-			calendarObjectInstance.isAllDay = calendarObjectInstance.eventComponent.isAllDay()
+			const isAllDay = this.calendarObjectInstance.eventComponent.isAllDay()
+			this.calendarObjectInstance.eventComponent.startDate.isDate = !isAllDay
+			this.calendarObjectInstance.eventComponent.endDate.isDate = !isAllDay
+			this.calendarObjectInstance.isAllDay = this.calendarObjectInstance.eventComponent.isAllDay()
 
 			// isAllDay = old value
 			if (isAllDay) {
-				calendarObjectInstance.eventComponent.endDate.addDuration(DurationValue.fromSeconds(-1 * 60 * 60 * 24))
+				this.calendarObjectInstance.eventComponent.endDate.addDuration(DurationValue.fromSeconds(-1 * 60 * 60 * 24))
 			} else {
-				calendarObjectInstance.eventComponent.endDate.addDuration(DurationValue.fromSeconds(60 * 60 * 24))
+				this.calendarObjectInstance.eventComponent.endDate.addDuration(DurationValue.fromSeconds(60 * 60 * 24))
 			}
 		},
 
@@ -308,33 +297,29 @@ export default defineStore('calendarObjectInstance', {
 		 * Change the location of an event
 		 *
 		 * @param {object} data The destructuring object
-		 * @param {object} data.calendarObjectInstance The calendarObjectInstance object
 		 * @param {string} data.location New location to set
 		 */
 		changeLocation({
-			calendarObjectInstance,
 			location,
 		}) {
 			// Special case: delete Apple-specific location property to avoid inconsistencies
-			calendarObjectInstance.eventComponent.deleteAllProperties('X-APPLE-STRUCTURED-LOCATION')
+			this.calendarObjectInstance.eventComponent.deleteAllProperties('X-APPLE-STRUCTURED-LOCATION')
 
-			calendarObjectInstance.eventComponent.location = location
-			calendarObjectInstance.location = location
+			this.calendarObjectInstance.eventComponent.location = location
+			this.calendarObjectInstance.location = location
 		},
 
 		/**
 		 * Change the description of an event
 		 *
 		 * @param {object} data The destructuring object
-		 * @param {object} data.calendarObjectInstance The calendarObjectInstance object
 		 * @param {string} data.description New description to set
 		 */
 		changeDescription({
-			calendarObjectInstance,
 			description,
 		}) {
 			// To avoid inconsistencies (bug #3863), remove all parameters (e.g., ALTREP) upon modification
-			const descriptionProperty = calendarObjectInstance.eventComponent.getFirstProperty('Description')
+			const descriptionProperty = this.calendarObjectInstance.eventComponent.getFirstProperty('Description')
 			if (descriptionProperty) {
 				for (const parameter of descriptionProperty.getParametersIterator()) {
 					descriptionProperty.deleteParameter(parameter.name)
@@ -342,10 +327,10 @@ export default defineStore('calendarObjectInstance', {
 			}
 
 			// Delete custom description properties
-			calendarObjectInstance.eventComponent.deleteAllProperties('X-ALT-DESC')
+			this.calendarObjectInstance.eventComponent.deleteAllProperties('X-ALT-DESC')
 
-			calendarObjectInstance.eventComponent.description = description
-			calendarObjectInstance.description = description
+			this.calendarObjectInstance.eventComponent.description = description
+			this.calendarObjectInstance.description = description
 		},
 
 		/**
@@ -422,7 +407,6 @@ export default defineStore('calendarObjectInstance', {
 		 * Adds an attendee to the event and sets the organizer if not present already
 		 *
 		 * @param {object} data The destructuring object
-		 * @param {object} data.calendarObjectInstance The calendarObjectInstance object
 		 * @param {string} data.commonName Displayname of attendee
 		 * @param {string} data.uri Email address of attendee
 		 * @param {string} data.calendarUserType Calendar-user-type of attendee (INDIVIDUAL, GROUP, RESOURCE, ROOM)
@@ -435,7 +419,6 @@ export default defineStore('calendarObjectInstance', {
 		 * @param {string | Array} data.member Group membership(s)
 		 */
 		addAttendee({
-			calendarObjectInstance,
 			commonName,
 			uri,
 			calendarUserType = null,
@@ -471,8 +454,8 @@ export default defineStore('calendarObjectInstance', {
 			}
 
 			// TODO - use real addAttendeeFrom method
-			calendarObjectInstance.eventComponent.addProperty(attendee)
-			calendarObjectInstance.attendees.push({
+			this.calendarObjectInstance.eventComponent.addProperty(attendee)
+			this.calendarObjectInstance.attendees.push({
 				commonName,
 				participationStatus,
 				role,
@@ -481,9 +464,8 @@ export default defineStore('calendarObjectInstance', {
 				attendeeProperty: markRaw(attendee),
 			})
 
-			if (!calendarObjectInstance.organizer && organizer) {
+			if (!this.calendarObjectInstance.organizer && organizer) {
 				this.setOrganizer({
-					calendarObjectInstance,
 					commonName: organizer.displayname,
 					email: organizer.emailAddress,
 				})
@@ -494,14 +476,12 @@ export default defineStore('calendarObjectInstance', {
 		 * Removes an attendee from the event
 		 *
 		 * @param {object} data The destructuring object
-		 * @param {object} data.calendarObjectInstance The calendarObjectInstance object
 		 * @param {object} data.attendee The attendee object to remove
 		 */
 		removeAttendee({
-			calendarObjectInstance,
 			attendee,
 		}) {
-			calendarObjectInstance.eventComponent.removeAttendee(attendee.attendeeProperty)
+			this.calendarObjectInstance.eventComponent.removeAttendee(attendee.attendeeProperty)
 			// Also remove members if attendee is a group
 			if (attendee.attendeeProperty.userType === 'GROUP') {
 				attendee.members.forEach(function(member) {
@@ -516,23 +496,23 @@ export default defineStore('calendarObjectInstance', {
 							member.attendeeProperty.member.splice(removeIndex, 1)
 						}
 					} else {
-						calendarObjectInstance.eventComponent.removeAttendee(member.attendeeProperty)
-						const index = calendarObjectInstance.attendees.indexOf(member)
+						this.calendarObjectInstance.eventComponent.removeAttendee(member.attendeeProperty)
+						const index = this.calendarObjectInstance.attendees.indexOf(member)
 						if (index !== -1) {
-							calendarObjectInstance.attendees.splice(index, 1)
+							this.calendarObjectInstance.attendees.splice(index, 1)
 						}
 					}
 				})
 			}
 
-			const index = calendarObjectInstance.attendees.indexOf(attendee)
+			const index = this.calendarObjectInstance.attendees.indexOf(attendee)
 			if (index !== -1) {
-				calendarObjectInstance.attendees.splice(index, 1)
+				this.calendarObjectInstance.attendees.splice(index, 1)
 			}
 
-			if (calendarObjectInstance.attendees.length === 0) {
-				calendarObjectInstance.organizer = null
-				calendarObjectInstance.eventComponent.deleteAllProperties('ORGANIZER')
+			if (this.calendarObjectInstance.attendees.length === 0) {
+				this.calendarObjectInstance.organizer = null
+				this.calendarObjectInstance.eventComponent.deleteAllProperties('ORGANIZER')
 			}
 		},
 
@@ -582,16 +562,15 @@ export default defineStore('calendarObjectInstance', {
 		 * Set the event's organizer
 		 *
 		 * @param {object} data The destructuring object
-		 * @param {object} data.calendarObjectInstance The calendarObjectInstance object
 		 * @param {string=} data.commonName Displayname of organizer
 		 * @param {string} data.email Email-address of organizer
 		 */
-		setOrganizer({ calendarObjectInstance, commonName = null, email }) {
-			calendarObjectInstance.eventComponent.setOrganizerFromNameAndEMail(commonName, email)
-			calendarObjectInstance.organizer = {
+		setOrganizer({ commonName = null, email }) {
+			this.calendarObjectInstance.eventComponent.setOrganizerFromNameAndEMail(commonName, email)
+			this.calendarObjectInstance.organizer = {
 				commonName,
 				uri: email,
-				attendeeProperty: calendarObjectInstance.eventComponent.getFirstProperty('ORGANIZER'),
+				attendeeProperty: this.calendarObjectInstance.eventComponent.getFirstProperty('ORGANIZER'),
 			}
 		},
 
@@ -599,7 +578,6 @@ export default defineStore('calendarObjectInstance', {
 		 * Adds a category to the event
 		 *
 		 * @param {object} data The destructuring object
-		 * @param {object} data.calendarObjectInstance The calendarObjectInstance object
 		 * @param {string} data.category Category to add
 		 */
 		addCategory({ category }) {
@@ -684,18 +662,16 @@ export default defineStore('calendarObjectInstance', {
 		 * Change the until limit of the recurrence-rule
 		 *
 		 * @param {object} data The destructuring object
-		 * @param {object} data.calendarObjectInstance The calendarObjectInstance object
 		 * @param {object} data.recurrenceRule The recurrenceRule object to modify
 		 * @param {Date} data.until The new until to set
 		 */
 		changeRecurrenceUntil({
-			calendarObjectInstance,
 			recurrenceRule,
 			until,
 		}) {
 			if (recurrenceRule.recurrenceRuleValue) {
 				// RFC 5545, setion 3.3.10: until must be in UTC if the start time is timezone-aware
-				if (calendarObjectInstance.startTimezoneId !== 'floating') {
+				if (this.calendarObjectInstance.startTimezoneId !== 'floating') {
 					recurrenceRule.recurrenceRuleValue.until = DateTimeValue.fromJSDate(until, { zone: 'utc' })
 				} else {
 					recurrenceRule.recurrenceRuleValue.until = DateTimeValue.fromJSDate(until)
@@ -766,18 +742,16 @@ export default defineStore('calendarObjectInstance', {
 		/**
 		 *
 		 * @param {object} data The destructuring object
-		 * @param {object} data.calendarObjectInstance The calendarObjectInstance object
 		 * @param {object} data.recurrenceRule The recurrenceRule object to modify
 		 */
 		_setDefaultRecurrenceByPartsForMonthlyBySetPosition({
-			calendarObjectInstance,
 			recurrenceRule,
 		}) {
 			if (recurrenceRule.recurrenceRuleValue) {
 				const {
 					byDay,
 					bySetPosition,
-				} = getBySetPositionAndBySetFromDate(calendarObjectInstance.startDate)
+				} = getBySetPositionAndBySetFromDate(this.calendarObjectInstance.startDate)
 				recurrenceRule.recurrenceRuleValue.setComponent('BYDAY', [byDay])
 				recurrenceRule.recurrenceRuleValue.setComponent('BYSETPOS', [bySetPosition])
 
@@ -791,16 +765,14 @@ export default defineStore('calendarObjectInstance', {
 		/**
 		 *
 		 * @param {object} data The destructuring object
-		 * @param {object} data.calendarObjectInstance The calendarObjectInstance object
 		 * @param {object} data.recurrenceRule The recurrenceRule object to modify
 		 */
 		setDefaultRecurrenceByPartsForYearlyBySetPosition({
-			calendarObjectInstance,
 			recurrenceRule,
 		}) {
 			if (recurrenceRule.recurrenceRuleValue) {
-				const byMonth = calendarObjectInstance.startDate.getMonth() + 1
-				const { byDay, bySetPosition } = getBySetPositionAndBySetFromDate(calendarObjectInstance.startDate)
+				const byMonth = this.calendarObjectInstance.startDate.getMonth() + 1
+				const { byDay, bySetPosition } = getBySetPositionAndBySetFromDate(this.calendarObjectInstance.startDate)
 
 				recurrenceRule.recurrenceRuleValue.setComponent('BYMONTH', [byMonth])
 				recurrenceRule.recurrenceRuleValue.setComponent('BYDAY', [byDay])
@@ -1133,19 +1105,17 @@ export default defineStore('calendarObjectInstance', {
 		/**
 		 *
 		 * @param {object} data The destructuring object
-		 * @param {object} data.calendarObjectInstance The calendarObjectInstance object
 		 * @param {string} data.type Type of alarm
 		 * @param {number} data.totalSeconds Total amount of seconds for new alarm
 		 * @param {boolean=} data.isDefault Whether this is the default alarm
 		 */
 		addAlarmToCalendarObjectInstance({
-			calendarObjectInstance,
 			type,
 			totalSeconds,
 			isDefault = false,
 		}) {
-			if (calendarObjectInstance.eventComponent) {
-				const eventComponent = calendarObjectInstance.eventComponent
+			if (this.calendarObjectInstance.eventComponent) {
+				const eventComponent = this.calendarObjectInstance.eventComponent
 
 				const duration = DurationValue.fromSeconds(totalSeconds)
 				const alarmComponent = eventComponent.addRelativeAlarm(type, duration)
@@ -1156,7 +1126,7 @@ export default defineStore('calendarObjectInstance', {
 
 				const alarmObject = mapAlarmComponentToAlarmObject(alarmComponent)
 
-				calendarObjectInstance.alarms.push(alarmObject)
+				this.calendarObjectInstance.alarms.push(alarmObject)
 
 				logger.debug(alarmObject.alarmComponent.toICALJs().toString())
 			}
@@ -1165,15 +1135,13 @@ export default defineStore('calendarObjectInstance', {
 		/**
 		 *
 		 * @param {object} data The destructuring object
-		 * @param {object} data.calendarObjectInstance The calendarObjectInstance object
 		 * @param {object} data.alarm The alarm object
 		 */
 		removeAlarmFromCalendarObjectInstance({
-			calendarObjectInstance,
 			alarm,
 		}) {
 			if (alarm.alarmComponent) {
-				const alarmIterator = calendarObjectInstance.eventComponent.getAlarmIterator()
+				const alarmIterator = this.calendarObjectInstance.eventComponent.getAlarmIterator()
 				let matchedAlarm = null
 				const targetSeconds = alarm.alarmComponent.trigger.value.totalSeconds
 				const targetAction = alarm.alarmComponent.action
@@ -1185,12 +1153,12 @@ export default defineStore('calendarObjectInstance', {
 				}
 
 				if (matchedAlarm) {
-					calendarObjectInstance.eventComponent.removeAlarm(matchedAlarm)
+					this.calendarObjectInstance.eventComponent.removeAlarm(matchedAlarm)
 				}
 
-				const index = calendarObjectInstance.alarms.indexOf(alarm)
+				const index = this.calendarObjectInstance.alarms.indexOf(alarm)
 				if (index !== -1) {
-					calendarObjectInstance.alarms.splice(index, 1)
+					this.calendarObjectInstance.alarms.splice(index, 1)
 				}
 			}
 		},
@@ -1198,11 +1166,9 @@ export default defineStore('calendarObjectInstance', {
 		/**
 		 * @deprecated
 		 * @param {object} data The destructuring object
-		 * @param {object} data.calendarObjectInstance The calendarObjectInstance object
 		 * @param {object} data.sharedData The shared file data to attach
 		 */
 		addAttachmentBySharedData({
-			calendarObjectInstance,
 			sharedData,
 		}) {
 			const attachment = AttachmentProperty.fromLink(sharedData.url)
@@ -1232,18 +1198,16 @@ export default defineStore('calendarObjectInstance', {
 			attachment.formatType = sharedData.getcontenttype
 			attachment.uri = sharedData.url ? sharedData.url : generateUrl(`/f/${sharedData.fileid}`)
 
-			calendarObjectInstance.eventComponent.addProperty(attachment)
-			calendarObjectInstance.attachments.push(attachment)
+			this.calendarObjectInstance.eventComponent.addProperty(attachment)
+			this.calendarObjectInstance.attachments.push(attachment)
 		},
 
 		/**
 		 *
 		 * @param {object} data The destructuring object
-		 * @param {object} data.calendarObjectInstance The calendarObjectInstance object
 		 * @param {object} data.sharedData The shared file data to attach
 		 */
 		addAttachmentWithProperty({
-			calendarObjectInstance,
 			sharedData,
 		}) {
 			const attachment = {}
@@ -1275,26 +1239,24 @@ export default defineStore('calendarObjectInstance', {
 
 			attachment.attachmentProperty = attachmentProperty
 
-			calendarObjectInstance.eventComponent.addProperty(attachmentProperty)
-			calendarObjectInstance.attachments.push(attachment)
+			this.calendarObjectInstance.eventComponent.addProperty(attachmentProperty)
+			this.calendarObjectInstance.attachments.push(attachment)
 		},
 
 		/**
 		 *
 		 * @param {object} data The destructuring object
-		 * @param {object} data.calendarObjectInstance The calendarObjectInstance object
 		 * @param {object} data.attachment The attachment object
 		 */
 		deleteAttachment({
-			calendarObjectInstance,
 			attachment,
 		}) {
 			try {
-				const index = calendarObjectInstance.attachments.indexOf(attachment)
+				const index = this.calendarObjectInstance.attachments.indexOf(attachment)
 				if (index !== -1) {
-					calendarObjectInstance.attachments.splice(index, 1)
+					this.calendarObjectInstance.attachments.splice(index, 1)
 				}
-				calendarObjectInstance.eventComponent.removeAttachment(attachment.attachmentProperty)
+				this.calendarObjectInstance.eventComponent.removeAttachment(attachment.attachmentProperty)
 			} catch {
 				// Ignore
 			}
@@ -1441,7 +1403,6 @@ export default defineStore('calendarObjectInstance', {
 			timezoneId,
 		}) {
 			this._updateTimeOfNewEvent({
-				calendarObjectInstance: this.calendarObjectInstance,
 				start,
 				end,
 				isAllDay,
@@ -1574,7 +1535,6 @@ export default defineStore('calendarObjectInstance', {
 			}
 
 			this.changeStartDateMutation({
-				calendarObjectInstance: this.calendarObjectInstance,
 				startDate,
 			})
 
@@ -1582,7 +1542,6 @@ export default defineStore('calendarObjectInstance', {
 			if (changeEndDate) {
 				const newEndDate = new Date(startDate.getTime() + oldDuration)
 				this.changeEndDateMutation({
-					calendarObjectInstance: this.calendarObjectInstance,
 					endDate: newEndDate,
 				})
 			}
@@ -1592,23 +1551,19 @@ export default defineStore('calendarObjectInstance', {
 		 * Change the timezone of the event's start
 		 *
 		 * @param {object} data The destructuring object for data
-		 * @param {object} data.calendarObjectInstance The calendarObjectInstance object
 		 * @param {string} data.startTimezone New timezone to set for start
 		 */
 		changeStartTimezone({
-			calendarObjectInstance,
 			startTimezone,
 		}) {
 			this._changeStartTimezoneMutation({
-				calendarObjectInstance,
 				startTimezone,
 			})
 
 			// Simulate a change of the start time to trigger the comparison
 			// of start and end and trigger an update of end if necessary
 			this.changeStartDateMutation({
-				calendarObjectInstance,
-				startDate: calendarObjectInstance.startDate,
+				startDate: this.calendarObjectInstance.startDate,
 			})
 		},
 
@@ -1627,7 +1582,6 @@ export default defineStore('calendarObjectInstance', {
 			}
 
 			this.changeEndDateMutation({
-				calendarObjectInstance: this.calendarObjectInstance,
 				endDate,
 			})
 		},
@@ -1636,63 +1590,54 @@ export default defineStore('calendarObjectInstance', {
 		 * Change the timezone of the event's end
 		 *
 		 * @param {object} data The destructuring object for data
-		 * @param {object} data.calendarObjectInstance The calendarObjectInstance object
 		 * @param {string} data.endTimezone New timezone to set for end
 		 */
 		changeEndTimezone({
-			calendarObjectInstance,
 			endTimezone,
 		}) {
 			this._changeEndTimezoneMutation({
-				calendarObjectInstance,
 				endTimezone,
 			})
 
 			// Simulate a change of the end time to trigger the comparison
 			// of start and end and trigger an update of start if necessary
 			this.changeEndDateMutation({
-				calendarObjectInstance,
-				endDate: calendarObjectInstance.endDate,
+				endDate: this.calendarObjectInstance.endDate,
 			})
 		},
 
 		/**
 		 *
 		 * @param {object} data The destructuring object for data
-		 * @param {object} data.calendarObjectInstance The calendarObjectInstance object
 		 * @param {object} data.recurrenceRule The recurrenceRule object to modify
 		 * @param {string} data.frequency The new frequency to set
 		 */
 		changeRecurrenceFrequency({
-			calendarObjectInstance,
 			recurrenceRule,
 			frequency,
 		}) {
-			logger.debug('changeRecurrenceFrequency', { calendarObjectInstance, recurrenceRule, frequency })
+			logger.debug('changeRecurrenceFrequency', { calendarObjectInstance: this.calendarObjectInstance, recurrenceRule, frequency })
 
 			if (recurrenceRule.frequency === 'NONE' && frequency !== 'NONE') {
 				// Add a new recurrence-rule
 				const recurrenceValue = RecurValue.fromData({})
 				const recurrenceProperty = new Property('RRULE', recurrenceValue)
-				calendarObjectInstance.eventComponent.addProperty(recurrenceProperty)
-				calendarObjectInstance.recurrenceRule.recurrenceRuleValue = recurrenceValue
+				this.calendarObjectInstance.eventComponent.addProperty(recurrenceProperty)
+				this.calendarObjectInstance.recurrenceRule.recurrenceRuleValue = recurrenceValue
 
 				this._resetRecurrenceByParts({ recurrenceRule })
 				this._changeRecurrenceFrequencyMutation({
-					calendarObjectInstance,
-					recurrenceRule: calendarObjectInstance.recurrenceRule,
+					recurrenceRule: this.calendarObjectInstance.recurrenceRule,
 					frequency,
 				})
 				this.changeRecurrenceInterval({
-					calendarObjectInstance,
-					recurrenceRule: calendarObjectInstance.recurrenceRule,
+					recurrenceRule: this.calendarObjectInstance.recurrenceRule,
 					interval: 1,
 				})
 				this.changeRecurrenceToInfinite({
-					recurrenceRule: calendarObjectInstance.recurrenceRule,
+					recurrenceRule: this.calendarObjectInstance.recurrenceRule,
 				})
 				this.setDefaultRecurrenceByParts({
-					calendarObjectInstance,
 					recurrenceRule,
 					frequency,
 				})
@@ -1702,22 +1647,20 @@ export default defineStore('calendarObjectInstance', {
 				logger.debug('calling removeRecurrenceRuleFromCalendarObjectInstance')
 				// Remove the recurrence-rule
 				if (recurrenceRule.recurrenceRuleValue) {
-					calendarObjectInstance.eventComponent.deleteAllProperties('RRULE')
+					this.calendarObjectInstance.eventComponent.deleteAllProperties('RRULE')
 					/// TODO calendarObjectInstance.recurrenceRule = getDefaultEventObject().recurrenceRule
-					calendarObjectInstance.recurrenceRule = getDefaultEventObject().recurrenceRule
+					this.calendarObjectInstance.recurrenceRule = getDefaultEventObject().recurrenceRule
 
-					logger.debug('Removed recurrence-rule', { calendarObjectInstance, recurrenceRule })
+					logger.debug('Removed recurrence-rule', { calendarObjectInstance: this.calendarObjectInstance, recurrenceRule })
 				}
 			} else {
 				// Change frequency of existing recurrence-rule
 				this._resetRecurrenceByParts({ recurrenceRule })
 				this._changeRecurrenceFrequencyMutation({
-					calendarObjectInstance,
-					recurrenceRule: calendarObjectInstance.recurrenceRule,
+					recurrenceRule: this.calendarObjectInstance.recurrenceRule,
 					frequency,
 				})
 				this.setDefaultRecurrenceByParts({
-					calendarObjectInstance,
 					recurrenceRule,
 					frequency,
 				})
@@ -1727,19 +1670,17 @@ export default defineStore('calendarObjectInstance', {
 		/**
 		 *
 		 * @param {object} data The destructuring object for data
-		 * @param {object} data.calendarObjectInstance The calendarObjectInstance object
 		 * @param {object} data.recurrenceRule The recurrenceRule object to modify
 		 * @param {string} data.frequency The new frequency to set
 		 */
 		setDefaultRecurrenceByParts({
-			calendarObjectInstance,
 			recurrenceRule,
 			frequency,
 		}) {
 			switch (frequency) {
 				case 'WEEKLY':
 					if (recurrenceRule.recurrenceRuleValue) {
-						const byDay = getWeekDayFromDate(calendarObjectInstance.startDate)
+						const byDay = getWeekDayFromDate(this.calendarObjectInstance.startDate)
 						recurrenceRule.recurrenceRuleValue.setComponent('BYDAY', [byDay])
 						recurrenceRule.byDay.push(byDay)
 
@@ -1749,7 +1690,7 @@ export default defineStore('calendarObjectInstance', {
 
 				case 'MONTHLY':
 					if (recurrenceRule.recurrenceRuleValue) {
-						const byMonthDay = calendarObjectInstance.startDate.getDate()
+						const byMonthDay = this.calendarObjectInstance.startDate.getDate()
 						recurrenceRule.recurrenceRuleValue.setComponent('BYMONTHDAY', [byMonthDay])
 						recurrenceRule.byMonthDay.push(byMonthDay)
 
@@ -1759,11 +1700,11 @@ export default defineStore('calendarObjectInstance', {
 
 				case 'YEARLY':
 					if (recurrenceRule.recurrenceRuleValue) {
-						const byMonth = calendarObjectInstance.startDate.getMonth() + 1 // Javascript months are zero-based
+						const byMonth = this.calendarObjectInstance.startDate.getMonth() + 1 // Javascript months are zero-based
 						recurrenceRule.recurrenceRuleValue.setComponent('BYMONTH', [byMonth])
 						recurrenceRule.byMonth.push(byMonth)
 
-						const byMonthDay = calendarObjectInstance.startDate.getDate()
+						const byMonthDay = this.calendarObjectInstance.startDate.getDate()
 						recurrenceRule.recurrenceRuleValue.setComponent('BYMONTHDAY', [byMonthDay])
 						recurrenceRule.byMonthDay.push(byMonthDay)
 
@@ -1776,17 +1717,14 @@ export default defineStore('calendarObjectInstance', {
 		/**
 		 *
 		 * @param {object} data The destructuring object for data
-		 * @param {object} data.calendarObjectInstance The calendarObjectInstance object
 		 * @param {object} data.recurrenceRule The recurrenceRule object to modify
 		 */
 		changeMonthlyRecurrenceFromByDayToBySetPosition({
-			calendarObjectInstance,
 			recurrenceRule,
 		}) {
 			logger.debug('changeMonthlyRecurrenceFromByDayToBySetPosition')
 			this._resetRecurrenceByParts({ recurrenceRule })
 			this._setDefaultRecurrenceByPartsForMonthlyBySetPosition({
-				calendarObjectInstance,
 				recurrenceRule,
 			})
 		},
@@ -1794,18 +1732,16 @@ export default defineStore('calendarObjectInstance', {
 		/**
 		 *
 		 * @param {object} data The destructuring object for data
-		 * @param {object} data.calendarObjectInstance The calendarObjectInstance object
 		 * @param {object} data.recurrenceRule The recurrenceRule object to modify
 		 */
 		changeMonthlyRecurrenceFromBySetPositionToByDay({
-			calendarObjectInstance,
 			recurrenceRule,
 		}) {
 			logger.debug('changeMonthlyRecurrenceFromBySetPositionToByDay')
 			this._resetRecurrenceByParts({ recurrenceRule })
 
 			if (recurrenceRule.recurrenceRuleValue) {
-				const byMonthDay = calendarObjectInstance.startDate.getDate()
+				const byMonthDay = this.calendarObjectInstance.startDate.getDate()
 				recurrenceRule.recurrenceRuleValue.setComponent('BYMONTHDAY', [byMonthDay])
 				recurrenceRule.byMonthDay.push(byMonthDay)
 
@@ -1816,16 +1752,13 @@ export default defineStore('calendarObjectInstance', {
 		/**
 		 *
 		 * @param {object} data The destructuring object for data
-		 * @param {object} data.calendarObjectInstance The calendarObjectInstance object
 		 * @param {object} data.recurrenceRule The recurrenceRule object to modify
 		 */
 		changeYearlyRecurrenceFromByDayToBySetPosition({
-			calendarObjectInstance,
 			recurrenceRule,
 		}) {
 			this._resetRecurrenceByParts({ recurrenceRule })
 			this.setDefaultRecurrenceByPartsForYearlyBySetPosition({
-				calendarObjectInstance,
 				recurrenceRule,
 			})
 		},
@@ -1833,21 +1766,19 @@ export default defineStore('calendarObjectInstance', {
 		/**
 		 *
 		 * @param {object} data The destructuring object for data
-		 * @param {object} data.calendarObjectInstance The calendarObjectInstance object
 		 * @param {object} data.recurrenceRule The recurrenceRule object to modify
 		 */
 		changeYearlyRecurrenceFromBySetPositionToByDay({
-			calendarObjectInstance,
 			recurrenceRule,
 		}) {
 			this._resetRecurrenceByParts({ recurrenceRule })
 
 			if (recurrenceRule.recurrenceRuleValue) {
-				const byMonth = calendarObjectInstance.startDate.getMonth() + 1 // Javascript months are zero-based
+				const byMonth = this.calendarObjectInstance.startDate.getMonth() + 1 // Javascript months are zero-based
 				recurrenceRule.recurrenceRuleValue.setComponent('BYMONTH', [byMonth])
 				recurrenceRule.byMonth.push(byMonth)
 
-				const byMonthDay = calendarObjectInstance.startDate.getDate()
+				const byMonthDay = this.calendarObjectInstance.startDate.getDate()
 				recurrenceRule.recurrenceRuleValue.setComponent('BYMONTHDAY', [byMonthDay])
 				recurrenceRule.byMonthDay.push(byMonthDay)
 			}
@@ -1856,31 +1787,29 @@ export default defineStore('calendarObjectInstance', {
 		/**
 		 *
 		 * @param {object} data The destructuring object for data
-		 * @param {object} data.calendarObjectInstance The calendarObjectInstance object
 		 * @param {object} data.recurrenceRule The recurrenceRule object to modify
 		 */
 		enableRecurrenceLimitByUntil({
-			calendarObjectInstance,
 			recurrenceRule,
 		}) {
 			let until
 			switch (recurrenceRule.frequency) {
 			// Defaults to 7 days
 				case 'DAILY':
-					until = new Date(calendarObjectInstance.startDate.getTime() + 7 * 24 * 60 * 60 * 1000)
+					until = new Date(this.calendarObjectInstance.startDate.getTime() + 7 * 24 * 60 * 60 * 1000)
 					break
 
 				// Defaults to 4 weeks
 				case 'WEEKLY':
-					until = new Date(calendarObjectInstance.startDate.getTime() + 4 * 7 * 24 * 60 * 60 * 1000)
+					until = new Date(this.calendarObjectInstance.startDate.getTime() + 4 * 7 * 24 * 60 * 60 * 1000)
 					break
 
 				// Defaults to 10 year
 				case 'YEARLY':
 					until = new Date(
-						calendarObjectInstance.startDate.getFullYear() + 10,
-						calendarObjectInstance.startDate.getMonth(),
-						calendarObjectInstance.startDate.getDate(),
+						this.calendarObjectInstance.startDate.getFullYear() + 10,
+						this.calendarObjectInstance.startDate.getMonth(),
+						this.calendarObjectInstance.startDate.getDate(),
 						23,
 						59,
 						59,
@@ -1891,9 +1820,9 @@ export default defineStore('calendarObjectInstance', {
 				case 'MONTHLY':
 				default:
 					until = new Date(
-						calendarObjectInstance.startDate.getFullYear() + 1,
-						calendarObjectInstance.startDate.getMonth(),
-						calendarObjectInstance.startDate.getDate(),
+						this.calendarObjectInstance.startDate.getFullYear() + 1,
+						this.calendarObjectInstance.startDate.getMonth(),
+						this.calendarObjectInstance.startDate.getDate(),
 						23,
 						59,
 						59,
@@ -1905,7 +1834,6 @@ export default defineStore('calendarObjectInstance', {
 				recurrenceRule,
 			})
 			this.changeRecurrenceUntil({
-				calendarObjectInstance,
 				recurrenceRule,
 				until,
 			})
@@ -2028,11 +1956,10 @@ export default defineStore('calendarObjectInstance', {
 		},
 
 		changeAlarmFromRelativeToAbsolute({
-			calendarObjectInstance,
 			alarm,
 		}) {
 			if (alarm.alarmComponent) {
-				const triggerDateTime = calendarObjectInstance.eventComponent.startDate.clone()
+				const triggerDateTime = this.calendarObjectInstance.eventComponent.startDate.clone()
 				// The trigger of an alarm must be DATE-TIME, startDate can be either.
 				triggerDateTime.isDate = false
 
@@ -2058,12 +1985,11 @@ export default defineStore('calendarObjectInstance', {
 		},
 
 		changeAlarmFromAbsoluteToRelative({
-			calendarObjectInstance,
 			alarm,
 		}) {
 			if (alarm.alarmComponent) {
 				const duration = alarm.alarmComponent.trigger.value
-					.subtractDateWithTimezone(calendarObjectInstance.eventComponent.startDate)
+					.subtractDateWithTimezone(this.calendarObjectInstance.eventComponent.startDate)
 
 				alarm.alarmComponent.setTriggerFromRelative(duration)
 				alarm.relativeIsBefore = alarm.alarmComponent.trigger.value.isNegative
@@ -2080,13 +2006,12 @@ export default defineStore('calendarObjectInstance', {
 
 		toggleAllDay() {
 			const settingsStore = useSettingsStore()
-			this.toggleAllDayMutation({ calendarObjectInstance: this.calendarObjectInstance })
+			this.toggleAllDayMutation()
 
 			if (!this.calendarObjectInstance.isAllDay) {
 				if (this.calendarObjectInstance.startTimezoneId === 'floating') {
 					const startTimezone = settingsStore.getResolvedTimezone
 					this._changeStartTimezoneMutation({
-						calendarObjectInstance: this.calendarObjectInstance,
 						startTimezone,
 					})
 				}
@@ -2110,20 +2035,17 @@ export default defineStore('calendarObjectInstance', {
 			const endDate = new Date(end * 1000)
 
 			if (this.calendarObjectInstance.isAllDay !== isAllDay) {
-				this.toggleAllDayMutation({ calendarObjectInstance: this.calendarObjectInstance })
+				this.toggleAllDayMutation()
 			}
 
 			this.changeStartTimezone({
-				calendarObjectInstance: this.calendarObjectInstance,
 				startTimezone: timezoneId,
 			})
 			this.changeEndTimezone({
-				calendarObjectInstance: this.calendarObjectInstance,
 				endTimezone: timezoneId,
 			})
 
 			this.changeStartDateMutation({
-				calendarObjectInstance: this.calendarObjectInstance,
 				startDate,
 			})
 
@@ -2131,12 +2053,10 @@ export default defineStore('calendarObjectInstance', {
 				// The full-calendar end date is exclusive, but the end-date
 				// that changeEndDate expects is inclusive, so we have to deduct one day.
 				this.changeEndDateMutation({
-					calendarObjectInstance: this.calendarObjectInstance,
 					endDate: new Date(endDate.getTime() - 24 * 60 * 60 * 1000),
 				})
 			} else {
 				this.changeEndDateMutation({
-					calendarObjectInstance: this.calendarObjectInstance,
 					endDate,
 				})
 			}

--- a/src/store/calendarObjects.js
+++ b/src/store/calendarObjects.js
@@ -11,7 +11,6 @@ import { markRaw } from 'vue'
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 import { mapCalendarJsToCalendarObject } from '@/models/calendarObject.js'
-import useCalendarObjectInstanceStore from '@/store/calendarObjectInstance.js'
 import useCalendarsStore from '@/store/calendars.js'
 import useFetchedTimeRangesStore from '@/store/fetchedTimeRanges.js'
 import logger from '@/utils/logger.js'
@@ -244,59 +243,6 @@ export default defineStore('calendarObjects', {
 				calendarObject.calendarComponent = markRaw(calendarObject.calendarComponent)
 			}
 			return Promise.resolve(calendarObject)
-		},
-
-		/**
-		 * Updates the time of the new calendar object
-		 *
-		 * @param {object} data destructuring object
-		 * @param {CalendarObject} data.calendarObjectInstance Calendar-object to
-		 * @param {number} data.start Timestamp for start of new event
-		 * @param {number} data.end Timestamp for end of new event
-		 * @param {string} data.timezoneId asd
-		 * @param {boolean} data.isAllDay foo
-		 */
-		updateTimeOfNewEvent({ calendarObjectInstance, start, end, timezoneId, isAllDay }) {
-			const calendarObjectInstanceStore = useCalendarObjectInstanceStore()
-			const isDirty = calendarObjectInstanceStore.calendarObjectInstance.eventComponent.isDirty()
-			const startDate = new Date(start * 1000)
-			const endDate = new Date(end * 1000)
-
-			if (calendarObjectInstance.isAllDay !== isAllDay) {
-				calendarObjectInstanceStore.toggleAllDayMutation({ calendarObjectInstance })
-			}
-
-			calendarObjectInstanceStore.changeStartTimezone({
-				calendarObjectInstance,
-				startTimezone: timezoneId,
-			})
-			calendarObjectInstanceStore.changeEndTimezone({
-				calendarObjectInstance,
-				endTimezone: timezoneId,
-			})
-
-			calendarObjectInstanceStore.changeStartDateMutation({
-				calendarObjectInstance,
-				startDate,
-			})
-
-			if (isAllDay) {
-				// The full-calendar end date is exclusive, but the end-date
-				// that changeEndDate expects is inclusive, so we have to deduct one day.
-				calendarObjectInstanceStore.changeEndDateMutation({
-					calendarObjectInstance,
-					endDate: new Date(endDate.getTime() - 24 * 60 * 60 * 1000),
-				})
-			} else {
-				calendarObjectInstanceStore.changeEndDateMutation({
-					calendarObjectInstance,
-					endDate,
-				})
-			}
-
-			if (!isDirty) {
-				calendarObjectInstance.eventComponent.undirtify()
-			}
 		},
 
 		/**

--- a/src/views/EditFull.vue
+++ b/src/views/EditFull.vue
@@ -130,8 +130,6 @@
 							<!-- TODO: If not editing the master item, force updating this and all future   -->
 							<!-- TODO: You can't edit recurrence-rule of no-range recurrence-exception -->
 							<Repeat
-								:calendarObjectInstance="calendarObjectInstance"
-								:recurrenceRule="calendarObjectInstance.recurrenceRule"
 								:isReadOnly="isReadOnly || isViewedByOrganizer === false"
 								:isEditingMasterItem="isEditingMasterItem"
 								:isRecurrenceException="isRecurrenceException"
@@ -190,12 +188,10 @@
 							@update:value="updateDescription" />
 
 						<AlarmList
-							:calendarObjectInstance="calendarObjectInstance"
 							:isReadOnly="isReadOnly" />
 
 						<AttachmentsList
 							v-if="!isLoading"
-							:calendarObjectInstance="calendarObjectInstance"
 							:isReadOnly="isReadOnly" />
 					</div>
 
@@ -206,7 +202,6 @@
 							<IconVideo :size="20" class="property-text__icon property-add-talk__icon" />
 							<AddTalkModal
 								v-if="isTalkModalOpen"
-								:calendarObjectInstance="calendarObjectInstance"
 								:delegatorUserId="delegatorUserId"
 								@close="isTalkModalOpen = false"
 								@updateLocation="updateLocation"
@@ -316,7 +311,6 @@
 						<InviteesList
 							v-if="!isLoading"
 							:calendar="selectedCalendar"
-							:calendarObjectInstance="calendarObjectInstance"
 							:isReadOnly="isReadOnly || isViewedByOrganizer === false"
 							:isSharedWithMe="isSharedWithMe"
 							:showHeader="true"
@@ -326,7 +320,6 @@
 					<div class="app-full-footer__right">
 						<ResourceList
 							v-if="!isLoading"
-							:calendarObjectInstance="calendarObjectInstance"
 							:isReadOnly="isReadOnly || isViewedByOrganizer === false" />
 					</div>
 				</div>

--- a/src/views/EditFull.vue
+++ b/src/views/EditFull.vue
@@ -604,7 +604,6 @@ export default {
 		 */
 		updateStatus(status) {
 			this.calendarObjectInstanceStore.changeStatus({
-				calendarObjectInstance: this.calendarObjectInstance,
 				status,
 			})
 		},
@@ -616,7 +615,6 @@ export default {
 		 */
 		updateTimeTransparency(timeTransparency) {
 			this.calendarObjectInstanceStore.changeTimeTransparency({
-				calendarObjectInstance: this.calendarObjectInstance,
 				timeTransparency,
 			})
 		},
@@ -628,7 +626,6 @@ export default {
 		 */
 		updateInvitationForwarding(invitationForwarding) {
 			this.calendarObjectInstanceStore.changeInvitationForwarding({
-				calendarObjectInstance: this.calendarObjectInstance,
 				invitationForwarding,
 			})
 		},
@@ -640,7 +637,6 @@ export default {
 		 */
 		addCategory(category) {
 			this.calendarObjectInstanceStore.addCategory({
-				calendarObjectInstance: this.calendarObjectInstance,
 				category,
 			})
 		},
@@ -652,7 +648,6 @@ export default {
 		 */
 		removeCategory(category) {
 			this.calendarObjectInstanceStore.removeCategory({
-				calendarObjectInstance: this.calendarObjectInstance,
 				category,
 			})
 		},
@@ -664,7 +659,6 @@ export default {
 		 */
 		updateColor(customColor) {
 			this.calendarObjectInstanceStore.changeCustomColor({
-				calendarObjectInstance: this.calendarObjectInstance,
 				customColor,
 			})
 		},

--- a/src/views/EditFull.vue
+++ b/src/views/EditFull.vue
@@ -554,14 +554,12 @@ export default {
 	methods: {
 		updateLocation(location) {
 			this.calendarObjectInstanceStore.changeLocation({
-				calendarObjectInstance: this.calendarObjectInstance,
 				location,
 			})
 		},
 
 		updateDescription(description) {
 			this.calendarObjectInstanceStore.changeDescription({
-				calendarObjectInstance: this.calendarObjectInstance,
 				description,
 			})
 		},
@@ -585,7 +583,6 @@ export default {
 		 */
 		updateAccessClass(accessClass) {
 			this.calendarObjectInstanceStore.changeAccessClass({
-				calendarObjectInstance: this.calendarObjectInstance,
 				accessClass,
 			})
 		},

--- a/src/views/EditSimple.vue
+++ b/src/views/EditSimple.vue
@@ -187,7 +187,6 @@
 						</div>
 						<AddTalkModal
 							v-if="isTalkModalOpen"
-							:calendarObjectInstance="calendarObjectInstance"
 							:delegatorUserId="delegatorUserId"
 							@close="isTalkModalOpen = false"
 							@updateLocation="updateLocation"
@@ -209,8 +208,7 @@
 							:showHeader="true"
 							:isReadOnly="isReadOnlyOrViewing || isViewedByOrganizer === false"
 							:isSharedWithMe="isSharedWithMe"
-							:calendar="selectedCalendar"
-							:calendarObjectInstance="calendarObjectInstance" />
+							:calendar="selectedCalendar" />
 
 						<InvitationResponseButtons
 							v-if="isViewedByAttendee && isViewing"
@@ -222,7 +220,6 @@
 						<div v-if="isReadOnlyOrViewing && hasAlarms" class="property-alarm-wrapper">
 							<Bell :size="20" class="property-alarm-icon" />
 							<AlarmList
-								:calendarObjectInstance="calendarObjectInstance"
 								:isReadOnly="isReadOnlyOrViewing" />
 						</div>
 					</div>


### PR DESCRIPTION
Stop passing redundant `calendarObjectInstance`.

Every editor related component should use `useCalendarObjectInstanceStore#calendarObjectInstance`.

This prepares the stage for "Advanced events editor API" #8522 which requires proper change detection between the model used by our editor and the model passed to the user.


## 🤖 AI (if applicable)

- Refactoring was done manually.
- Esp. the reasoning

## For Reviewers

I tried creating individual commits with refactoring steps.
This might help with the review.