### PR TITLE
fix(delegation): display delegated calendars after enable status change

### DIFF
--- a/src/components/AppNavigation/CalendarList.vue
+++ b/src/components/AppNavigation/CalendarList.vue
@@ -128,6 +128,7 @@ async function update(): Promise<void> {
 		...sortedCalendars.shared,
 		...sortedCalendars.deck,
 		...sortedCalendars.tasks,
+		...sortedCalendars.delegated,
 	]
 	const newOrder = currentCalendars.reduce<Record<string, number>>((newOrderObj, currentItem, currentIndex) => {
 		newOrderObj[currentItem.id] = currentIndex


### PR DESCRIPTION
Fixes  #8741

#### Before

https://github.com/user-attachments/assets/c0bf53a9-ccb6-48cd-8910-660340decbfc


#### After


https://github.com/user-attachments/assets/1a18a815-2579-4467-88a8-bdfcd0d241c1



## 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
