### PR TITLE
fix(appointments): handle invalid booking dates

### DIFF
--- a/lib/Controller/BookingController.php
+++ b/lib/Controller/BookingController.php
@@ -69,12 +69,17 @@ class BookingController extends Controller {
 			$this->logger->error('Timezone invalid', ['exception' => $e]);
 			return JsonResponse::fail('Invalid timezone', Http::STATUS_UNPROCESSABLE_ENTITY);
 		}
-		// Convert selected date to requesters selected timezone adjusted start and end of day in epoch
-		$startTimeInTz = (new DateTime($dateSelected, $tz))
-			->getTimestamp();
-		$endTimeInTz = (new DateTime($dateSelected, $tz))
-			->modify('+1 day')
-			->getTimestamp();
+		try {
+			// Convert selected date to requesters selected timezone adjusted start and end of day in epoch
+			$startTimeInTz = (new DateTime($dateSelected, $tz))
+				->getTimestamp();
+			$endTimeInTz = (new DateTime($dateSelected, $tz))
+				->modify('+1 day')
+				->getTimestamp();
+		} catch (\Exception $e) {
+			$this->logger->error('Date invalid', ['exception' => $e]);
+			return JsonResponse::fail('Invalid date', Http::STATUS_UNPROCESSABLE_ENTITY);
+		}
 
 		if ($startTimeInTz > $endTimeInTz) {
 			$this->logger->warning('Invalid time range - end time ' . $endTimeInTz . ' before start time ' . $startTimeInTz);

--- a/tests/php/unit/Controller/BookingControllerTest.php
+++ b/tests/php/unit/Controller/BookingControllerTest.php
@@ -176,6 +176,24 @@ class BookingControllerTest extends TestCase {
 		self::assertSame(['status' => 'fail', 'data' => 'Invalid timezone'], $response->getData());
 	}
 
+	public function testGetBookableSlotsInvalidDate(): void {
+		$this->time->expects(self::never())
+			->method('getTime');
+		$this->apptService->expects(self::never())
+			->method('findByToken');
+		$this->bookingService->expects(self::never())
+			->method('getAvailableSlots');
+		$this->logger->expects(self::once())
+			->method('error')
+			->with('Date invalid');
+
+		$response = $this->controller->getBookableSlots('abc123', 'not-a-date', 'Europe/Berlin');
+
+		self::assertInstanceOf(JsonResponse::class, $response);
+		self::assertSame(Http::STATUS_UNPROCESSABLE_ENTITY, $response->getStatus());
+		self::assertSame(['status' => 'fail', 'data' => 'Invalid date'], $response->getData());
+	}
+
 	public function testGetBookableSlotsTimezoneIdentical(): void {
 		$currentDate = (new DateTime('2024-6-30'))->getTimestamp();
 		$selectedDate = '2024-7-1';


### PR DESCRIPTION
## Summary

- Return a controlled `422 Unprocessable Entity` response for malformed public booking dates.
- Prevent invalid date input from reaching appointment lookup and slot generation.
- Add a regression test for invalid `dateSelected` values.

Fixes #8858.

## Testing

- `php -l lib/Controller/BookingController.php`
- `php -l tests/php/unit/Controller/BookingControllerTest.php`
- `git diff --check`
- PHPUnit could not run locally because the `phpunit` executable is not available in the workspace.