### PR TITLE
refactor: replace JavaScript navigation with links

### DIFF
--- a/src/components/AppNavigation/Proposal/ProposalList.vue
+++ b/src/components/AppNavigation/Proposal/ProposalList.vue
@@ -20,8 +20,8 @@
 
 		<template v-if="!userHasEmailAddress">
 			<NcAppNavigationItem
-				:name="t('calendar', 'A configured email address is required to use meeting proposals')"
-				@click="window.open(generateUrl('settings/user'), '_blank').focus()">
+				:href="userSettingsUrl"
+				:name="t('calendar', 'A configured email address is required to use meeting proposals')">
 				<template #icon>
 					<WarningIcon :size="20" class="proposal-list__warning-icon" />
 				</template>
@@ -97,7 +97,7 @@ import type { Proposal } from '@/models/proposals/proposals'
 
 import { showError, showSuccess } from '@nextcloud/dialogs'
 import { t } from '@nextcloud/l10n'
-import { generateUrl } from '@nextcloud/router'
+import { generateUrl, getBaseUrl } from '@nextcloud/router'
 import { computed, onMounted, ref, watch } from 'vue'
 // icons
 import WarningIcon from 'vue-material-design-icons/AlertCircleOutline'
@@ -127,6 +127,7 @@ const showDeleteDialog = ref(false)
 const pendingDeleteProposal = ref<Proposal | null>(null)
 
 const userHasEmailAddress = computed(() => (principalStore?.getCurrentUserPrincipal?.emailAddress?.length ?? 0) > 0)
+const userSettingsUrl = generateUrl('settings/user', {}, { baseURL: getBaseUrl() })
 
 const deleteDialogMessage = computed(() => {
 	const title = pendingDeleteProposal.value?.title ?? t('calendar', 'No title')

--- a/src/components/AppointmentConfigModal/NoEmailAddressWarning.vue
+++ b/src/components/AppointmentConfigModal/NoEmailAddressWarning.vue
@@ -5,22 +5,18 @@
 
 <script setup lang="ts">
 import { t } from '@nextcloud/l10n'
-import { generateUrl } from '@nextcloud/router'
+import { generateUrl, getBaseUrl } from '@nextcloud/router'
 import { NcAppNavigationItem } from '@nextcloud/vue'
 import AlertCircleIcon from 'vue-material-design-icons/AlertCircle.vue'
 
 const title = t('calendar', 'To configure appointments, add your email address in personal settings.')
-
-function openUserSettings(): void {
-	const url = generateUrl('settings/user')
-	window.open(url, '_blank')?.focus()
-}
+const userSettingsUrl = generateUrl('settings/user', {}, { baseURL: getBaseUrl() })
 </script>
 
 <template>
 	<NcAppNavigationItem
-		:name="title"
-		@click="openUserSettings">
+		:href="userSettingsUrl"
+		:name="title">
 		<template #icon>
 			<AlertCircleIcon :size="20" class="no-email-warning__icon" />
 		</template>

--- a/src/components/Editor/Attachments/AttachmentsList.vue
+++ b/src/components/Editor/Attachments/AttachmentsList.vue
@@ -70,11 +70,22 @@
 		<NcDialog
 			v-if="showOpenConfirmation"
 			v-model:open="showOpenConfirmation"
-			:name="t('calendar', 'Confirmation')"
-			:buttons="openConfirmationButtons">
+			:name="t('calendar', 'Confirmation')">
 			<p class="external-link-message">
 				{{ openConfirmationMessage }}
 			</p>
+			<template #actions>
+				<NcButton @click="showOpenConfirmation = false">
+					{{ t('calendar', 'Cancel') }}
+				</NcButton>
+				<NcButton
+					:href="openConfirmationUrl"
+					target="_blank"
+					rel="noopener noreferrer"
+					variant="primary">
+					{{ t('calendar', 'Proceed') }}
+				</NcButton>
+			</template>
 		</NcDialog>
 	</div>
 </template>
@@ -85,6 +96,7 @@ import { generateUrl, getBaseUrl } from '@nextcloud/router'
 import {
 	NcActionButton,
 	NcActions,
+	NcButton,
 	NcDialog,
 	NcListItem,
 } from '@nextcloud/vue'
@@ -110,6 +122,7 @@ export default {
 		NcListItem,
 		NcActions,
 		NcActionButton,
+		NcButton,
 		Upload,
 		Close,
 		Folder,
@@ -130,7 +143,7 @@ export default {
 			uploading: false,
 			showOpenConfirmation: false,
 			openConfirmationMessage: '',
-			openConfirmationButtons: [],
+			openConfirmationUrl: '',
 		}
 	},
 
@@ -276,21 +289,7 @@ export default {
 		 */
 		showConfirmationDialog(message, url) {
 			this.openConfirmationMessage = message
-			this.openConfirmationButtons = [
-				{
-					label: t('calendar', 'Cancel'),
-					callback: () => {
-						this.showOpenConfirmation = false
-					},
-				},
-				{
-					label: t('calendar', 'Proceed'),
-					type: 'primary',
-					callback: () => {
-						window.open(url.href, '_blank', 'noopener noreferrer')
-					},
-				},
-			]
+			this.openConfirmationUrl = url.href
 			this.showOpenConfirmation = true
 		},
 	},

--- a/src/fullcalendar/eventSources/eventSourceFunction.js
+++ b/src/fullcalendar/eventSources/eventSourceFunction.js
@@ -11,6 +11,7 @@ import {
 	getHexForColorName,
 } from '@/utils/color.js'
 import logger from '@/utils/logger.js'
+import { generateTaskUrl } from '@/utils/url.ts'
 /**
  * convert an array of calendar-objects to events
  *
@@ -195,6 +196,10 @@ export function eventSourceFunction(calendarObjects, calendar, start, end, timez
 					description: object.description,
 					attendeeCount,
 				},
+			}
+
+			if (object.name === 'VTODO' && settingsStore.tasksEnabled) {
+				fcEvent.url = generateTaskUrl(calendarObject.dav.url)
 			}
 
 			if (object.color) {

--- a/src/fullcalendar/interaction/eventClick.js
+++ b/src/fullcalendar/interaction/eventClick.js
@@ -5,7 +5,6 @@
 import { showInfo } from '@nextcloud/dialogs'
 import { emit } from '@nextcloud/event-bus'
 import { translate as t } from '@nextcloud/l10n'
-import { generateUrl } from '@nextcloud/router'
 import { errorCatchAsync } from '@/fullcalendar/utils/errors.js'
 import useSettingsStore from '@/store/settings.js'
 import useWidgetStore from '@/store/widget.js'
@@ -28,7 +27,7 @@ import {
  */
 export default function(router, route, window, isWidget = false, ref = undefined) {
 	const widgetStore = useWidgetStore()
-	return errorCatchAsync(function({ event }) {
+	return errorCatchAsync(function({ event, jsEvent }) {
 		if (isWidget) {
 			widgetStore.setWidgetRef({ widgetRef: ref.fullCalendar.$el })
 		}
@@ -38,7 +37,7 @@ export default function(router, route, window, isWidget = false, ref = undefined
 				break
 
 			case 'VTODO':
-				handleToDoClick(event, route, window, isWidget)
+				handleToDoClick(event, route, jsEvent, isWidget)
 				break
 		}
 	}, 'eventClick')
@@ -94,13 +93,14 @@ function handleEventClick(event, router, route, window, isWidget = false) {
  *
  * @param {EventDef} event FullCalendar event
  * @param {object} route The current Vue route
- * @param {Window} window The window object
+ * @param {MouseEvent} jsEvent The native click event
  * @param {boolean} isWidget Whether the calendar is embedded as a widget
  */
-function handleToDoClick(event, route, window, isWidget = false) {
+function handleToDoClick(event, route, jsEvent, isWidget = false) {
 	const settingsStore = useSettingsStore()
 
 	if (getViewMode(route.name, isWidget) !== ViewMode.USER) {
+		jsEvent?.preventDefault()
 		return
 	}
 
@@ -111,9 +111,8 @@ function handleToDoClick(event, route, window, isWidget = false) {
 	emit('calendar:handle-todo-click', { calendarId, taskId })
 
 	if (!settingsStore.tasksEnabled) {
+		jsEvent?.preventDefault()
 		showInfo(t('calendar', 'Please ask your administrator to enable the Tasks App.'))
 		return
 	}
-	const url = `apps/tasks/calendars/${encodeURIComponent(calendarId)}/tasks/${encodeURIComponent(taskId)}`
-	window.open(generateUrl(url), '_blank')
 }

--- a/src/fullcalendar/rendering/eventDidMount.js
+++ b/src/fullcalendar/rendering/eventDidMount.js
@@ -133,6 +133,13 @@ function buildAriaLabel(event) {
 export default errorCatch(function({ event, el }) {
 	// Set aria-label for screen reader accessibility
 	el.setAttribute('aria-label', buildAriaLabel(event))
+
+	if (event.extendedProps.objectType === 'VTODO' && event.url) {
+		const link = el.matches('a') ? el : el.querySelector('a[href]')
+		link?.setAttribute('target', '_blank')
+		link?.setAttribute('rel', 'noopener noreferrer')
+		el.classList.remove('fc-event-forced-url')
+	}
 	if (el.classList.contains('fc-event-nc-alarms')) {
 		const notificationIcon = document.createElement('span')
 		notificationIcon.classList.add('icon-event-reminder')

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -2,6 +2,21 @@
  * SPDX-FileCopyrightText: 2021 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
+import { generateUrl } from '@nextcloud/router'
+
+/**
+ * Generate the Tasks app URL for a calendar task.
+ *
+ * @param davUrl - The task's DAV URL
+ * @return The task URL
+ */
+export function generateTaskUrl(davUrl: string): string {
+	const davUrlParts = davUrl.split('/')
+	const taskId = davUrlParts.pop()!
+	const calendarId = davUrlParts.pop()!
+
+	return generateUrl(`apps/tasks/calendars/${encodeURIComponent(calendarId)}/tasks/${encodeURIComponent(taskId)}`)
+}
 
 /**
  * Works like urldecode() from php

--- a/tests/javascript/unit/fullcalendar/interaction/eventClick.test.js
+++ b/tests/javascript/unit/fullcalendar/interaction/eventClick.test.js
@@ -3,8 +3,8 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 import { showInfo } from '@nextcloud/dialogs'
+import { emit } from '@nextcloud/event-bus'
 import { translate } from '@nextcloud/l10n'
-import { generateUrl } from '@nextcloud/router'
 import { createPinia, setActivePinia } from 'pinia'
 import eventClick from '@/fullcalendar/interaction/eventClick.js'
 import EditorMixin from '@/mixins/EditorMixin.js'
@@ -16,9 +16,9 @@ import {
 } from '@/utils/router.js'
 
 vi.mock('@/utils/router.js')
-vi.mock('@nextcloud/router')
 vi.mock('@nextcloud/l10n')
 vi.mock('@nextcloud/dialogs')
+vi.mock('@nextcloud/event-bus')
 
 describe('fullcalendar/eventClick test suite', () => {
 	beforeEach(() => {
@@ -27,9 +27,9 @@ describe('fullcalendar/eventClick test suite', () => {
 		// Default to a normal authenticated view so tests that don't care
 		// about public/embedded/widget behaviour don't need to set this up.
 		getViewMode.mockReturnValue(ViewMode.USER)
-		generateUrl.mockClear()
 		translate.mockClear()
 		showInfo.mockClear()
+		emit.mockClear()
 
 		setActivePinia(createPinia())
 	})
@@ -291,7 +291,7 @@ describe('fullcalendar/eventClick test suite', () => {
 		expect(router.push.mock.calls.length).toEqual(0)
 	})
 
-	it('should forward to the task app if enabled', () => {
+	it('should let the task link handle navigation if enabled', () => {
 		const settingsStore = useSettingsStore()
 		settingsStore.tasksEnabled = true
 
@@ -310,11 +310,8 @@ describe('fullcalendar/eventClick test suite', () => {
 				protocol: 'http:',
 				host: 'nextcloud.testing',
 			},
-			open: vi.fn(),
 		}
-
-		generateUrl
-			.mockReturnValueOnce('/generated-url')
+		const jsEvent = { preventDefault: vi.fn() }
 
 		const eventClickFunction = eventClick(router, route, window)
 		eventClickFunction({ event: {
@@ -324,13 +321,13 @@ describe('fullcalendar/eventClick test suite', () => {
 				recurrenceId: 'recurrence456',
 				objectType: 'VTODO',
 			},
-		}})
+		}, jsEvent })
 
-		expect(generateUrl).toHaveBeenCalledTimes(1)
-		expect(generateUrl).toHaveBeenNthCalledWith(1, 'apps/tasks/calendars/reminders/tasks/EAFB112A-4556-404A-B807-B1E040D0F7A0.ics')
-
-		expect(window.open).toHaveBeenCalledTimes(1)
-		expect(window.open).toHaveBeenNthCalledWith(1, '/generated-url', '_blank')
+		expect(jsEvent.preventDefault).not.toHaveBeenCalled()
+		expect(emit).toHaveBeenCalledWith('calendar:handle-todo-click', {
+			calendarId: 'reminders',
+			taskId: 'EAFB112A-4556-404A-B807-B1E040D0F7A0.ics',
+		})
 	})
 
 	it('should do nothing when tasks is disabled and route is public', () => {
@@ -353,7 +350,7 @@ describe('fullcalendar/eventClick test suite', () => {
 				host: 'nextcloud.testing',
 			},
 		}
-		const oldLocation = window.location
+		const jsEvent = { preventDefault: vi.fn() }
 
 		getViewMode
 			.mockReturnValueOnce(ViewMode.PUBLIC)
@@ -366,13 +363,12 @@ describe('fullcalendar/eventClick test suite', () => {
 				recurrenceId: 'recurrence456',
 				objectType: 'VTODO',
 			},
-		}})
+		}, jsEvent })
 
 		expect(getViewMode).toHaveBeenCalledTimes(1)
 		expect(getViewMode).toHaveBeenNthCalledWith(1, 'EditFullView', false)
 
-		expect(generateUrl).toHaveBeenCalledTimes(0)
-		expect(window.location).toEqual(oldLocation)
+		expect(jsEvent.preventDefault).toHaveBeenCalledTimes(1)
 	})
 
 	it('should show a hint to enable tasks app, when disabled but not public', () => {
@@ -395,7 +391,7 @@ describe('fullcalendar/eventClick test suite', () => {
 				host: 'nextcloud.testing',
 			},
 		}
-		const oldLocation = window.location
+		const jsEvent = { preventDefault: vi.fn() }
 
 		getViewMode
 			.mockReturnValueOnce(ViewMode.USER)
@@ -410,7 +406,7 @@ describe('fullcalendar/eventClick test suite', () => {
 				recurrenceId: 'recurrence456',
 				objectType: 'VTODO',
 			},
-		}})
+		}, jsEvent })
 
 		expect(translate).toHaveBeenCalledTimes(1)
 		expect(translate).toHaveBeenNthCalledWith(1, 'calendar', 'Please ask your administrator to enable the Tasks App.')
@@ -421,8 +417,7 @@ describe('fullcalendar/eventClick test suite', () => {
 		expect(getViewMode).toHaveBeenCalledTimes(1)
 		expect(getViewMode).toHaveBeenNthCalledWith(1, 'EditFullView', false)
 
-		expect(generateUrl).toHaveBeenCalledTimes(0)
-		expect(window.location).toEqual(oldLocation)
+		expect(jsEvent.preventDefault).toHaveBeenCalledTimes(1)
 	})
 
 	it('should do nothing when there is no require action on route leave', () => {
@@ -584,85 +579,5 @@ describe('fullcalendar/eventClick test suite', () => {
 		const next = vi.fn()
 		EditorMixin.requiresActionOnRouteLeave = true
 		EditorMixin.beforeRouteLeave(toRoute, fromRoute, next)
-	})
-
-	it('should properly encode calendarId containing percent-encoded spaces (shared by user with space)', () => {
-		const settingsStore = useSettingsStore()
-		settingsStore.tasksEnabled = true
-
-		const router = { push: vi.fn() }
-		const route = {
-			name: 'EditFullView',
-			params: {
-				object: 'object123',
-				otherParam: '456',
-				recurrenceId: 'recurrence456',
-			},
-		}
-		const window = {
-			innerWidth: 1920,
-			location: {
-				protocol: 'http:',
-				host: 'nextcloud.testing',
-			},
-			open: vi.fn(),
-		}
-
-		generateUrl.mockReturnValueOnce('/generated-url')
-
-		const eventClickFunction = eventClick(router, route, window)
-		eventClickFunction({ event: {
-			extendedProps: {
-				davUrl: '/remote.php/dav/calendars/admin/calendar_shared_by_User%20NAME/EAFB112A-4556-404A-B807-B1E040D0F7A0.ics',
-				object: 'object123',
-				recurrenceId: 'recurrence456',
-				objectType: 'VTODO',
-			},
-		}})
-
-		expect(generateUrl).toHaveBeenCalledTimes(1)
-		expect(generateUrl).toHaveBeenNthCalledWith(1, 'apps/tasks/calendars/calendar_shared_by_User%2520NAME/tasks/EAFB112A-4556-404A-B807-B1E040D0F7A0.ics')
-		expect(window.open).toHaveBeenCalledTimes(1)
-		expect(window.open).toHaveBeenNthCalledWith(1, '/generated-url', '_blank')
-	})
-
-	it('should encode special characters in calendarId and taskId', () => {
-		const settingsStore = useSettingsStore()
-		settingsStore.tasksEnabled = true
-
-		const router = { push: vi.fn() }
-		const route = {
-			name: 'EditFullView',
-			params: {
-				object: 'object123',
-				otherParam: '456',
-				recurrenceId: 'recurrence456',
-			},
-		}
-		const window = {
-			innerWidth: 1920,
-			location: {
-				protocol: 'http:',
-				host: 'nextcloud.testing',
-			},
-			open: vi.fn(),
-		}
-
-		generateUrl.mockReturnValueOnce('/generated-url')
-
-		const eventClickFunction = eventClick(router, route, window)
-		eventClickFunction({ event: {
-			extendedProps: {
-				davUrl: '/remote.php/dav/calendars/admin/calendar#special/task?file&name.ics',
-				object: 'object123',
-				recurrenceId: 'recurrence456',
-				objectType: 'VTODO',
-			},
-		}})
-
-		expect(generateUrl).toHaveBeenCalledTimes(1)
-		expect(generateUrl).toHaveBeenNthCalledWith(1, 'apps/tasks/calendars/calendar%23special/tasks/task%3Ffile%26name.ics')
-		expect(window.open).toHaveBeenCalledTimes(1)
-		expect(window.open).toHaveBeenNthCalledWith(1, '/generated-url', '_blank')
 	})
 })

--- a/tests/javascript/unit/utils/url.test.ts
+++ b/tests/javascript/unit/utils/url.test.ts
@@ -3,9 +3,16 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-import { urldecode } from '@/utils/url'
+import { generateUrl } from '@nextcloud/router'
+import { generateTaskUrl, urldecode } from '@/utils/url'
+
+vi.mock('@nextcloud/router')
 
 describe('utils/url test suite', () => {
+	beforeEach(() => {
+		vi.mocked(generateUrl).mockClear()
+	})
+
 	it('should decode urls encoded by php', () => {
 		const testData = [
 			['my+group+%2B%26%3F%25', 'my group +&?%'],
@@ -17,5 +24,23 @@ describe('utils/url test suite', () => {
 			const decoded = urldecode(encoded)
 			expect(decoded).toEqual(expected)
 		}
+	})
+
+	it.each([
+		[
+			'/remote.php/dav/calendars/admin/calendar_shared_by_User%20NAME/EAFB112A-4556-404A-B807-B1E040D0F7A0.ics',
+			'apps/tasks/calendars/calendar_shared_by_User%2520NAME/tasks/EAFB112A-4556-404A-B807-B1E040D0F7A0.ics',
+		],
+		[
+			'/remote.php/dav/calendars/admin/calendar#special/task?file&name.ics',
+			'apps/tasks/calendars/calendar%23special/tasks/task%3Ffile%26name.ics',
+		],
+	])('should generate a task URL from %s', (davUrl, expectedPath) => {
+		vi.mocked(generateUrl).mockReturnValueOnce('/generated-url')
+
+		const result = generateTaskUrl(davUrl)
+
+		expect(result).toBe('/generated-url')
+		expect(generateUrl).toHaveBeenCalledWith(expectedPath)
 	})
 })


### PR DESCRIPTION
## Summary

- replace JavaScript-driven navigation with links for user settings and attachment confirmation
- expose Tasks destinations through FullCalendar event URLs while preserving task click handling
- open task links in a new tab without redirecting the Calendar tab

Closes: https://github.com/nextcloud/calendar/issues/8811