### PR TITLE
fix(appointments): catch actual exception type for invalid timezones

### DIFF
--- a/lib/Controller/BookingController.php
+++ b/lib/Controller/BookingController.php
@@ -25,7 +25,6 @@ use OCP\AppFramework\Http\Attribute\UserRateLimit;
 use OCP\AppFramework\Http\TemplateResponse;
 use OCP\AppFramework\Services\IInitialState;
 use OCP\AppFramework\Utility\ITimeFactory;
-use OCP\DB\Exception;
 use OCP\IConfig;
 use OCP\IRequest;
 use OCP\IURLGenerator;
@@ -66,9 +65,9 @@ class BookingController extends Controller {
 	): JsonResponse {
 		try {
 			$tz = new DateTimeZone($timeZone);
-		} catch (Exception $e) {
+		} catch (\Exception $e) {
 			$this->logger->error('Timezone invalid', ['exception' => $e]);
-			return JsonResponse::fail('Invalid time zone', Http::STATUS_UNPROCESSABLE_ENTITY);
+			return JsonResponse::fail('Invalid timezone', Http::STATUS_UNPROCESSABLE_ENTITY);
 		}
 		// Convert selected date to requesters selected timezone adjusted start and end of day in epoch
 		$startTimeInTz = (new DateTime($dateSelected, $tz))

--- a/lib/Service/Appointments/BookingService.php
+++ b/lib/Service/Appointments/BookingService.php
@@ -101,8 +101,8 @@ class BookingService {
 
 		try {
 			$tz = new DateTimeZone($timeZone);
-		} catch (DbException $e) {
-			throw new InvalidArgumentException('Could not make sense of the timezone', $e->getCode(), $e);
+		} catch (\Exception $e) {
+			throw new InvalidArgumentException('Could not make sense of the timezone', previous: $e);
 		}
 
 		$booking = new Booking();

--- a/tests/php/unit/Controller/BookingControllerTest.php
+++ b/tests/php/unit/Controller/BookingControllerTest.php
@@ -10,7 +10,6 @@ namespace OCA\Calendar\Controller;
 
 use ChristophWurst\Nextcloud\Testing\TestCase;
 use DateTime;
-use Exception;
 use InvalidArgumentException;
 use OC\URLGenerator;
 use OCA\Calendar\Db\AppointmentConfig;
@@ -166,9 +165,15 @@ class BookingControllerTest extends TestCase {
 			->with($apptConfg->getToken());
 		$this->bookingService->expects(self::never())
 			->method('getAvailableSlots');
-		$this->expectException(Exception::class);
+		$this->logger->expects(self::once())
+			->method('error')
+			->with('Timezone invalid');
 
-		$this->controller->getBookableSlots($apptConfg->getToken(), $selectedDate, 'Hook/Neverland');
+		$response = $this->controller->getBookableSlots($apptConfg->getToken(), $selectedDate, 'Hook/Neverland');
+
+		self::assertInstanceOf(JsonResponse::class, $response);
+		self::assertSame(Http::STATUS_UNPROCESSABLE_ENTITY, $response->getStatus());
+		self::assertSame(['status' => 'fail', 'data' => 'Invalid timezone'], $response->getData());
 	}
 
 	public function testGetBookableSlotsTimezoneIdentical(): void {

--- a/tests/php/unit/Service/Appointments/BookingServiceTest.php
+++ b/tests/php/unit/Service/Appointments/BookingServiceTest.php
@@ -10,7 +10,7 @@ namespace OCA\Calendar\Tests\Unit\Service\Appointments;
 
 use ChristophWurst\Nextcloud\Testing\TestCase;
 use DateTimeImmutable;
-use Exception;
+use InvalidArgumentException;
 use OCA\Calendar\Db\AppointmentConfig;
 use OCA\Calendar\Db\Booking;
 use OCA\Calendar\Db\BookingMapper;
@@ -160,7 +160,7 @@ class BookingServiceTest extends TestCase {
 		$this->random->expects(self::never())
 			->method('generate');
 
-		$this->expectException(Exception::class);
+		$this->expectExceptionObject(new InvalidArgumentException('Could not make sense of the timezone'));
 		$this->service->book(new AppointmentConfig(), 4054546654, 44545454, 'Nighttime/DAYTIME!', 'Test', 'test@test.com', 'Test');
 	}
 


### PR DESCRIPTION
Assisted-by: ClaudeCode:claude-sonnet-5

## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
