### PR TITLE
fix: make period header translation reactive

### DIFF
--- a/src/components/AppNavigation/AppNavigationHeader/AppNavigationHeaderDatePicker.vue
+++ b/src/components/AppNavigation/AppNavigationHeader/AppNavigationHeaderDatePicker.vue
@@ -45,9 +45,14 @@ const view = computed<string>(() => {
 	return route.params.view
 })
 
-function dateFormatWrapper(date: Date): string {
-	return formatDateRange(date, view.value, settingsStore.momentLocale, false)
-}
+type NcDateTimePickerFormatProp = InstanceType<typeof NcDateTimePicker>['$props']['format']
+const dateFormatFn = computed<NcDateTimePickerFormatProp>(() => {
+	const momentLocaleValue = settingsStore.momentLocale
+	const viewValue = view.value
+	return function(date: Date) {
+		return formatDateRange(date, viewValue, momentLocaleValue)
+	}
+})
 
 const previousLabel = computed(() => {
 	switch (view.value) {
@@ -172,7 +177,7 @@ useHotKey(['p', 'k'], () => navigateTimeRangeBackward())
 		</NcButton>
 		<NcDateTimePicker
 			class="datepicker-button-section__datepicker"
-			:format="dateFormatWrapper"
+			:format="dateFormatFn"
 			:modelValue="selectedDate"
 			:type="view === 'multiMonthYear' ? 'year' : 'date'"
 			@update:modelValue="navigateToDate" />


### PR DESCRIPTION
When the moment.js locale was loaded after first rendering the header did not rerender displaying the wrong translation.

Fixes #8756

#### Before


Did not automatically updates translation once moment.js locale is available.
It only changed translation after once changing the date.

https://github.com/user-attachments/assets/5c99977c-76e2-49cd-9821-c24b719463fc



#### After 

Automatically updates translation once moment.js locale is available.

https://github.com/user-attachments/assets/d3cba35a-e16a-4d67-928f-b318150e140f

