### PR TITLE
[stable6.6] fix(deps): update dependency @nextcloud/vue to ^9.11.0 (stable6.6)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
         "@nextcloud/notify_push": "^1.4.0",
         "@nextcloud/router": "^3.1.0",
         "@nextcloud/timezones": "^1.0.2",
-        "@nextcloud/vue": "^9.10.0",
+        "@nextcloud/vue": "^9.11.0",
         "autosize": "^6.0.1",
         "color-convert": "^3.1.3",
         "color-string": "^2.1.4",
@@ -1599,9 +1599,9 @@
       }
     },
     "node_modules/@nextcloud/vue": {
-      "version": "9.10.0",
-      "resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-9.10.0.tgz",
-      "integrity": "sha512-Za9O6ZpRNmjMuKPgiUDg98lY4+sFasemaPY6h7rti4H4An9VglKjL7l/YZh3criJLfhoDL6ACMwZiNcvFV626A==",
+      "version": "9.11.0",
+      "resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-9.11.0.tgz",
+      "integrity": "sha512-LRsyU9Mxs0b2xWqbxygps8O7/i1z4QhNQD9/QDni+VqFY3V0N95mAgmKJm6vfoFuxTAMXERp9bjqFn3UV542gw==",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@ckpack/vue-color": "^1.6.0",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "@nextcloud/notify_push": "^1.4.0",
     "@nextcloud/router": "^3.1.0",
     "@nextcloud/timezones": "^1.0.2",
-    "@nextcloud/vue": "^9.10.0",
+    "@nextcloud/vue": "^9.11.0",
     "autosize": "^6.0.1",
     "color-convert": "^3.1.3",
     "color-string": "^2.1.4",


### PR DESCRIPTION
Mainly updating to get the fixes

 - https://github.com/nextcloud-libraries/nextcloud-vue/pull/8657 
 - https://github.com/nextcloud-libraries/nextcloud-vue/pull/8884
 
 The other fixes and features are bonus goodies.
