### PR TITLE
fix(editor): prevent close button overlap

### DIFF
--- a/src/components/Editor/CalendarPickerHeader.vue
+++ b/src/components/Editor/CalendarPickerHeader.vue
@@ -82,6 +82,9 @@
 			:user="ownerUserId"
 			:displayName="ownerDisplayName"
 			:size="24" />
+		<div v-if="$slots.actions" class="calendar-picker-header__actions">
+			<slot name="actions" />
+		</div>
 	</div>
 </template>
 
@@ -343,6 +346,16 @@ export default {
 		flex-shrink: 0;
 		align-self: center;
 		margin-inline-start: var(--default-grid-baseline);
+	}
+
+	&__actions {
+		flex-shrink: 0;
+		align-self: center;
+		margin-inline-start: auto;
+
+		:deep(button) {
+			margin-inline-start: 0;
+		}
 	}
 
 	&__icon {

--- a/src/components/Editor/CalendarPickerHeader.vue
+++ b/src/components/Editor/CalendarPickerHeader.vue
@@ -82,9 +82,6 @@
 			:user="ownerUserId"
 			:displayName="ownerDisplayName"
 			:size="24" />
-		<div v-if="$slots.actions" class="calendar-picker-header__actions">
-			<slot name="actions" />
-		</div>
 	</div>
 </template>
 
@@ -346,16 +343,6 @@ export default {
 		flex-shrink: 0;
 		align-self: center;
 		margin-inline-start: var(--default-grid-baseline);
-	}
-
-	&__actions {
-		flex-shrink: 0;
-		align-self: center;
-		margin-inline-start: auto;
-
-		:deep(button) {
-			margin-inline-start: 0;
-		}
 	}
 
 	&__icon {

--- a/src/views/EditSimple.vue
+++ b/src/views/EditSimple.vue
@@ -108,14 +108,6 @@
 								{{ $t('calendar', 'Delete this and all future') }}
 							</ActionButton>
 						</Actions>
-						<Actions>
-							<ActionButton @click="cancel(false)">
-								<template #icon>
-									<Close :size="20" decorative />
-								</template>
-								{{ $t('calendar', 'Close') }}
-							</ActionButton>
-						</Actions>
 					</div>
 
 					<!-- Header -->
@@ -125,7 +117,20 @@
 							:calendars="calendars"
 							:isReadOnly="isReadOnlyOrViewing || !canModifyCalendar"
 							:isViewedByAttendee="isViewedByOrganizer === false"
-							@update:value="changeCalendar" />
+							@update:value="changeCalendar">
+							<template #actions>
+								<div class="event-popover__header-actions">
+									<Actions>
+										<ActionButton @click="cancel(false)">
+											<template #icon>
+												<Close :size="20" decorative />
+											</template>
+											{{ $t('calendar', 'Close') }}
+										</ActionButton>
+									</Actions>
+								</div>
+							</template>
+						</CalendarPickerHeader>
 
 						<PropertyTitle
 							:value="titleOrPlaceholder"
@@ -915,6 +920,19 @@ export default {
 		:deep(.calendar-picker-header) {
 			margin-inline-start: 0;
 			margin-bottom: calc(var(--default-grid-baseline) * 2);
+		}
+
+		.event-popover__header-actions {
+			display: flex;
+			flex-shrink: 0;
+			gap: var(--default-grid-baseline);
+			align-items: center;
+			opacity: .7;
+
+			:deep(.action-item.action-item--single) {
+				width: calc(var(--default-grid-baseline) * 11);
+				height: calc(var(--default-grid-baseline) * 11);
+			}
 		}
 
 		.event-popover__cancelled {

--- a/src/views/EditSimple.vue
+++ b/src/views/EditSimple.vue
@@ -108,6 +108,14 @@
 								{{ $t('calendar', 'Delete this and all future') }}
 							</ActionButton>
 						</Actions>
+						<Actions>
+							<ActionButton @click="cancel(false)">
+								<template #icon>
+									<Close :size="20" decorative />
+								</template>
+								{{ $t('calendar', 'Close') }}
+							</ActionButton>
+						</Actions>
 					</div>
 
 					<!-- Header -->
@@ -117,20 +125,7 @@
 							:calendars="calendars"
 							:isReadOnly="isReadOnlyOrViewing || !canModifyCalendar"
 							:isViewedByAttendee="isViewedByOrganizer === false"
-							@update:value="changeCalendar">
-							<template #actions>
-								<div class="event-popover__header-actions">
-									<Actions>
-										<ActionButton @click="cancel(false)">
-											<template #icon>
-												<Close :size="20" decorative />
-											</template>
-											{{ $t('calendar', 'Close') }}
-										</ActionButton>
-									</Actions>
-								</div>
-							</template>
-						</CalendarPickerHeader>
+							@update:value="changeCalendar" />
 
 						<PropertyTitle
 							:value="titleOrPlaceholder"
@@ -920,18 +915,10 @@ export default {
 		:deep(.calendar-picker-header) {
 			margin-inline-start: 0;
 			margin-bottom: calc(var(--default-grid-baseline) * 2);
-		}
 
-		.event-popover__header-actions {
-			display: flex;
-			flex-shrink: 0;
-			gap: var(--default-grid-baseline);
-			align-items: center;
-			opacity: .7;
-
-			:deep(.action-item.action-item--single) {
-				width: calc(var(--default-grid-baseline) * 11);
-				height: calc(var(--default-grid-baseline) * 11);
+			&::after {
+				content: '';
+				flex: 0 0 calc(var(--default-grid-baseline) * 11);
 			}
 		}
 


### PR DESCRIPTION
## Summary

- add a trailing actions slot to the calendar picker header
- move the simple editor close action into the header flex layout
- keep long calendar names from overlapping the close control

Fixes #8799

Before:
<img width="674" height="237" alt="image" src="https://github.com/user-attachments/assets/32e6f0f9-faa1-4393-aa5e-e0f92146a660" />

After:
<img width="575" height="417" alt="image" src="https://github.com/user-attachments/assets/22a917ac-d4fc-413b-91fe-9b40937b400b" />
