### PR TITLE
fix: hide invitation reply buttons on cancelled event

### DIFF
--- a/src/mixins/EditorMixin.js
+++ b/src/mixins/EditorMixin.js
@@ -140,6 +140,14 @@ export default {
 			return this.calendarObjectInstance?.isAllDay ?? false
 		},
 		/**
+		 * Returns whether or not the event has been cancelled
+		 *
+		 * @return {boolean}
+		 */
+		isCancelled() {
+			return this.calendarObjectInstance.status === 'CANCELLED'
+		},
+		/**
 		 * Returns whether or not the user is allowed to modify the all-day setting
 		 *
 		 * @return {boolean}

--- a/src/views/EditFull.vue
+++ b/src/views/EditFull.vue
@@ -161,7 +161,7 @@
 					</div>
 
 					<InvitationResponseButtons
-						v-if="isViewedByAttendee"
+						v-if="isViewedByAttendee && !isCancelled"
 						:attendee="userAsAttendee"
 						:calendarId="calendarId"
 						:narrow="true"

--- a/src/views/EditSimple.vue
+++ b/src/views/EditSimple.vue
@@ -216,7 +216,7 @@
 							:calendar="selectedCalendar" />
 
 						<InvitationResponseButtons
-							v-if="isViewedByAttendee && isViewing"
+							v-if="isViewedByAttendee && isViewing && !isCancelled"
 							class="event-popover__response-buttons"
 							:attendee="userAsAttendee"
 							:calendarId="calendarId"
@@ -371,7 +371,6 @@ export default {
 			boundaryElement: null,
 			isVisible: true,
 			isViewing: true,
-			isCancelled: false,
 			closeMask: false,
 			showCancelDialog: false,
 			cancelButtons: [
@@ -460,7 +459,6 @@ export default {
 			this.hasDescription = false
 			this.hasAttendees = false
 			this.hasAlarms = false
-			this.isCancelled = false
 
 			if (this.calendarObjectInstance) {
 				if (typeof this.calendarObjectInstance.location === 'string' && this.calendarObjectInstance.location.trim() !== '') {
@@ -474,9 +472,6 @@ export default {
 				}
 				if (Array.isArray(this.calendarObjectInstance.alarms) && this.calendarObjectInstance.alarms.length > 0) {
 					this.hasAlarms = true
-				}
-				if (this.calendarObjectInstance.status === 'CANCELLED') {
-					this.isCancelled = true
 				}
 
 				// Reposition after content changes


### PR DESCRIPTION
Do not include `InvitationResponseButtons` if the event has been cancelled, and add a "This event was cancelled" notice also in `EditFull` (copied from `EditSimple`).

Note: changes to the close button for mobile were required to properly accomodate the textual notice.

Fixes #4420 
