### PR TITLE
feat(ux): shorter button labels to improve readability in certain languages

### DIFF
--- a/src/views/EditFull.vue
+++ b/src/views/EditFull.vue
@@ -441,7 +441,7 @@ export default {
 			showPreloader: false,
 			cancelButtons: [
 				{
-					label: t('calendar', 'Discard changes'),
+					label: t('calendar', 'Discard'),
 					variant: 'secondary',
 					icon: IconDelete,
 					callback: () => { this.cancel(true) },

--- a/src/views/EditSimple.vue
+++ b/src/views/EditSimple.vue
@@ -369,7 +369,7 @@ export default {
 			showCancelDialog: false,
 			cancelButtons: [
 				{
-					label: t('calendar', 'Discard changes'),
+					label: t('calendar', 'Discard'),
 					variant: 'secondary',
 					icon: IconDelete,
 					callback: () => { this.cancel(true) },


### PR DESCRIPTION
⚠️ Important : not tested (no test environment)

Current problem in French (many other languages may have the same issue) : 
- buttons are very large
- some texts are truncated (ellipsis)

| French, currently | French after this PR |
| --- | --- |
| <img width="443" height="208" alt="2026-08-18_14-34" src="https://github.com/user-attachments/assets/10282f7c-d14d-41f1-8416-51bb950db29a" /> | <img width="443" height="208" alt="2026-08-18_14-34_1" src="https://github.com/user-attachments/assets/be17340e-14fd-4bc8-9830-28da3fe01423" /> |

Same problem as [62880](https://github.com/nextcloud/server/pull/62880)

I suggest using only action verbs (one word per button) so that the information is clear and easy to read, and so that the interface isn't cluttered with buttons that are too large.

Concerns simple and full editor.