### PR TITLE
fix(editor): correct width and border of property select styling

### DIFF
--- a/src/styles/app-full.scss
+++ b/src/styles/app-full.scss
@@ -70,17 +70,8 @@
 		.v-select {
 			width: 100%;
 			margin: 0 !important;
-			overflow-x: hidden;
-
-			.vs__dropdown-toggle {
-				overflow-y: visible !important;
-			}
 		}
 	}
-}
-
-.vs__selected-options {
-	max-width: calc(100% - var(--default-clickable-area) - var(--default-grid-baseline));
 }
 
 .property-repeat__summary__content {


### PR DESCRIPTION
Styling broke after update of nextcloud/vue@9.9.0 to @9.10.0

I will look into height alignment after this.

#### Before 9.10

<img width="1844" height="1263" alt="image" src="https://github.com/user-attachments/assets/2b8d9979-07b3-4ee4-8240-0b23ca74e82e" />

#### On `main`

<img width="1844" height="1263" alt="image" src="https://github.com/user-attachments/assets/9401ab14-b267-4c24-a6a0-6e998cd936e1" />

#### With this PR

<img width="1844" height="1263" alt="image" src="https://github.com/user-attachments/assets/a4abf4d6-0613-4137-b370-d25446eecc06" />

