### PR TITLE
feat(calendars): add per-calendar notification muting toggle

### DIFF
--- a/src/components/AppNavigation/CalendarList/CalendarListItem.vue
+++ b/src/components/AppNavigation/CalendarList/CalendarListItem.vue
@@ -18,6 +18,7 @@ import {
 	NcAvatar,
 } from '@nextcloud/vue'
 import { computed, ref } from 'vue'
+import BellOffOutline from 'vue-material-design-icons/BellOffOutline.vue'
 import CheckboxBlank from 'vue-material-design-icons/CheckboxBlankOutline.vue'
 import CheckboxMarked from 'vue-material-design-icons/CheckboxMarked.vue'
 import ContentCopy from 'vue-material-design-icons/ContentCopy.vue'
@@ -173,6 +174,7 @@ async function copyPublicLink(): Promise<void> {
 		showError(t('calendar', 'Calendar link could not be copied to clipboard.'))
 	}
 }
+
 </script>
 
 <template>
@@ -197,7 +199,8 @@ async function copyPublicLink(): Promise<void> {
 		</template>
 
 		<template #counter>
-			<LinkVariant v-if="isSharedByMe" :size="20" />
+			<BellOffOutline v-if="calendar.disableAlarmNotifications" :size="20" :title="t('calendar', 'Notifications muted')" />
+			<LinkVariant v-else-if="isSharedByMe" :size="20" />
 			<NcAvatar
 				v-else-if="isDelegated && loadedDelegatorPrincipal && !actionsMenuOpen"
 				:user="delegatorUserId"

--- a/src/components/AppNavigation/EditCalendarModal.vue
+++ b/src/components/AppNavigation/EditCalendarModal.vue
@@ -43,6 +43,9 @@
 					{{ $t('calendar', 'Never show me as busy (set this calendar to transparent)') }}
 				</NcCheckboxRadioSwitch>
 			</template>
+			<NcCheckboxRadioSwitch v-if="isAfterVersion36" v-model="disableAlarmNotifications">
+				{{ $t('calendar', 'Disable alarm notifications for this calendar') }}
+			</NcCheckboxRadioSwitch>
 			<template v-if="!calendar.isSharedWithMe && isAfterVersion">
 				<div class="edit-calendar-modal__default-alarm">
 					<label for="default-alarm-partday-select" class="edit-calendar-modal__default-alarm__label">
@@ -170,6 +173,7 @@ export default {
 			calendarColor: undefined,
 			calendarColorChanged: false,
 			isTransparent: false,
+			disableAlarmNotifications: false,
 			calendarName: undefined,
 			calendarNameChanged: false,
 			selectedDefaultAlarmPartDay: null,
@@ -330,6 +334,15 @@ export default {
 		isAfterVersion() {
 			return isAfterVersion(34)
 		},
+
+		/**
+		 * Whether the per-calendar disable alarm notifications feature is supported (Nextcloud 36+)
+		 *
+		 * @return {boolean}
+		 */
+		isAfterVersion36() {
+			return isAfterVersion(36)
+		},
 	},
 
 	watch: {
@@ -343,6 +356,7 @@ export default {
 			this.calendarNameChanged = false
 			this.calendarColorChanged = false
 			this.isTransparent = calendar.transparency === 'transparent'
+			this.disableAlarmNotifications = calendar.disableAlarmNotifications || false
 
 			// Initialize default alarm for part-day events
 			if (calendar.defaultAlarmPartDay === null) {
@@ -448,6 +462,24 @@ export default {
 		},
 
 		/**
+		 * Save the calendar disableAlarmNotifications preference.
+		 */
+		async saveDisableAlarmNotifications() {
+			try {
+				await this.calendarsStore.changeCalendarDisableAlarmNotifications({
+					calendar: this.calendar,
+					disableAlarmNotifications: this.disableAlarmNotifications,
+				})
+			} catch (error) {
+				logger.error('Failed to save calendar disable alarm notifications preference', {
+					calendar: this.calendar,
+					error,
+				})
+				throw error
+			}
+		},
+
+		/**
 		 * Save unsaved changes and close the modal.
 		 *
 		 * @return {Promise<void>}
@@ -461,6 +493,9 @@ export default {
 					await this.saveColor()
 				}
 				await this.saveTransparency()
+				if (this.isAfterVersion36) {
+					await this.saveDisableAlarmNotifications()
+				}
 				if (this.calendarNameChanged) {
 					await this.saveName()
 				}

--- a/src/models/calendar.js
+++ b/src/models/calendar.js
@@ -72,6 +72,8 @@ function getDefaultCalendarObject(props = {}) {
 		defaultAlarmPartDay: null,
 		// Default alarm/reminder for full-day events in seconds (null if disabled)
 		defaultAlarmFullDay: null,
+		// Whether alarm notifications/reminders are disabled for this calendar
+		disableAlarmNotifications: false,
 		...props,
 	}
 }
@@ -117,6 +119,7 @@ function mapDavCollectionToCalendar(calendar, currentUserPrincipal) {
 	const defaultAlarmPartDay = isAfterVersion(34) && calendar.defaultAlarmPartDay !== undefined ? calendar.defaultAlarmPartDay : null
 	// Default alarm for full-day events in this calendar (in seconds)
 	const defaultAlarmFullDay = isAfterVersion(34) && calendar.defaultAlarmFullDay !== undefined ? calendar.defaultAlarmFullDay : null
+	const disableAlarmNotifications = isAfterVersion(36) && calendar.disableAlarmNotifications !== undefined ? Boolean(calendar.disableAlarmNotifications) : false
 
 	// If the user is not authenticated, the calendar
 	// will always be marked as shared with them
@@ -172,6 +175,7 @@ function mapDavCollectionToCalendar(calendar, currentUserPrincipal) {
 		transparency,
 		defaultAlarmPartDay,
 		defaultAlarmFullDay,
+		disableAlarmNotifications,
 		dav: calendar,
 	})
 }

--- a/src/store/calendars.js
+++ b/src/store/calendars.js
@@ -641,6 +641,30 @@ export default defineStore('calendars', {
 		},
 
 		/**
+		 * Change whether alarm notifications are disabled for a calendar
+		 *
+		 * @param {object} data destructuring object
+		 * @param {object} data.calendar the calendar to modify
+		 * @param {boolean} data.disableAlarmNotifications whether alarm notifications should be disabled
+		 * @return {Promise}
+		 */
+		async changeCalendarDisableAlarmNotifications({ calendar, disableAlarmNotifications }) {
+			const disableAlarmNotificationsChanged = calendar.disableAlarmNotifications !== disableAlarmNotifications
+
+			if (!disableAlarmNotificationsChanged) {
+				return
+			}
+
+			calendar.dav.disableAlarmNotifications = disableAlarmNotifications
+
+			await calendar.dav.update()
+
+			if (this.calendarsById[calendar.id]) {
+				this.calendarsById[calendar.id].disableAlarmNotifications = disableAlarmNotifications
+			}
+		},
+
+		/**
 		 * Share calendar with User or Group
 		 *
 		 * @param {object} data destructuring object

--- a/src/types/calendar.ts
+++ b/src/types/calendar.ts
@@ -101,6 +101,8 @@ export interface CalendarInterface {
 	defaultAlarmPartDay: number | null
 	/** Default alarm/reminder for full-day events in seconds (null if disabled) */
 	defaultAlarmFullDay: number | null
+	/** Whether alarm notifications/reminders are disabled for this calendar */
+	disableAlarmNotifications: boolean
 	/** Handle of the countdown interval while the calendar is pending deletion */
 	deleteInterval?: ReturnType<typeof setInterval>
 	/** Seconds remaining until a pending deletion is executed */

--- a/tests/javascript/unit/models/calendar.test.js
+++ b/tests/javascript/unit/models/calendar.test.js
@@ -44,6 +44,7 @@ describe('Test suite: Calendar model (models/calendar.js)', () => {
 			transparency: 'opaque',
 			defaultAlarmFullDay: null,
 			defaultAlarmPartDay: null,
+			disableAlarmNotifications: false,
 			delegatorUrl: '',
 		})
 	})
@@ -82,6 +83,7 @@ describe('Test suite: Calendar model (models/calendar.js)', () => {
 			transparency: 'opaque',
 			defaultAlarmFullDay: null,
 			defaultAlarmPartDay: null,
+			disableAlarmNotifications: false,
 			delegatorUrl: '',
 		})
 	})
@@ -135,6 +137,7 @@ describe('Test suite: Calendar model (models/calendar.js)', () => {
 			loading: false,
 			defaultAlarmFullDay: null,
 			defaultAlarmPartDay: null,
+			disableAlarmNotifications: false,
 			delegatorUrl: '',
 		})
 
@@ -190,6 +193,7 @@ describe('Test suite: Calendar model (models/calendar.js)', () => {
 			loading: false,
 			defaultAlarmFullDay: null,
 			defaultAlarmPartDay: null,
+			disableAlarmNotifications: false,
 			delegatorUrl: '',
 		})
 
@@ -243,6 +247,7 @@ describe('Test suite: Calendar model (models/calendar.js)', () => {
 			loading: false,
 			defaultAlarmFullDay: null,
 			defaultAlarmPartDay: null,
+			disableAlarmNotifications: false,
 			delegatorUrl: '',
 		})
 
@@ -296,6 +301,7 @@ describe('Test suite: Calendar model (models/calendar.js)', () => {
 			loading: false,
 			defaultAlarmFullDay: null,
 			defaultAlarmPartDay: null,
+			disableAlarmNotifications: false,
 			delegatorUrl: '',
 		})
 
@@ -349,6 +355,7 @@ describe('Test suite: Calendar model (models/calendar.js)', () => {
 			loading: false,
 			defaultAlarmFullDay: null,
 			defaultAlarmPartDay: null,
+			disableAlarmNotifications: false,
 			delegatorUrl: '',
 		})
 
@@ -402,6 +409,7 @@ describe('Test suite: Calendar model (models/calendar.js)', () => {
 			loading: false,
 			defaultAlarmFullDay: null,
 			defaultAlarmPartDay: null,
+			disableAlarmNotifications: false,
 			delegatorUrl: '',
 		})
 
@@ -455,6 +463,7 @@ describe('Test suite: Calendar model (models/calendar.js)', () => {
 			loading: false,
 			defaultAlarmFullDay: null,
 			defaultAlarmPartDay: null,
+			disableAlarmNotifications: false,
 			delegatorUrl: '',
 		})
 
@@ -508,6 +517,7 @@ describe('Test suite: Calendar model (models/calendar.js)', () => {
 			loading: false,
 			defaultAlarmFullDay: null,
 			defaultAlarmPartDay: null,
+			disableAlarmNotifications: false,
 			delegatorUrl: '',
 		})
 
@@ -617,6 +627,7 @@ describe('Test suite: Calendar model (models/calendar.js)', () => {
 			loading: false,
 			defaultAlarmFullDay: null,
 			defaultAlarmPartDay: null,
+			disableAlarmNotifications: false,
 			delegatorUrl: '',
 		})
 
@@ -742,6 +753,7 @@ describe('Test suite: Calendar model (models/calendar.js)', () => {
 			loading: false,
 			defaultAlarmFullDay: null,
 			defaultAlarmPartDay: null,
+			disableAlarmNotifications: false,
 			delegatorUrl: '',
 		})
 
@@ -796,6 +808,7 @@ describe('Test suite: Calendar model (models/calendar.js)', () => {
 			loading: false,
 			defaultAlarmFullDay: null,
 			defaultAlarmPartDay: null,
+			disableAlarmNotifications: false,
 			delegatorUrl: '',
 		})
 	})


### PR DESCRIPTION
## Summary
Adds frontend UI controls to mute/unmute notifications per calendar.

* Resolves: https://github.com/nextcloud/calendar/issues/6390
* Requires: https://github.com/nextcloud/cdav-library/pull/1088
* Requires: https://github.com/nextcloud/server/pull/63774

- UI checkbox toggle in `EditCalendarModal.vue`.
- Context menu action & muted bell icon (`BellOffOutline`) in `CalendarListItem.vue`.
- Model and Pinia store integration mapping `{http://nextcloud.com/ns}ignore-reminders`.

## Checklist

- Code is properly formatted
- Sign-off message is added to all commits
- [x] Tests are included or not required for simple UI bindings
- [x] Documentation has been updated or is not required