### PR TITLE
Fix icon usage

### DIFF
--- a/src/components/AppNavigation/AppNavigationHeader/AppNavigationHeaderViewMenu.vue
+++ b/src/components/AppNavigation/AppNavigationHeader/AppNavigationHeaderViewMenu.vue
@@ -82,7 +82,6 @@ useHotKey(['l', '5'], () => selectView('listMonth'))
 			<NcActionButton
 				v-for="view in views"
 				:key="view.id"
-				:icon="view.icon"
 				:closeAfterClick="true"
 				@click="selectView(view.id)">
 				<template #icon>

--- a/src/components/AppNavigation/CalendarList/CalendarListNew.vue
+++ b/src/components/AppNavigation/CalendarList/CalendarListNew.vue
@@ -291,10 +291,8 @@ function closeMenu(): void {
 					</template>
 				</ActionInput>
 				<ActionText
-					v-if="showCreateCalendarSaving">
-					<template #icon>
-						<div class="icon icon-loading-small" />
-					</template>
+					v-if="showCreateCalendarSaving"
+					icon="icon-loading-small">
 					{{ t('calendar', 'Creating calendar …') }}
 				</ActionText>
 
@@ -315,10 +313,8 @@ function closeMenu(): void {
 					</template>
 				</ActionInput>
 				<ActionText
-					v-if="showCreateCalendarTaskListSaving">
-					<template #icon>
-						<div class="icon icon-loading-small" />
-					</template>
+					v-if="showCreateCalendarTaskListSaving"
+					icon="icon-loading-small">
 					{{ t('calendar', 'Creating calendar …') }}
 				</ActionText>
 
@@ -340,10 +336,8 @@ function closeMenu(): void {
 					</template>
 				</ActionInput>
 				<ActionText
-					v-if="showCreateSubscriptionSaving">
-					<template #icon>
-						<div class="icon icon-loading-small" />
-					</template>
+					v-if="showCreateSubscriptionSaving"
+					icon="icon-loading-small">
 					{{ t('calendar', 'Creating subscription …') }}
 				</ActionText>
 				<ActionButton

--- a/src/components/AppNavigation/CalendarList/PublicCalendarListItem.vue
+++ b/src/components/AppNavigation/CalendarList/PublicCalendarListItem.vue
@@ -129,10 +129,8 @@ async function copySubscriptionLink(): Promise<void> {
 				{{ t('calendar', 'Copy subscription link') }}
 			</ActionButton>
 			<ActionText
-				v-if="showCopySubscriptionLinkSpinner">
-				<template #icon>
-					<div class="icon icon-loading-small" />
-				</template>
+				v-if="showCopySubscriptionLinkSpinner"
+				icon="icon-loading-small">
 				{{ t('calendar', 'Copying link …') }}
 			</ActionText>
 			<ActionText v-if="showCopySubscriptionLinkSuccess">

--- a/src/components/AppNavigation/CalendarList/Trashbin.vue
+++ b/src/components/AppNavigation/CalendarList/Trashbin.vue
@@ -21,15 +21,18 @@
 					<h2>{{ t('calendar', 'Trash bin') }}</h2>
 					<NcEmptyContent
 						v-if="loading"
-						icon="icon-loading"
 						class="modal__content__loading"
-						:description="t('calendar', 'Loading deleted items.')" />
+						:description="t('calendar', 'Loading deleted items.')">
+						<template #icon>
+							<NcLoadingIcon decorative />
+						</template>
+					</NcEmptyContent>
 					<NcEmptyContent
 						v-else-if="!items.length"
 						class="modal__content__empty"
 						:description="t('calendar', 'You do not have any deleted items.')">
 						<template #icon>
-							<IconDelete :size="20" decorative />
+							<IconDelete decorative />
 						</template>
 					</NcEmptyContent>
 					<template v-else>
@@ -112,6 +115,7 @@ import {
 	NcButton,
 	NcDateTime,
 	NcEmptyContent,
+	NcLoadingIcon,
 	NcModal,
 } from '@nextcloud/vue'
 import { mapState, mapStores } from 'pinia'
@@ -132,6 +136,7 @@ export default {
 		NcEmptyContent,
 		NcModal,
 		IconDelete,
+		NcLoadingIcon,
 	},
 
 	data() {

--- a/src/components/AppNavigation/Settings/SettingsDelegationSection.vue
+++ b/src/components/AppNavigation/Settings/SettingsDelegationSection.vue
@@ -14,9 +14,12 @@
 			:description="t('calendar', 'Allow users to manage your calendar events and invitations on your behalf.')">
 			<NcEmptyContent
 				v-if="loading"
-				icon="icon-loading"
 				class="delegation-settings__loading"
-				:description="t('calendar', 'Loading delegates\u2026')" />
+				:description="t('calendar', 'Loading delegates\u2026')">
+				<template #icon>
+					<NcLoadingIcon decorative />
+				</template>
+			</NcEmptyContent>
 			<ul v-else class="delegation-settings__list">
 				<NcListItem
 					v-for="delegate in delegationStore.delegates"

--- a/src/components/AppointmentConfigModal/Confirmation.vue
+++ b/src/components/AppointmentConfigModal/Confirmation.vue
@@ -45,7 +45,7 @@ async function copyLink(): Promise<void> {
 	<div class="app-config-modal-confirmation">
 		<EmptyContent :name="title">
 			<template #icon>
-				<CheckIcon />
+				<CheckIcon decorative />
 			</template>
 		</EmptyContent>
 		<div class="app-config-modal-confirmation__buttons">

--- a/src/components/Editor/AddTalkModal.vue
+++ b/src/components/Editor/AddTalkModal.vue
@@ -12,9 +12,12 @@
 		<div class="modal-content">
 			<NcEmptyContent
 				v-if="loading"
-				icon="icon-loading"
 				class="modal__content__loading"
-				:description="t('calendar', 'Fetching Talk rooms…')" />
+				:description="t('calendar', 'Fetching Talk rooms…')">
+				<template #icon>
+					<NcLoadingIcon decorative />
+				</template>
+			</NcEmptyContent>
 			<NcEmptyContent
 				v-else-if="talkConversations.length === 0"
 				:description="t('calendar', 'No Talk room available')" />
@@ -87,6 +90,7 @@ import {
 	NcFormBoxButton,
 	NcFormGroup,
 	NcListItem,
+	NcLoadingIcon,
 	NcModal,
 } from '@nextcloud/vue'
 import md5 from 'md5'
@@ -118,6 +122,7 @@ export default {
 		NcFormBoxButton,
 		NcListItem,
 		NcFormGroup,
+		NcLoadingIcon,
 	},
 
 	props: {

--- a/src/components/EmptyCalendar.vue
+++ b/src/components/EmptyCalendar.vue
@@ -8,7 +8,7 @@
 		:name="$t('calendar', 'Public calendar does not exist')"
 		:description="$t('calendar', 'Maybe the share was deleted or has expired?')">
 		<template #icon>
-			<CalendarBlank :size="20" decorative />
+			<CalendarBlank decorative />
 		</template>
 	</EmptyContent>
 </template>

--- a/src/components/Subscription/PublicCalendarSubscriptionPicker.vue
+++ b/src/components/Subscription/PublicCalendarSubscriptionPicker.vue
@@ -20,7 +20,7 @@
 				:title="$t('calendar', 'No valid public calendars configured')"
 				:description="$t('calendar', 'Contact your server administrator to resolve this issue.')">
 				<template #icon>
-					<CalendarBlank :size="20" decorative />
+					<CalendarBlank decorative />
 				</template>
 			</NcEmptyContent>
 			<p v-else-if="showHolidays" class="holiday-subscription-picker__attribution">

--- a/src/views/Appointments/Booking.vue
+++ b/src/views/Appointments/Booking.vue
@@ -45,7 +45,7 @@
 				<div class="booking__slot-selection">
 					<h5>{{ $t('calendar', 'Select slot') }}</h5>
 					<div class="booking__slots">
-						<Loading v-if="loadingSlots" class="loading" :size="24" />
+						<NcLoadingIcon v-if="loadingSlots" :size="24" />
 						<NcEmptyContent
 							v-else-if="slots.length === 0 && !loadingSlots"
 							:title="$t('calendar', 'No slots available')"
@@ -92,10 +92,9 @@ import {
 	NcDateTimePicker as DateTimePicker,
 	NcEmptyContent,
 	NcGuestContent,
+	NcLoadingIcon,
 	NcTimezonePicker as TimezonePicker,
 } from '@nextcloud/vue'
-import { h } from 'vue'
-import MDILoading from 'vue-material-design-icons/Loading.vue'
 import AppointmentBookingConfirmation from '@/components/Appointments/AppointmentBookingConfirmation.vue'
 import AppointmentDetails from '@/components/Appointments/AppointmentDetails.vue'
 import AppointmentSlot from '@/components/Appointments/AppointmentSlot.vue'
@@ -103,13 +102,6 @@ import { bookSlot, findSlots } from '@/services/appointmentService.js'
 import logger from '@/utils/logger.js'
 
 import '@nextcloud/dialogs/style.css'
-
-function Loading(props) {
-	return h(MDILoading, {
-		class: 'animation-rotate',
-		...props,
-	})
-}
 
 export default {
 	name: 'Booking',
@@ -121,8 +113,8 @@ export default {
 		AppointmentDetails,
 		AppointmentBookingConfirmation,
 		NcGuestContent,
-		Loading,
 		NcEmptyContent,
+		NcLoadingIcon,
 	},
 
 	props: {

--- a/src/views/EditFull.vue
+++ b/src/views/EditFull.vue
@@ -27,7 +27,7 @@
 			<template v-else-if="isError">
 				<NcEmptyContent :name="$t('calendar', 'Event does not exist')" :description="error">
 					<template #icon>
-						<CalendarBlank :size="20" decorative />
+						<CalendarBlank decorative />
 					</template>
 				</NcEmptyContent>
 			</template>

--- a/src/views/EditSimple.vue
+++ b/src/views/EditSimple.vue
@@ -46,7 +46,7 @@
 
 					<EmptyContent :name="$t('calendar', 'Event does not exist')" :description="error">
 						<template #icon>
-							<CalendarBlank :size="20" decorative />
+							<CalendarBlank decorative />
 						</template>
 					</EmptyContent>
 				</template>


### PR DESCRIPTION
Fixes some icon usage.
Includes small visual fixes for users and less warning in console for developers.
Commit messages include details on why changes needed to be made.

| Component | Before | After | Note |
|---|---|---|---|
| `NcActionButton` | <img width="266" height="473" alt="image" src="https://github.com/user-attachments/assets/e5a54dba-cd50-4cf8-856e-708c1fc62666" /> | <img width="266" height="473" alt="image" src="https://github.com/user-attachments/assets/f86b7804-dd78-4514-ad64-6b2f92563074" /> | No visual change |
| `NcActionButton` | Warning  `Invalid prop: type check failed for prop "icon". ... at <NcActionButton key="dayGridMonth" icon= ` | no warning | |
| replace `class: 'animation-rotate'` | <img width="1199" height="1264" alt="image" src="https://github.com/user-attachments/assets/85f7995b-7dfc-4485-989b-171ecce94488" /> | <img width="1199" height="1264" alt="image" src="https://github.com/user-attachments/assets/0557ea71-b2a9-41ec-a1c2-0ec1ed4a7ec6" /> | |
| `NcActionText` | <video src="https://github.com/user-attachments/assets/2dd34bc5-9f1b-4f3b-af76-dc53f8120c7a"></video> |  <video src="https://github.com/user-attachments/assets/b716fa94-eab2-448c-8278-f9c3e7f18a1d"></video> | |
| `NcEmptyContent` |  <img width="1568" height="543" alt="image" src="https://github.com/user-attachments/assets/a8baceb1-f084-4650-9efd-779e97cd4162" /> | <img width="1568" height="543" alt="image" src="https://github.com/user-attachments/assets/528f44fb-0907-4d9f-96c4-1e08da3fafc4" /> | |
