### PR TITLE
fix(freebusy): don't render "undefined" as the title of busy blocks

### DIFF
--- a/src/fullcalendar/eventSources/freeBusyResourceEventSourceFunction.js
+++ b/src/fullcalendar/eventSources/freeBusyResourceEventSourceFunction.js
@@ -14,10 +14,7 @@ import { getParserManager } from '@nextcloud/calendar-js'
  * @param {Date} start The start of the fetched time-range
  * @param {Date} end The end of the fetched time-range
  * @param {string} timezone Timezone of user viewing data
- * @param {string} [attendeeName] Name of the attendee, used as title for the event.
- *   Omitted by bulk callers, which render the name in the resource lane header
- *   instead — passing undefined through to `title` made FullCalendar print the
- *   string "undefined" inside every busy block.
+ * @param {string} attendeeName name of the attendee, used as title for the event
  * @param {boolean} isOrganizer Whether or not the user is the organizer of the event
  * @return {object[]}
  */

--- a/src/fullcalendar/eventSources/freeBusyResourceEventSourceFunction.js
+++ b/src/fullcalendar/eventSources/freeBusyResourceEventSourceFunction.js
@@ -14,11 +14,14 @@ import { getParserManager } from '@nextcloud/calendar-js'
  * @param {Date} start The start of the fetched time-range
  * @param {Date} end The end of the fetched time-range
  * @param {string} timezone Timezone of user viewing data
- * @param {string} attendeeName name of the attendee, used as title for the event
+ * @param {string} [attendeeName] Name of the attendee, used as title for the event.
+ *   Omitted by bulk callers, which render the name in the resource lane header
+ *   instead — passing undefined through to `title` made FullCalendar print the
+ *   string "undefined" inside every busy block.
  * @param {boolean} isOrganizer Whether or not the user is the organizer of the event
  * @return {object[]}
  */
-export default function(uri, calendarData, success, start, end, timezone, attendeeName, isOrganizer = false) {
+export default function(uri, calendarData, success, start, end, timezone, attendeeName = '', isOrganizer = false) {
 	if (!success) {
 		return [{
 			id: Math.random().toString(36).substring(7),

--- a/tests/javascript/unit/fullcalendar/eventSources/freeBusyResourceEventSourceFunction.test.js
+++ b/tests/javascript/unit/fullcalendar/eventSources/freeBusyResourceEventSourceFunction.test.js
@@ -5,6 +5,7 @@
 import { translate } from '@nextcloud/l10n'
 import { createPinia, setActivePinia } from 'pinia'
 import { eventSourceFunction } from '@/fullcalendar/eventSources/eventSourceFunction.js'
+import freeBusyResourceEventSourceFunction from '@/fullcalendar/eventSources/freeBusyResourceEventSourceFunction.js'
 import useSettingsStore from '@/store/settings.js'
 import { getAllObjectsInTimeRange } from '@/utils/calendarObject.js'
 import {
@@ -874,5 +875,42 @@ describe('fullcalendar/freeBusyResourceEventSourceFunction test suite', () => {
 		getAllObjectsInTimeRange.mockReturnValueOnce([eventA, eventB, eventC])
 		result = eventSourceFunction(calendarObjects, calendar, start, end, timezone)
 		expect(result).toHaveLength(3)
+	})
+
+	describe('event title', () => {
+		const start = { getInTimezone: () => ({ jsDate: new Date(2020, 1, 1, 10, 0, 0, 0) }) }
+		const end = { getInTimezone: () => ({ jsDate: new Date(2020, 1, 1, 11, 0, 0, 0) }) }
+
+		it('should not render "undefined" as title when no attendee name is given', () => {
+			// Bulk callers omit attendeeName because the name is already shown in
+			// the resource lane header. Before this was defaulted, `title` became
+			// the literal string "undefined" in every rendered busy block.
+			const result = freeBusyResourceEventSourceFunction(
+				'mailto:room@example.com',
+				null,
+				false,
+				start,
+				end,
+				'UTC',
+			)
+
+			expect(result).toHaveLength(1)
+			expect(result[0].title).toBe('')
+		})
+
+		it('should still use the attendee name when one is given', () => {
+			const result = freeBusyResourceEventSourceFunction(
+				'mailto:room@example.com',
+				null,
+				false,
+				start,
+				end,
+				'UTC',
+				'Meeting room A',
+			)
+
+			expect(result).toHaveLength(1)
+			expect(result[0].title).toBe('Meeting room A')
+		})
 	})
 })


### PR DESCRIPTION
The room availability dialog prints the literal string `undefined` inside every busy block.

## Cause

`getBusySlots()` has two paths. The non-bulk one passes `attendees[0].commonName` as `attendeeName`; the bulk one omits the argument entirely:

```js
// src/services/freeBusySlotService.js
if (bulk) {
    events.push(...freeBusyResourceEventSourceFunction(uri, data.calendarData, data.success, startDateTime, endDateTime, timezoneObject))
} else {
    events.push(...freeBusyResourceEventSourceFunction(uri, data.calendarData, data.success, startDateTime, endDateTime, timezoneObject, attendees[0].commonName, isOrganizer))
}
```

`freeBusyResourceEventSourceFunction` assigns that parameter straight to `title`, so for every bulk caller the title becomes `undefined` — which FullCalendar renders as text.

## Why default to an empty string rather than thread a name through

The bulk callers already display the name elsewhere, so repeating it inside each block would be redundant:

- `RoomAvailabilityModal` builds its own `resources[]` list (`attendee.commonName || attendee.uri.slice(7)`) and renders it as the **resource lane header**.
- `ProposalEditor` only reads `resourceId` from the returned events; it never touches `title`.

So the block itself does not need a label — it just must not print `undefined`.

## Tests

Added a regression test covering both the omitted and the supplied name. Verified it fails without the change (`expected undefined to be `) and passes with it. The wider `fullcalendar/` + `services/` suites stay green (130 tests).

## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI