### PR TITLE
fix(resources): tidy up the room filter row

### DIFF
--- a/src/components/Editor/Resources/RoomSelectionModal.vue
+++ b/src/components/Editor/Resources/RoomSelectionModal.vue
@@ -436,7 +436,6 @@ watch(
 
 		&__label {
 			color: var(--color-text-maxcontrast);
-			font-size: calc(var(--default-font-size) * 0.9);
 		}
 
 		// Give every control the same height and let the row decide the width
@@ -448,10 +447,7 @@ watch(
 			margin: 0;
 		}
 
-		// NcSelect pads the toggle by --border-width-input on every side, which
-		// stacks on top of the min-height and makes the select 2px taller than
-		// the text field next to it. The padding is dropped in the open state
-		// anyway, so clearing it here keeps both controls at the same height.
+		// NcSelect pads the toggle by --border-width-input on every side
 		:deep(.v-select.select .vs__dropdown-toggle) {
 			min-height: var(--default-clickable-area);
 			padding: 0;

--- a/src/components/Editor/Resources/RoomSelectionModal.vue
+++ b/src/components/Editor/Resources/RoomSelectionModal.vue
@@ -448,8 +448,13 @@ watch(
 			margin: 0;
 		}
 
+		// NcSelect pads the toggle by --border-width-input on every side, which
+		// stacks on top of the min-height and makes the select 2px taller than
+		// the text field next to it. The padding is dropped in the open state
+		// anyway, so clearing it here keeps both controls at the same height.
 		:deep(.v-select.select .vs__dropdown-toggle) {
 			min-height: var(--default-clickable-area);
+			padding: 0;
 		}
 
 		// While the dropdown is closed there is nothing to type into, so the


### PR DESCRIPTION
Two small fixes to the filter row in the room picker, found while testing 6.6.0-rc.1 on Nextcloud 34.

## 1. The Features select is 2px taller than the text field next to it

`NcSelect` sets padding on the toggle:

<img width="1619" height="475" alt="image" src="https://github.com/user-attachments/assets/b9bb4dad-2fd4-4877-9059-b7f8769a3af0" />

```css
.v-select.select .vs__dropdown-toggle {
	padding: var(--border-width-input);
}
```

That stacks on top of the `min-height: var(--default-clickable-area)` the toggle already carries in this component, so the select ends up at 36px where **Minimum capacity** sits at 34px. `min-height` is a floor, not a ceiling, so it cannot hold the padding back.

| control | before | after |
|---|---|---|
| `NcTextField` (Minimum capacity) | 34px | 34px |
| `NcSelect` (Features) | 36px | 34px |

**Why clearing the padding is safe:** `NcSelect` already drops it to `0` in its open state (`.vs--open .vs__dropdown-toggle`), where it swaps in the thicker `--border-width-input-focused` border instead. So the control does not jump when the dropdown opens — I measured the closed and open states side by side, both 34px.

**On fixing this in nextcloud-vue instead:** the root cause is in `NcSelect`, and every app placing a select next to a text field has the same mismatch. That felt out of scope here, so this fixes it locally. Worth noting the override is forward-compatible: if `NcSelect` later drops the padding itself, `padding: 0` here becomes redundant rather than harmful — I verified all four combinations (current/fixed component × with/without this override) and every one that includes either fix lands on 34px. Happy to move it into `nextcloud-vue` if you would rather fix it at the source.

## 2. The filter labels are smaller than the colour is calibrated for

The labels pair `--color-text-maxcontrast` with `0.9 * --default-font-size`, rendering at 13.5px.

`--color-text-maxcontrast` resolves to `#6b6b6b`, giving **5.33:1** on `--color-main-background`. That clears WCAG AA (4.5:1) but not AAA (7:1), and the token is calibrated for text at the default size. Shrinking the label keeps a colour already close to the floor while making the text smaller than what it was picked for — at 13.5px it is well under the 24px large-text threshold, so the full 4.5:1 requirement still applies.

Dropping the `font-size` override puts the labels back at 15px. The colour is unchanged, so they stay visually secondary to the controls below them.

Both changes are CSS-only, in the same filter row, and verified on a live Nextcloud 34 instance running 6.6.0-rc.1.
