### PR TITLE
Set task start to allow visualization as regular event (take 2)

### DIFF
--- a/src/components/CalendarGrid.vue
+++ b/src/components/CalendarGrid.vue
@@ -420,22 +420,6 @@ export default {
 </script>
 
 <style scoped lang="scss">
-.calendar-grid-checkbox {
-	border-style: solid;
-	border-width: 2px;
-	border-radius: 4px;
-	height: 16px;
-	width: 16px;
-}
-
-.calendar-grid-checkbox-checked {
-	border-style: solid;
-	border-width: 8px;
-	border-radius: 4px;
-	height: 16px;
-	width: 16px;
-}
-
 .fullcalendar-widget{
 	min-height: 500px;
 	:deep(.fc-col-header-cell-cushion){

--- a/src/fullcalendar/eventSources/eventSourceFunction.js
+++ b/src/fullcalendar/eventSources/eventSourceFunction.js
@@ -95,12 +95,33 @@ export function eventSourceFunction(calendarObjects, calendar, start, end, timez
 				// if there is no due date, we store the task in the
 				// tasksstore, so user can add it to the calendar if
 				// he wants
-				if (object.endDate === null) {
-					jsStart = null
-					jsEnd = null
-				} else {
-					jsStart = object.endDate.getInTimezone(timezone).jsDate
+				jsStart = null
+				jsEnd = null
+				// Pick up the start and end dates if available.
+				if (object.startDate) {
+					jsStart = object.startDate.getInTimezone(timezone).jsDate
+				}
+				if (object.endDate) {
 					jsEnd = object.endDate.getInTimezone(timezone).jsDate
+				}
+				let hasOnlyOneDate = false
+				if (jsStart === null && jsEnd !== null) {
+					// Task has no start date.  Display the start
+					// of the task as its due date.
+					jsStart = new Date(jsEnd)
+					hasOnlyOneDate = true
+				} else if (jsStart !== null && jsEnd === null) {
+					// Task has no due date.  Display the end of
+					// the task as its start date.
+					jsEnd = new Date(jsStart)
+					hasOnlyOneDate = true
+				}
+				if (hasOnlyOneDate && !object.isAllDay()) {
+					// A timed task with only one date would otherwise render as
+					// a zero-length slot in the time grid, too short for its
+					// checkbox and title to be legible. Give it a visible
+					// minimum span instead.
+					jsEnd = new Date(jsEnd.getTime() + 30 * 60 * 1000)
 				}
 			} else {
 				// We do not want to display anything that's neither
@@ -198,7 +219,7 @@ export function eventSourceFunction(calendarObjects, calendar, start, end, timez
 				}
 			}
 
-			if (object.name === 'VTODO' && object.endDate === null && object.percent !== 100 && object.status !== 'COMPLETED') {
+			if (object.name === 'VTODO' && object.startDate === null && object.endDate === null && object.percent !== 100 && object.status !== 'COMPLETED') {
 				fcEvent.create = true
 				tasksStore.appendTask(calendar.id, fcEvent)
 			} else {

--- a/src/fullcalendar/rendering/eventDidMount.js
+++ b/src/fullcalendar/rendering/eventDidMount.js
@@ -152,9 +152,9 @@ export default errorCatch(function({ event, el }) {
 			dotElement.style.color = 'var(--color-main-text)'
 
 			if (event.extendedProps.percent === 100) {
-				dotElement.classList.add('calendar-grid-checkbox-checked')
+				dotElement.classList.add('fc-task-checkbox--checked')
 			} else {
-				dotElement.classList.add('calendar-grid-checkbox')
+				dotElement.classList.add('fc-task-checkbox')
 			}
 		} else if (el.classList.contains('fc-daygrid-dot-event')) {
 			// Dot event in day grid view
@@ -164,9 +164,9 @@ export default errorCatch(function({ event, el }) {
 			dotElement.style.color = 'var(--color-main-text)'
 
 			if (event.extendedProps.percent === 100) {
-				dotElement.classList.add('calendar-grid-checkbox-checked')
+				dotElement.classList.add('fc-task-checkbox--checked')
 			} else {
-				dotElement.classList.add('calendar-grid-checkbox')
+				dotElement.classList.add('fc-task-checkbox')
 			}
 		} else {
 			// AgendaView and all-day grid view
@@ -174,9 +174,9 @@ export default errorCatch(function({ event, el }) {
 			const checkboxElement = document.createElement('div')
 			checkboxElement.classList.add('fc-event-title-checkbox')
 			if (event.extendedProps.percent === 100) {
-				checkboxElement.classList.add('calendar-grid-checkbox-checked')
+				checkboxElement.classList.add('fc-task-checkbox--checked')
 			} else {
-				checkboxElement.classList.add('calendar-grid-checkbox')
+				checkboxElement.classList.add('fc-task-checkbox')
 			}
 
 			titleContainer.prepend(checkboxElement)

--- a/src/styles/fullcalendar.scss
+++ b/src/styles/fullcalendar.scss
@@ -213,6 +213,22 @@
 		}
 	}
 
+	.fc-task-checkbox {
+		border-style: solid;
+		border-width: 2px;
+		border-radius: 4px;
+		height: 16px;
+		width: 16px;
+	}
+
+	.fc-task-checkbox--checked {
+		border-style: solid;
+		border-width: 8px;
+		border-radius: 4px;
+		height: 16px;
+		width: 16px;
+	}
+
 	.fc-list-event-checkbox {
 		margin: 2px 4px 0 -2px;
 		line-height: 1;

--- a/tests/javascript/unit/fullcalendar/eventSources/freeBusyResourceEventSourceFunction.test.js
+++ b/tests/javascript/unit/fullcalendar/eventSources/freeBusyResourceEventSourceFunction.test.js
@@ -442,6 +442,7 @@ describe('fullcalendar/freeBusyResourceEventSourceFunction test suite', () => {
 		const event4End = new Date(2020, 5, 6, 0, 0, 0, 0)
 		const event5Start = new Date(2020, 6, 10, 10, 0, 0, 0)
 		const event5End = new Date(2020, 6, 10, 10, 0, 0, 0)
+		const event6Start = new Date(2020, 7, 1, 9, 0, 0, 0)
 
 		const eventComponentSet = [{
 			name: 'VTODO',
@@ -564,6 +565,23 @@ describe('fullcalendar/freeBusyResourceEventSourceFunction test suite', () => {
 			percent: null,
 			getFirstPropertyFirstValue: vi.fn().mockReturnValue(null),
 			getPropertyIterator: vi.fn().mockReturnValue([]),
+		}, {
+			name: 'VTODO',
+			id: '7',
+			isAllDay: vi.fn().mockReturnValue(false),
+			getReferenceRecurrenceId: vi.fn().mockReturnValue({ unixTime: 123 }),
+			canModifyAllDay: vi.fn().mockReturnValue(false),
+			startDate: {
+				getInTimezone: vi.fn().mockReturnValue({
+					jsDate: event6Start,
+				}),
+			},
+			endDate: null,
+			hasComponent: vi.fn().mockReturnValue(false),
+			title: 'Task without Due but with a start date',
+			percent: null,
+			getFirstPropertyFirstValue: vi.fn().mockReturnValue(null),
+			getPropertyIterator: vi.fn().mockReturnValue([]),
 		}]
 
 		getAllObjectsInTimeRange
@@ -607,7 +625,7 @@ describe('fullcalendar/freeBusyResourceEventSourceFunction test suite', () => {
 				attendeeCount: 0,
 			},
 			id: '1###1',
-			start: event1End,
+			start: event1Start,
 			title: 'Untitled task',
 		}, {
 			allDay: false,
@@ -631,7 +649,7 @@ describe('fullcalendar/freeBusyResourceEventSourceFunction test suite', () => {
 				attendeeCount: 0,
 			},
 			id: '1###2',
-			start: event2End,
+			start: event2Start,
 			title: 'Untitled task',
 		}, {
 			allDay: false,
@@ -655,7 +673,7 @@ describe('fullcalendar/freeBusyResourceEventSourceFunction test suite', () => {
 				attendeeCount: 0,
 			},
 			id: '1###3',
-			start: event3End,
+			start: event3Start,
 			title: 'Untitled task (99%)',
 		}, {
 			allDay: false,
@@ -679,7 +697,7 @@ describe('fullcalendar/freeBusyResourceEventSourceFunction test suite', () => {
 				attendeeCount: 0,
 			},
 			id: '1###4',
-			start: event4End,
+			start: event4Start,
 			title: 'This task has a title',
 		}, {
 			allDay: false,
@@ -703,30 +721,57 @@ describe('fullcalendar/freeBusyResourceEventSourceFunction test suite', () => {
 				attendeeCount: 0,
 			},
 			id: '1###5',
-			start: event5End,
+			start: event5Start,
 			title: 'This task has a title and percent (99%)',
+		}, {
+			allDay: false,
+			classNames: [
+				'fc-event-nc-task',
+			],
+			end: new Date(event6Start.getTime() + 30 * 60 * 1000),
+			extendedProps: {
+				calendarId: 'Calendar id 456',
+				calendarName: 'Calendar displayname',
+				calendarOrder: 1337,
+				canModifyAllDay: false,
+				davUrl: 'url1',
+				objectId: '1',
+				vobjectId: '7',
+				objectType: 'VTODO',
+				percent: null,
+				recurrenceId: 123,
+				description: undefined,
+				location: undefined,
+				attendeeCount: 0,
+			},
+			id: '1###7',
+			start: event6Start,
+			title: 'Task without Due but with a start date',
 		}])
 
-		expect(eventComponentSet[0].startDate.getInTimezone).toHaveBeenCalledTimes(0)
-		expect(eventComponentSet[0].endDate.getInTimezone).toHaveBeenCalledTimes(2)
+		expect(eventComponentSet[6].startDate.getInTimezone).toHaveBeenCalledTimes(1)
+		expect(eventComponentSet[6].startDate.getInTimezone).toHaveBeenNthCalledWith(1, timezone)
+
+		expect(eventComponentSet[0].startDate.getInTimezone).toHaveBeenCalledTimes(1)
+		expect(eventComponentSet[0].startDate.getInTimezone).toHaveBeenNthCalledWith(1, timezone)
+		expect(eventComponentSet[0].endDate.getInTimezone).toHaveBeenCalledTimes(1)
 		expect(eventComponentSet[0].endDate.getInTimezone).toHaveBeenNthCalledWith(1, timezone)
-		expect(eventComponentSet[0].endDate.getInTimezone).toHaveBeenNthCalledWith(2, timezone)
-		expect(eventComponentSet[1].startDate.getInTimezone).toHaveBeenCalledTimes(0)
-		expect(eventComponentSet[1].endDate.getInTimezone).toHaveBeenCalledTimes(2)
+		expect(eventComponentSet[1].startDate.getInTimezone).toHaveBeenCalledTimes(1)
+		expect(eventComponentSet[1].startDate.getInTimezone).toHaveBeenNthCalledWith(1, timezone)
+		expect(eventComponentSet[1].endDate.getInTimezone).toHaveBeenCalledTimes(1)
 		expect(eventComponentSet[1].endDate.getInTimezone).toHaveBeenNthCalledWith(1, timezone)
-		expect(eventComponentSet[1].endDate.getInTimezone).toHaveBeenNthCalledWith(2, timezone)
-		expect(eventComponentSet[2].startDate.getInTimezone).toHaveBeenCalledTimes(0)
-		expect(eventComponentSet[2].endDate.getInTimezone).toHaveBeenCalledTimes(2)
+		expect(eventComponentSet[2].startDate.getInTimezone).toHaveBeenCalledTimes(1)
+		expect(eventComponentSet[2].startDate.getInTimezone).toHaveBeenNthCalledWith(1, timezone)
+		expect(eventComponentSet[2].endDate.getInTimezone).toHaveBeenCalledTimes(1)
 		expect(eventComponentSet[2].endDate.getInTimezone).toHaveBeenNthCalledWith(1, timezone)
-		expect(eventComponentSet[2].endDate.getInTimezone).toHaveBeenNthCalledWith(2, timezone)
-		expect(eventComponentSet[3].startDate.getInTimezone).toHaveBeenCalledTimes(0)
-		expect(eventComponentSet[3].endDate.getInTimezone).toHaveBeenCalledTimes(2)
+		expect(eventComponentSet[3].startDate.getInTimezone).toHaveBeenCalledTimes(1)
+		expect(eventComponentSet[3].startDate.getInTimezone).toHaveBeenNthCalledWith(1, timezone)
+		expect(eventComponentSet[3].endDate.getInTimezone).toHaveBeenCalledTimes(1)
 		expect(eventComponentSet[3].endDate.getInTimezone).toHaveBeenNthCalledWith(1, timezone)
-		expect(eventComponentSet[3].endDate.getInTimezone).toHaveBeenNthCalledWith(2, timezone)
-		expect(eventComponentSet[4].startDate.getInTimezone).toHaveBeenCalledTimes(0)
-		expect(eventComponentSet[4].endDate.getInTimezone).toHaveBeenCalledTimes(2)
+		expect(eventComponentSet[4].startDate.getInTimezone).toHaveBeenCalledTimes(1)
+		expect(eventComponentSet[4].startDate.getInTimezone).toHaveBeenNthCalledWith(1, timezone)
+		expect(eventComponentSet[4].endDate.getInTimezone).toHaveBeenCalledTimes(1)
 		expect(eventComponentSet[4].endDate.getInTimezone).toHaveBeenNthCalledWith(1, timezone)
-		expect(eventComponentSet[4].endDate.getInTimezone).toHaveBeenNthCalledWith(2, timezone)
 
 		expect(translate).toHaveBeenCalledTimes(3)
 		expect(translate).toHaveBeenNthCalledWith(1, 'calendar', 'Untitled task')


### PR DESCRIPTION
Intended to supersede https://github.com/nextcloud/calendar/pull/3033 which appears abandoned by an author no longer active on Github.

Fixes https://github.com/nextcloud/calendar/issues/2669 and https://github.com/nextcloud/calendar/issues/8824 .

