### PR TITLE
Hide e-mail controls in calendar when e-mail sending is disabled

### DIFF
--- a/lib/Controller/PublicViewController.php
+++ b/lib/Controller/PublicViewController.php
@@ -89,6 +89,7 @@ class PublicViewController extends Controller {
 		$defaultShowTasks = $this->config->getAppValue($this->appName, 'showTasks', 'yes');
 		$defaultTasksSidebar = $this->config->getAppValue($this->appName, 'tasksSidebar', 'yes');
 		$defaultCanSubscribeLink = $this->config->getAppValue('dav', 'allow_calendar_link_subscriptions', 'yes');
+		$defaultSendInvitations = $this->config->getAppValue('dav', 'sendInvitations', 'yes');
 
 		$appVersion = $this->config->getAppValue($this->appName, 'installed_version', '');
 
@@ -110,6 +111,7 @@ class PublicViewController extends Controller {
 		$this->initialStateService->provideInitialState($this->appName, 'hide_event_export', false);
 		$this->initialStateService->provideInitialState($this->appName, 'can_subscribe_link', $defaultCanSubscribeLink);
 		$this->initialStateService->provideInitialState($this->appName, 'show_resources', false);
+		$this->initialStateService->provideInitialState($this->appName, 'send_invitations', $defaultSendInvitations);
 
 		return new PublicTemplateResponse($this->appName, 'main', [
 			'share_url' => $this->getShareURL(),

--- a/lib/Controller/ViewController.php
+++ b/lib/Controller/ViewController.php
@@ -46,7 +46,6 @@ class ViewController extends Controller {
 	 * @return TemplateResponse
 	 */
 	public function index():TemplateResponse {
-
 		$this->calendarInitialStateService->run();
 		return new TemplateResponse($this->appName, 'main');
 	}

--- a/lib/Service/CalendarInitialStateService.php
+++ b/lib/Service/CalendarInitialStateService.php
@@ -74,6 +74,7 @@ class CalendarInitialStateService {
 			$forceEventAlarmType = false;
 		}
 		$canSubscribeLink = $this->config->getAppValue('dav', 'allow_calendar_link_subscriptions', 'yes') === 'yes';
+		$sendInvitations = $this->config->getAppValue('dav', 'sendInvitations', 'yes') === 'yes';
 		$showResources = $this->config->getAppValue($this->appName, 'showResources', 'yes') === 'yes';
 		$publicCalendars = $this->config->getAppValue($this->appName, 'publicCalendars', '');
 
@@ -119,6 +120,7 @@ class CalendarInitialStateService {
 		$this->initialStateService->provideInitialState('tasks_enabled', $tasksEnabled);
 		$this->initialStateService->provideInitialState('hide_event_export', $hideEventExport);
 		$this->initialStateService->provideInitialState('force_event_alarm_type', $forceEventAlarmType);
+		$this->initialStateService->provideInitialState('send_invitations', $sendInvitations);
 		if (!is_null($this->userId)) {
 			$this->initialStateService->provideInitialState('appointmentConfigs', $this->appointmentConfigService->getAllAppointmentConfigurations($this->userId));
 		}

--- a/src/components/Editor/Invitees/InviteesListItem.vue
+++ b/src/components/Editor/Invitees/InviteesListItem.vue
@@ -49,6 +49,7 @@
 			<Actions v-if="!isReadOnly && isViewedByOrganizer">
 				<ActionCheckbox
 					v-if="!members.length"
+					v-show="sendInvitations"
 					:modelValue="attendee.rsvp"
 					@update:modelValue="toggleRSVP">
 					{{ $t('calendar', 'Request reply') }}
@@ -127,6 +128,7 @@ import AvatarParticipationStatus from '@/components/Editor/AvatarParticipationSt
 import AttendeeDisplay from '@/components/Editor/Invitees/AttendeeDisplay.vue'
 import { getAttendeeDetails } from '@/services/attendeeDetails.js'
 import useCalendarObjectInstanceStore from '@/store/calendarObjectInstance.js'
+import useSettingsStore from '@/store/settings.js'
 import { removeMailtoPrefix } from '@/utils/attendee.js'
 
 export default {
@@ -184,6 +186,7 @@ export default {
 	computed: {
 		...mapStores(useCalendarObjectInstanceStore),
 		...mapState(useCalendarObjectInstanceStore, ['calendarObjectInstance']),
+		...mapState(useSettingsStore, ['sendInvitations']),
 		/**
 		 * @return {string}
 		 */

--- a/src/store/settings.js
+++ b/src/store/settings.js
@@ -41,6 +41,7 @@ export default defineStore('settings', {
 			timezone: 'automatic',
 			hideEventExport: false,
 			forceEventAlarmType: false,
+			sendInvitations: true,
 			canSubscribeLink: true,
 			showResources: true,
 			// user-defined Nextcloud settings
@@ -347,8 +348,9 @@ export default defineStore('settings', {
 		 * @param {string} data.attachmentsFolder Default user's attachments folder
 		 * @param {boolean} data.showResources Show or hide the resources tab
 		 * @param {string} data.publicCalendars The list of public calendars configured by the administrator
+		 * @param {boolean} data.sendInvitations Whether or not sending invitation e-mails is enabled
 		 */
-		loadSettingsFromServer({ appVersion, eventLimit, firstRun, showWeekNumbers, showTasks, showWeekends, skipPopover, slotDuration, defaultReminder, defaultReminderPartDay, defaultReminderFullDay, talkEnabled, tasksEnabled, timezone, hideEventExport, forceEventAlarmType, disableAppointments, tasksSidebar, canSubscribeLink, attachmentsFolder, showResources, publicCalendars }) {
+		loadSettingsFromServer({ appVersion, eventLimit, firstRun, showWeekNumbers, showTasks, showWeekends, skipPopover, slotDuration, defaultReminder, defaultReminderPartDay, defaultReminderFullDay, talkEnabled, tasksEnabled, timezone, hideEventExport, forceEventAlarmType, disableAppointments, tasksSidebar, canSubscribeLink, attachmentsFolder, showResources, publicCalendars, sendInvitations }) {
 			logInfo(`
 Initial settings:
 	- AppVersion: ${appVersion}
@@ -373,6 +375,7 @@ Initial settings:
 	- attachmentsFolder: ${attachmentsFolder}
 	- ShowResources: ${showResources}
 	- PublicCalendars: ${publicCalendars}
+	- SendInvitations: ${sendInvitations}
 `)
 
 			this.appVersion = appVersion
@@ -397,6 +400,7 @@ Initial settings:
 			this.attachmentsFolder = attachmentsFolder
 			this.showResources = showResources
 			this.publicCalendars = publicCalendars
+			this.sendInvitations = sendInvitations
 		},
 
 		/**

--- a/src/views/Calendar.vue
+++ b/src/views/Calendar.vue
@@ -347,6 +347,7 @@ export default {
 			showResources: loadState('calendar', 'show_resources', true),
 			publicCalendars: loadState('calendar', 'publicCalendars', []),
 			tasksSidebar: loadState('calendar', 'tasks_sidebar', true),
+			sendInvitations: loadState('calendar', 'send_invitations'),
 		})
 		this.settingsStore.initializeCalendarJsConfig()
 

--- a/tests/javascript/unit/store/settings.test.js
+++ b/tests/javascript/unit/store/settings.test.js
@@ -60,6 +60,7 @@ describe('store/settings test suite', () => {
 			showResources: true,
 			publicCalendars: null,
 			searchQuery: '',
+			sendInvitations: true,
 		})
 	})
 
@@ -91,6 +92,7 @@ describe('store/settings test suite', () => {
 			attachmentsFolder: '/Calendar',
 			showResources: true,
 			publicCalendars: null,
+			sendInvitations: true,
 		}
 
 		settingsStore.$state = state
@@ -119,6 +121,7 @@ describe('store/settings test suite', () => {
 			attachmentsFolder: '/Attachments',
 			showResources: true,
 			publicCalendars: null,
+			sendInvitations: true,
 		}
 
 		settingsStore.loadSettingsFromServer(settings)
@@ -148,6 +151,7 @@ Initial settings:
 	- attachmentsFolder: /Attachments
 	- ShowResources: true
 	- PublicCalendars: null
+	- SendInvitations: true
 `)
 		expect(settingsStore.$state).toEqual({
 			appVersion: '2.1.0',
@@ -176,6 +180,7 @@ Initial settings:
 			showResources: true,
 			publicCalendars: null,
 			searchQuery: '',
+			sendInvitations: true,
 		})
 	})
 

--- a/tests/php/unit/Controller/PublicViewControllerTest.php
+++ b/tests/php/unit/Controller/PublicViewControllerTest.php
@@ -48,7 +48,7 @@ class PublicViewControllerTest extends TestCase {
 	}
 
 	public function testPublicIndexWithBranding():void {
-		$this->config->expects(self::exactly(12))
+		$this->config->expects(self::exactly(13))
 			->method('getAppValue')
 			->willReturnMap([
 				['calendar', 'eventLimit', 'yes', 'no'],
@@ -62,6 +62,7 @@ class PublicViewControllerTest extends TestCase {
 				['calendar', 'showTasks', 'yes', 'yes'],
 				['calendar', 'tasksSidebar', 'yes', 'yes'],
 				['dav', 'allow_calendar_link_subscriptions', 'yes', 'defaultCanSubscribeLink'],
+				['dav', 'sendInvitations', 'yes', 'defaultSendInvitations'],
 				['calendar', 'installed_version', '', '1.0.0']
 			]);
 
@@ -87,7 +88,7 @@ class PublicViewControllerTest extends TestCase {
 			->with('imagePath456')
 			->willReturn('absoluteImagePath456');
 
-		$this->initialStateService->expects(self::exactly(18))
+		$this->initialStateService->expects(self::exactly(19))
 			->method('provideInitialState')
 			->willReturnMap([
 				['calendar', 'app_version', '1.0.0'],
@@ -108,6 +109,7 @@ class PublicViewControllerTest extends TestCase {
 				['calendar', 'hide_event_export', false],
 				['calendar', 'can_subscribe_link', 'defaultCanSubscribeLink'],
 				['calendar', 'show_resources', false],
+				['calendar', 'send_invitations', 'defaultSendInvitations'],
 			]);
 
 		$response = $this->controller->publicIndexWithBranding('');
@@ -132,7 +134,7 @@ class PublicViewControllerTest extends TestCase {
 	}
 
 	public function testPublicIndexForEmbedding():void {
-		$this->config->expects(self::exactly(12))
+		$this->config->expects(self::exactly(13))
 			->method('getAppValue')
 			->willReturnMap([
 				['calendar', 'eventLimit', 'yes', 'yes'],
@@ -146,6 +148,7 @@ class PublicViewControllerTest extends TestCase {
 				['calendar', 'showTasks', 'yes', 'defaultShowTasks'],
 				['calendar', 'tasksSidebar', 'yes', 'defaulttasksSidebar'],
 				['dav', 'allow_calendar_link_subscriptions', 'yes', 'defaultCanSubscribeLink'],
+				['dav', 'sendInvitations', 'yes', 'defaultSendInvitations'],
 				['calendar', 'installed_version', '', '1.0.0']
 			]);
 		$this->request->expects(self::once())
@@ -189,11 +192,12 @@ class PublicViewControllerTest extends TestCase {
 			['calendar', 'hide_event_export', false],
 			['calendar', 'can_subscribe_link', 'defaultCanSubscribeLink'],
 			['calendar', 'show_resources', false],
+			['calendar', 'send_invitations', 'defaultSendInvitations'],
 			['calendar', 'is_embed', true],
 		];
 		$callIndex = 0;
 
-		$this->initialStateService->expects(self::exactly(19))
+		$this->initialStateService->expects(self::exactly(20))
 			->method('provideInitialState')
 			->willReturnCallback(function ($appName, $key, $value) use (&$callIndex, $expectedCalls) {
 				$this->assertEquals($expectedCalls[$callIndex][0], $appName);

--- a/tests/php/unit/Service/CalendarInitialStateServiceTest.php
+++ b/tests/php/unit/Service/CalendarInitialStateServiceTest.php
@@ -104,7 +104,7 @@ class CalendarInitialStateServiceTest extends TestCase {
 			$this->groupManager,
 			$this->userManager,
 		);
-		$this->config->expects(self::exactly(19))
+		$this->config->expects(self::exactly(20))
 			->method('getAppValue')
 			->willReturnMap([
 				['calendar', 'eventLimit', 'yes', 'defaultEventLimit'],
@@ -124,6 +124,7 @@ class CalendarInitialStateServiceTest extends TestCase {
 				['calendar', 'disableAppointments', 'no', 'no'],
 				['calendar', 'forceEventAlarmType', '', 'forceEventAlarmType'],
 				['dav', 'allow_calendar_link_subscriptions', 'yes', 'no'],
+				['dav', 'sendInvitations', 'yes', 'yes'],
 				['calendar', 'showResources', 'yes', 'yes'],
 				['calendar', 'publicCalendars', ''],
 				['spreed', 'start_conversations', '[]', '[]'],
@@ -175,7 +176,7 @@ class CalendarInitialStateServiceTest extends TestCase {
 			->willReturn([$this->createMock(IResourceBackend::class)]);
 		$this->roomManager->expects(self::never())
 			->method('getBackends');
-		$this->initialStateService->expects(self::exactly(29))
+		$this->initialStateService->expects(self::exactly(30))
 			->method('provideInitialState')
 			->willReturnMap([
 				['app_version', '1.0.0'],
@@ -198,6 +199,7 @@ class CalendarInitialStateServiceTest extends TestCase {
 				['tasks_enabled', true],
 				['hide_event_export', true],
 				['force_event_alarm_type', null],
+				['send_invitations', true],
 				['appointmentConfigs', [new AppointmentConfig()]],
 				['disable_appointments', false],
 				['can_subscribe_link', false],
@@ -228,7 +230,7 @@ class CalendarInitialStateServiceTest extends TestCase {
 			$this->groupManager,
 			$this->userManager,
 		);
-		$this->config->expects(self::exactly(17))
+		$this->config->expects(self::exactly(18))
 			->method('getAppValue')
 			->willReturnMap([
 				['calendar', 'eventLimit', 'yes', 'defaultEventLimit'],
@@ -248,6 +250,7 @@ class CalendarInitialStateServiceTest extends TestCase {
 				['calendar', 'disableAppointments', 'no', 'no'],
 				['calendar', 'forceEventAlarmType', '', 'forceEventAlarmType'],
 				['dav', 'allow_calendar_link_subscriptions', 'yes', 'no'],
+				['dav', 'sendInvitations', 'yes', 'yes'],
 				['calendar', 'showResources', 'yes', 'yes'],
 				['calendar', 'publicCalendars', ''],
 			]);
@@ -293,7 +296,7 @@ class CalendarInitialStateServiceTest extends TestCase {
 		$this->roomManager->expects(self::once())
 			->method('getBackends')
 			->willReturn([]);
-		$this->initialStateService->expects(self::exactly(28))
+		$this->initialStateService->expects(self::exactly(29))
 			->method('provideInitialState')
 			->willReturnMap([
 				['app_version', '1.0.0'],
@@ -316,6 +319,7 @@ class CalendarInitialStateServiceTest extends TestCase {
 				['tasks_enabled', true],
 				['hide_event_export', true],
 				['force_event_alarm_type', null],
+				['send_invitations', true],
 				['disable_appointments', false],
 				['can_subscribe_link', false],
 				['show_resources', true],
@@ -351,7 +355,7 @@ class CalendarInitialStateServiceTest extends TestCase {
 			$this->groupManager,
 			$this->userManager,
 		);
-		$this->config->expects(self::exactly(19))
+		$this->config->expects(self::exactly(20))
 			->method('getAppValue')
 			->willReturnMap([
 				['calendar', 'eventLimit', 'yes', 'defaultEventLimit'],
@@ -371,6 +375,7 @@ class CalendarInitialStateServiceTest extends TestCase {
 				['calendar', 'disableAppointments', 'no', 'no'],
 				['calendar', 'forceEventAlarmType', '', 'forceEventAlarmType'],
 				['dav', 'allow_calendar_link_subscriptions', 'yes', 'no'],
+				['dav', 'sendInvitations', 'yes', 'yes'],
 				['calendar', 'showResources', 'yes', 'yes'],
 				['calendar', 'publicCalendars', ''],
 				['spreed', 'start_conversations', '[]', '[]'],
@@ -423,7 +428,7 @@ class CalendarInitialStateServiceTest extends TestCase {
 		$this->roomManager->expects(self::once())
 			->method('getBackends')
 			->willReturn([$this->createMock(IRoomBackend::class)]);
-		$this->initialStateService->expects(self::exactly(29))
+		$this->initialStateService->expects(self::exactly(30))
 			->method('provideInitialState')
 			->willReturnMap([
 				['app_version', '1.0.0'],
@@ -446,6 +451,7 @@ class CalendarInitialStateServiceTest extends TestCase {
 				['tasks_enabled', false],
 				['hide_event_export', true],
 				['force_event_alarm_type', null],
+				['send_invitations', true],
 				['appointmentConfigs', [new AppointmentConfig()]],
 				['disable_appointments', false],
 				['can_subscribe_link', false],


### PR DESCRIPTION
This mod hides `Send email` checkbox from attendee context menu if `dav.sendInvitations` is disabled. It also replaces misleading status message about invitations already sent when adding attendee to event"