### PR TITLE
fix(appointments): prevent unreachable overflow on the booking page

### DIFF
--- a/src/views/Appointments/Booking.vue
+++ b/src/views/Appointments/Booking.vue
@@ -261,10 +261,11 @@ export default {
 #appointment-booking {
 	display: flex;
 	justify-content: center;
-	align-items: center;
+	align-items: safe center;
 	width: 100%;
 	align-self: flex-start;
 	min-height: 100%;
+	height: auto;
 }
 </style>
 
@@ -273,8 +274,9 @@ export default {
 	display: flex;
 	width: 100%;
 	align-self: stretch;
+	min-height: 100vh;
 	flex-direction: column;
-	justify-content: center;
+	justify-content: safe center;
 	align-items: center;
 }
 


### PR DESCRIPTION

## 🤖 AI (debugged in chat with claude Opus 5)

## Summary

The public appointment booking page centers its content vertically inside a
container fixed at `100vh`. When the content is taller than the viewport, the
overflow is split evenly above and below the container; the upper part ends up
at a negative offset and cannot be reached by scrolling.

This replaces the fixed heights with `min-height` / `auto` and uses the `safe`
alignment keyword on both vertical-axis centering declarations.

## How it works

`safe center` is identical to `center` whenever the content fits, and degrades
to `start` when it would overflow. The desktop layout is therefore unchanged,
and the behaviour adapts to dynamic content height — long descriptions, or the
slot column expanding after a date is picked — without introducing a
breakpoint.

## Testing

Verified on a production instance running Calendar <VERSION> by applying the
equivalent declarations as custom CSS:

- Desktop: layout unchanged, content still vertically centered
- iOS Safari, multi-line description: whole page reachable, nothing clipped at
  the top
- Slot column expanded after picking a date: no reflow into unreachable space

## Related

Refs #8029

## Browser support

`safe` alignment: Chrome 93+, Firefox 63+, Safari 16.4+.