### PR TITLE
refactor: enforce handling catched errorw

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -22,6 +22,11 @@ export default [
 		rules: {
 			// Relax some rules for now. Can be improved later on (baseline).
 			'vue/multi-word-component-names': 'warn',
+			// Force to use the caught errors e.g. log, rethrow or comment about explicit exceptions.
+			'no-restricted-syntax': ['error', {
+				selector: 'CatchClause[param=null]',
+				message: 'Bind the caught error: use `catch (error)`.',
+			}],
 			'preserve-caught-error': 'warn',
 			'@nextcloud/no-deprecated-library-props': 'warn',
 			'vue/custom-event-name-casing': 'warn',

--- a/src/components/AppNavigation/CalendarList/Trashbin.vue
+++ b/src/components/AppNavigation/CalendarList/Trashbin.vue
@@ -171,8 +171,8 @@ export default {
 				let eventSummary = t('calendar', 'Untitled item')
 				try {
 					eventSummary = vobject?.calendarComponent.getComponentIterator().next().value?.title
-				} catch {
-					// ignore
+				} catch (error) {
+					logger.error('Failed to read event summary from deleted calendar object', { error })
 				}
 				let subline = vobject.calendar?.displayName || t('calendar', 'Unknown calendar')
 				if (vobject.isEvent) {

--- a/src/components/AppNavigation/EditCalendarModal.vue
+++ b/src/components/AppNavigation/EditCalendarModal.vue
@@ -467,7 +467,8 @@ export default {
 				if (this.isAfterVersion && this.defaultAlarmChanged) {
 					await this.saveDefaultAlarm()
 				}
-			} catch {
+			} catch (error) {
+				logger.error('Failed to save calendar changes', { error })
 				showError(this.$t('calendar', 'Failed to save calendar name and color'))
 			}
 

--- a/src/components/AppNavigation/EditCalendarModal/SharingSearch.vue
+++ b/src/components/AppNavigation/EditCalendarModal/SharingSearch.vue
@@ -192,7 +192,8 @@ export default {
 			let results
 			try {
 				results = await principalPropertySearchByDisplaynameOrEmail(query)
-			} catch {
+			} catch (error) {
+				logger.error('Failed to search for sharees via DAV', { error })
 				return []
 			}
 
@@ -252,7 +253,8 @@ export default {
 						itemType: 'principals',
 					},
 				})
-			} catch {
+			} catch (error) {
+				logger.error('Failed to search for sharees via circles', { error })
 				return []
 			}
 
@@ -309,7 +311,8 @@ export default {
 						lookup: false,
 					},
 				})
-			} catch {
+			} catch (error) {
+				logger.error('Failed to search for remote sharees', { error })
 				return []
 			}
 

--- a/src/components/AppNavigation/Proposal/ProposalList.vue
+++ b/src/components/AppNavigation/Proposal/ProposalList.vue
@@ -175,7 +175,8 @@ async function destroyProposal(): Promise<void> {
 		await proposalStore.destroyProposal(proposal)
 		showSuccess(t('calendar', 'Successfully deleted proposal'))
 		fetchProposals()
-	} catch {
+	} catch (error) {
+		logger.error('Failed to delete proposal', { error })
 		showError(t('calendar', 'Failed to delete proposal'))
 	}
 }
@@ -183,7 +184,8 @@ async function destroyProposal(): Promise<void> {
 async function fetchProposals(): Promise<void> {
 	try {
 		storedProposals.value = await proposalStore.listProposals()
-	} catch {
+	} catch (error) {
+		logger.error('Failed to retrieve proposals', { error })
 		showError(t('calendar', 'Failed to retrieve proposals'))
 	}
 }

--- a/src/components/Editor/InvitationResponseButtons.vue
+++ b/src/components/Editor/InvitationResponseButtons.vue
@@ -117,7 +117,8 @@ export default {
 				await this.setParticipationStatus('ACCEPTED')
 				showSuccess(this.t('calendar', 'The invitation has been accepted successfully.'))
 				this.$emit('close')
-			} catch {
+			} catch (error) {
+				logger.error('Failed to accept the invitation', { error })
 				showError(this.t('calendar', 'Failed to accept the invitation.'))
 			}
 		},
@@ -127,7 +128,8 @@ export default {
 				await this.setParticipationStatus('DECLINED')
 				showSuccess(this.t('calendar', 'The invitation has been declined successfully.'))
 				this.$emit('close')
-			} catch {
+			} catch (error) {
+				logger.error('Failed to decline the invitation', { error })
 				showError(this.t('calendar', 'Failed to decline the invitation.'))
 			}
 		},
@@ -137,7 +139,8 @@ export default {
 				await this.setParticipationStatus('TENTATIVE')
 				showSuccess(this.t('calendar', 'Your participation has been marked as tentative.'))
 				this.$emit('close')
-			} catch {
+			} catch (error) {
+				logger.error('Failed to set the participation status to tentative', { error })
 				showError(this.t('calendar', 'Failed to set the participation status to tentative.'))
 			}
 		},

--- a/src/components/Editor/Invitees/AttendeeDisplay.vue
+++ b/src/components/Editor/Invitees/AttendeeDisplay.vue
@@ -81,7 +81,8 @@ export default {
 				const text = `${this.displayName} <${this.email}>`
 				await navigator.clipboard.writeText(text)
 				showSuccess(this.$t('calendar', 'Copied to clipboard'))
-			} catch {
+			} catch (error) {
+				logger.error('Failed to copy attendee to clipboard', { error })
 				showError(this.$t('calendar', 'Failed to copy'))
 			}
 		},

--- a/src/components/Editor/Invitees/InviteesList.vue
+++ b/src/components/Editor/Invitees/InviteesList.vue
@@ -479,7 +479,8 @@ export default {
 			try {
 				await navigator.clipboard.writeText(tsvContent)
 				showSuccess(this.t('calendar', 'Attendees copied to clipboard'))
-			} catch {
+			} catch (error) {
+				logger.error('Failed to copy attendees to clipboard', { error })
 				showError(this.t('calendar', 'Failed to copy attendees to clipboard'))
 			}
 		},

--- a/src/components/Subscription/PublicCalendarSubscriptionPicker.vue
+++ b/src/components/Subscription/PublicCalendarSubscriptionPicker.vue
@@ -71,7 +71,8 @@ function isValidString(str, allowNull = false) {
 function isValidURL(str) {
 	try {
 		return Boolean(new URL(str))
-	} catch {
+	} catch (error) {
+		logger.error('Failed to parse subscription URL', { error })
 		return false
 	}
 }

--- a/src/router.js
+++ b/src/router.js
@@ -11,6 +11,7 @@ import Calendar from '@/views/Calendar.vue'
 import EditFull from '@/views/EditFull.vue'
 import EditSimple from '@/views/EditSimple.vue'
 import useProposalStore from '@/store/proposalStore'
+import logger from '@/utils/logger.js'
 import {
 	getDefaultEndDateForNewEvent,
 	getDefaultStartDateForNewEvent,
@@ -153,7 +154,8 @@ const router = createRouter({
 							if (!found) {
 								showError(t('calendar', 'This meeting proposal no longer exists'))
 							}
-						} catch {
+						} catch (error) {
+							logger.error('Failed to open meeting proposal', { error })
 							showError(t('calendar', 'Failed to open meeting proposal'))
 						}
 

--- a/src/services/talkService.ts
+++ b/src/services/talkService.ts
@@ -131,7 +131,8 @@ export async function createRoomFromProposal(proposal: ProposalInterface): Promi
 								return
 							}
 							resolve({ email: participant.address })
-						} catch {
+						} catch (error) {
+							logger.error('Failed to resolve participant to a user account', { error })
 							resolve({ email: participant.address })
 						}
 					} else {

--- a/src/services/timezoneOffsetService.ts
+++ b/src/services/timezoneOffsetService.ts
@@ -44,7 +44,8 @@ export function getTimezoneOffset(proposalDate: Date, timezoneId: string): numbe
 		)
 
 		timezoneOffset = Math.round((asUTC - proposalDate.getTime()) / 60000)
-	} catch {
+	} catch (error) {
+		logger.error('Failed to compute timezone offset', { error })
 		timezoneOffset = 0
 	}
 

--- a/src/store/calendarObjectInstance.js
+++ b/src/store/calendarObjectInstance.js
@@ -1214,8 +1214,8 @@ export default defineStore('calendarObjectInstance', {
 					this.calendarObjectInstance.attachments.splice(index, 1)
 				}
 				this.calendarObjectInstance.eventComponent.removeAttachment(attachment.attachmentProperty)
-			} catch {
-				// Ignore
+			} catch (error) {
+				logger.error('Failed to delete attachment', { error })
 			}
 		},
 

--- a/src/utils/localeTime.js
+++ b/src/utils/localeTime.js
@@ -4,11 +4,13 @@
  */
 
 import { getCanonicalLocale } from '@nextcloud/l10n'
+import logger from '@/utils/logger.js'
 
 const locale = [getCanonicalLocale(), undefined].find((locale) => {
 	try {
 		(new Date()).toLocaleString(locale)
-	} catch {
+	} catch (error) {
+		logger.error('Failed to format date with canonical locale', { error })
 		return false
 	}
 

--- a/src/utils/moment.js
+++ b/src/utils/moment.js
@@ -60,6 +60,7 @@ async function getLocaleFor(locale) {
 		// default load e.g. en-de
 		await import(`moment/locale/${locale}.js`)
 		return locale
+	// eslint-disable-next-line no-restricted-syntax -- try-catch is used for availibility check
 	} catch {
 		const splitLocale = locale.split('-')
 		try {
@@ -68,6 +69,7 @@ async function getLocaleFor(locale) {
 			locale = splitLocale[0]
 			await import(`moment/locale/${locale}.js`)
 			return locale
+		// eslint-disable-next-line no-restricted-syntax -- try-catch is used for availibility check
 		} catch {
 			// failure, fallback to english
 			logger.debug('Fallback to locale', { locale: 'en' })

--- a/src/utils/router.js
+++ b/src/utils/router.js
@@ -7,6 +7,7 @@ import {
 	dateFactory,
 	getUnixTimestampFromDate,
 } from '@/utils/date.js'
+import logger from '@/utils/logger.js'
 
 /**
  * Gets the initial view
@@ -16,7 +17,8 @@ import {
 export function getInitialView() {
 	try {
 		return loadState('calendar', 'initial_view')
-	} catch {
+	} catch (error) {
+		logger.error('Failed to load initial view state', { error })
 		return 'dayGridMonth'
 	}
 }
@@ -30,7 +32,8 @@ export function getPreferredEditorRoute() {
 	let skipPopover
 	try {
 		skipPopover = loadState('calendar', 'skip_popover')
-	} catch {
+	} catch (error) {
+		logger.error('Failed to load skip-popover state', { error })
 		skipPopover = false
 	}
 

--- a/src/views/EditSimple.vue
+++ b/src/views/EditSimple.vue
@@ -843,7 +843,8 @@ export default {
 			try {
 				await this.save(thisAndAllFuture)
 				this.requiresActionOnRouteLeave = false
-			} catch {
+			} catch (error) {
+				logger.error('Failed to save event, reverting to edit mode', { error })
 				this.isViewing = false
 			}
 		},


### PR DESCRIPTION
I want to see error details in console.
Either (1) they indicate some real error happen or (2) we should we abuse it for control flow.
If it is the later we should eventually replace it with proper check (e.g. feature available, action allowed etc.)

Especially everything with regards to editing is complicated and we might currently overview some error that cause or indicate broken editor state.

Assisted-by: ClaudeCode:claude-sonnet-5

## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
