### PR TITLE
fix(appointments): validate positive durations

### DIFF
--- a/lib/Controller/AppointmentConfigController.php
+++ b/lib/Controller/AppointmentConfigController.php
@@ -120,6 +120,40 @@ class AppointmentConfigController extends Controller {
 	}
 
 	/**
+	 * @throws InvalidArgumentException
+	 */
+	private function validateValues(
+		int $length,
+		int $increment,
+		int $preparationDuration,
+		int $followupDuration,
+		int $timeBeforeNextSlot,
+		?int $dailyMax,
+		?int $start,
+		?int $end,
+		?int $futureLimit,
+	): void {
+		if ($length <= 0) {
+			throw new InvalidArgumentException('Length must be greater than zero');
+		}
+		if ($increment < 5 * 60) {
+			throw new InvalidArgumentException('Increment must be at least 5 minutes');
+		}
+		if ($preparationDuration < 0 || $followupDuration < 0 || $timeBeforeNextSlot < 0) {
+			throw new InvalidArgumentException('Durations must not be negative');
+		}
+		if ($dailyMax !== null && $dailyMax <= 0) {
+			throw new InvalidArgumentException('Daily maximum must be greater than zero');
+		}
+		if ($futureLimit !== null && $futureLimit <= 0) {
+			throw new InvalidArgumentException('Future limit must be greater than zero');
+		}
+		if ($start !== null && $end !== null && $start >= $end) {
+			throw new InvalidArgumentException('Start must be before end');
+		}
+	}
+
+	/**
 	 * @NoAdminRequired
 	 *
 	 * @param string $name
@@ -164,6 +198,7 @@ class AppointmentConfigController extends Controller {
 			return JsonResponse::fail();
 		}
 		try {
+			$this->validateValues($length, $increment, $preparationDuration, $followupDuration, $timeBeforeNextSlot, $dailyMax, $start, $end, $futureLimit);
 			$this->validateAvailability($availability);
 		} catch (InvalidArgumentException $e) {
 			return JsonResponse::fail($e->getMessage(), Http::STATUS_UNPROCESSABLE_ENTITY);
@@ -242,6 +277,7 @@ class AppointmentConfigController extends Controller {
 			return JsonResponse::fail(null, Http::STATUS_NOT_FOUND);
 		}
 		try {
+			$this->validateValues($length, $increment, $preparationDuration, $followupDuration, $timeBeforeNextSlot, $dailyMax, $start, $end, $futureLimit);
 			$this->validateAvailability($availability);
 		} catch (InvalidArgumentException $e) {
 			return JsonResponse::fail($e->getMessage(), Http::STATUS_UNPROCESSABLE_ENTITY);

--- a/tests/php/unit/Controller/AppointmentConfigControllerTest.php
+++ b/tests/php/unit/Controller/AppointmentConfigControllerTest.php
@@ -208,6 +208,37 @@ class AppointmentConfigControllerTest extends TestCase {
 		self::assertEquals(422, $response->getStatus());
 	}
 
+	/**
+	 * @dataProvider invalidConfigValuesProvider
+	 */
+	public function testCreateWithInvalidConfigValues(array $values): void {
+		$this->service->expects(self::never())
+			->method('create');
+
+		$response = $this->controller->create(
+			'Test',
+			'Test',
+			'Test',
+			'PUBLIC',
+			'test',
+			$this->availability,
+			...$values,
+		);
+
+		self::assertEquals(422, $response->getStatus());
+	}
+
+	public static function invalidConfigValuesProvider(): array {
+		return [
+			'negative preparation duration' => [[5 * 60, 5 * 60, -1, 0, 0, null, null, null, null, null]],
+			'negative follow-up duration' => [[5 * 60, 5 * 60, 0, -1, 0, null, null, null, null, null]],
+			'negative buffer' => [[5 * 60, 5 * 60, 0, 0, -1, null, null, null, null, null]],
+			'zero daily maximum' => [[5 * 60, 5 * 60, 0, 0, 0, 0, null, null, null, null]],
+			'zero future limit' => [[5 * 60, 5 * 60, 0, 0, 0, null, null, null, null, 0]],
+			'end before start' => [[5 * 60, 5 * 60, 0, 0, 0, null, null, 2, 1, null]],
+		];
+	}
+
 	public function testCreate(): void {
 		$appointment = new AppointmentConfig();
 		$appointment->setName('Test');
@@ -303,6 +334,27 @@ class AppointmentConfigControllerTest extends TestCase {
 		);
 
 		self::assertEquals(200, $response->getStatus());
+	}
+
+	public function testUpdateWithInvalidIncrement(): void {
+		$this->service->expects(self::never())
+			->method('findByIdAndUser');
+		$this->service->expects(self::never())
+			->method('update');
+
+		$response = $this->controller->update(
+			1,
+			'Test',
+			'Test',
+			'Test',
+			'PUBLIC',
+			'test',
+			$this->availability,
+			5 * 60,
+			0
+		);
+
+		self::assertEquals(422, $response->getStatus());
 	}
 
 	public function testUpdateNotFound(): void {


### PR DESCRIPTION
## Summary

- Reject non-positive appointment `length` and `increment` values before persistence.
- Apply the validation to both create and update endpoints.
- Add regression tests for invalid increments.

Fixes #8857.

## Testing

- `php -l lib/Controller/AppointmentConfigController.php`
- `php -l tests/php/unit/Controller/AppointmentConfigControllerTest.php`
- `git diff --check`
- PHPUnit could not run locally because the `phpunit` executable is not available in the workspace.