### PR TITLE
fix: do not re-enable disabled default reminders because of legacy default reminder settings

### DIFF
--- a/src/utils/alarms.js
+++ b/src/utils/alarms.js
@@ -282,7 +282,11 @@ export function getDefaultReminderForEvent({ calendar, isAllDay }) {
 		}
 	}
 
-	const globalDefaultReminder = parseInt(isAllDay ? settingsStore.defaultReminderFullDay : settingsStore.defaultReminderPartDay)
+	const globalDefaultReminderRaw = isAllDay ? settingsStore.defaultReminderFullDay : settingsStore.defaultReminderPartDay
+	if (globalDefaultReminderRaw === 'none') {
+		return null
+	}
+	const globalDefaultReminder = parseInt(globalDefaultReminderRaw)
 	if (!isNaN(globalDefaultReminder)) {
 		return globalDefaultReminder
 	}

--- a/tests/javascript/unit/utils/alarms.test.js
+++ b/tests/javascript/unit/utils/alarms.test.js
@@ -3,9 +3,12 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 import { getParserManager } from '@nextcloud/calendar-js'
+import { createPinia, setActivePinia } from 'pinia'
+import useSettingsStore from '@/store/settings.js'
 import {
 	getAmountAndUnitForTimedEvents,
 	getAmountHoursMinutesAndUnitForAllDayEvents,
+	getDefaultReminderForEvent,
 	getFactorForAlarmUnit,
 	getTotalSecondsFromAmountAndUnitForTimedEvents,
 	getTotalSecondsFromAmountHourMinutesAndUnitForAllDayEvents,
@@ -263,6 +266,51 @@ describe('utils/alarms test suite', () => {
 
 			const alarm = event.getAlarmIterator().next().value
 			expect([...alarm.getPropertyIterator('ATTENDEE')]).toHaveLength(1)
+		})
+	})
+
+	describe('getDefaultReminderForEvent', () => {
+		let settingsStore
+
+		beforeEach(() => {
+			setActivePinia(createPinia())
+			settingsStore = useSettingsStore()
+		})
+
+		it('enabled part day reminder overrides legacy reminder', () => {
+			settingsStore.defaultReminder = '0'
+			settingsStore.defaultReminderPartDay = '3600'
+
+			const reminder = getDefaultReminderForEvent({ isAllDay: false })
+
+			expect(reminder).toBe(3600)
+		})
+
+		it('enabled full day reminder overrides legacy reminder', () => {
+			settingsStore.defaultReminder = '0'
+			settingsStore.defaultReminderFullDay = '3600'
+
+			const reminder = getDefaultReminderForEvent({ isAllDay: true })
+
+			expect(reminder).toBe(3600)
+		})
+
+		it('disabled part day reminder overrides legacy reminder', () => {
+			settingsStore.defaultReminder = '0'
+			settingsStore.defaultReminderPartDay = 'none'
+
+			const reminder = getDefaultReminderForEvent({ isAllDay: false })
+
+			expect(reminder).toBe(null)
+		})
+
+		it('disabled full day reminder overrides legacy reminder', () => {
+			settingsStore.defaultReminder = '0'
+			settingsStore.defaultReminderFullDay = 'none'
+
+			const reminder = getDefaultReminderForEvent({ isAllDay: true })
+
+			expect(reminder).toBe(null)
 		})
 	})
 })


### PR DESCRIPTION
Resolves #8816

### Given

- `php occ user:setting <userId> calendar defaultReminder 0`
- <img width="1123" height="334" alt="Screenshot From 2026-08-31 14-43-04" src="https://github.com/user-attachments/assets/ccdc28c7-0294-4345-86c2-b76778b11692" />


### Before

<img width="1024" height="334" alt="Screenshot From 2026-08-31 14-43-15" src="https://github.com/user-attachments/assets/6571c285-1ec7-4ca3-975f-10a1f3c49c8a" />

### After

<img width="1019" height="271" alt="Screenshot From 2026-08-31 14-43-33" src="https://github.com/user-attachments/assets/ad943002-2d64-412e-96cd-4a7255a2f755" />

