### PR TITLE
[stable6.5] fix(delegation): display delegated calendars after enable status change

### DIFF
--- a/src/components/AppNavigation/CalendarList.vue
+++ b/src/components/AppNavigation/CalendarList.vue
@@ -293,6 +293,7 @@ export default {
 				...this.sortedCalendars.shared,
 				...this.sortedCalendars.deck,
 				...this.sortedCalendars.tasks,
+				...this.sortedCalendars.delegated,
 			]
 			const newOrder = currentCalendars.reduce((newOrderObj, currentItem, currentIndex) => {
 				newOrderObj[currentItem.id] = currentIndex


### PR DESCRIPTION
Backport of PR https://github.com/nextcloud/calendar/pull/8786