### PR TITLE
fix(appointments): validate availability input

### DIFF
--- a/lib/Controller/AppointmentConfigController.php
+++ b/lib/Controller/AppointmentConfigController.php
@@ -82,16 +82,35 @@ class AppointmentConfigController extends Controller {
 		if ($expectedKeys !== $actualKeys) {
 			throw new InvalidArgumentException('Invalid value for availability');
 		}
+		if (!is_string($availability['timezoneId']) || $availability['timezoneId'] === '') {
+			throw new InvalidArgumentException('Invalid value for availability timezone');
+		}
+		try {
+			new \DateTimeZone($availability['timezoneId']);
+		} catch (\Exception $e) {
+			throw new InvalidArgumentException('Invalid value for availability timezone', 0, $e);
+		}
 
 		$expectedDayKeys = ['FR', 'MO', 'SA', 'SU', 'TH', 'TU', 'WE'];
+		if (!is_array($availability['slots'])) {
+			throw new InvalidArgumentException('Invalid value for availability slots');
+		}
 		$actualDayKeys = array_keys($availability['slots']);
 		sort($actualDayKeys);
 		if ($expectedDayKeys !== $actualDayKeys) {
 			throw new InvalidArgumentException('Invalid value for availability slots');
 		}
+		foreach ($availability['slots'] as $daySlots) {
+			if (!is_array($daySlots)) {
+				throw new InvalidArgumentException('Invalid value for availability slots');
+			}
+		}
 
 		$slots = array_merge(...array_values($availability['slots']));
 		foreach ($slots as $slot) {
+			if (!is_array($slot) || !isset($slot['start'], $slot['end']) || !is_int($slot['start']) || !is_int($slot['end']) || $slot['start'] >= $slot['end']) {
+				throw new InvalidArgumentException('Invalid value for availability slot');
+			}
 			$slotKeys = array_keys($slot);
 			sort($slotKeys);
 			if ($slotKeys !== ['end', 'start']) {

--- a/tests/php/unit/Controller/AppointmentConfigControllerTest.php
+++ b/tests/php/unit/Controller/AppointmentConfigControllerTest.php
@@ -145,6 +145,69 @@ class AppointmentConfigControllerTest extends TestCase {
 		self::assertEquals(422, $response->getStatus());
 	}
 
+	public function testCreateWithInvalidAvailabilityTimezone(): void {
+		$availability = $this->availability;
+		$availability['timezoneId'] = 'Invalid/Timezone';
+
+		$this->service->expects(self::never())
+			->method('create');
+
+		$response = $this->controller->create(
+			'Test',
+			'Test',
+			'Test',
+			'PUBLIC',
+			'test',
+			$availability,
+			5 * 60,
+			5 * 60
+		);
+
+		self::assertEquals(422, $response->getStatus());
+	}
+
+	public function testCreateWithInvalidAvailabilitySlot(): void {
+		$availability = $this->availability;
+		$availability['slots']['MO'][] = ['start' => '10:00', 'end' => '11:00'];
+
+		$this->service->expects(self::never())
+			->method('create');
+
+		$response = $this->controller->create(
+			'Test',
+			'Test',
+			'Test',
+			'PUBLIC',
+			'test',
+			$availability,
+			5 * 60,
+			5 * 60
+		);
+
+		self::assertEquals(422, $response->getStatus());
+	}
+
+	public function testCreateWithInvalidAvailabilityDay(): void {
+		$availability = $this->availability;
+		$availability['slots']['MO'] = 'invalid';
+
+		$this->service->expects(self::never())
+			->method('create');
+
+		$response = $this->controller->create(
+			'Test',
+			'Test',
+			'Test',
+			'PUBLIC',
+			'test',
+			$availability,
+			5 * 60,
+			5 * 60
+		);
+
+		self::assertEquals(422, $response->getStatus());
+	}
+
 	public function testCreate(): void {
 		$appointment = new AppointmentConfig();
 		$appointment->setName('Test');


### PR DESCRIPTION
## Summary

- Validate appointment availability timezone identifiers.
- Reject malformed weekday slot containers and slots with non-integer or reversed timestamps.
- Add regression tests for invalid timezone, day, and slot values.

Fixes #8859.

## Testing

- `php -l lib/Controller/AppointmentConfigController.php`
- `php -l tests/php/unit/Controller/AppointmentConfigControllerTest.php`
- `git diff --check`
- PHPUnit could not run locally because the `phpunit` executable is not available in the workspace.