### PR TITLE
fix: use standard hover style for navigation date picker

### DIFF
--- a/src/components/AppNavigation/AppNavigationHeader/AppNavigationHeaderDatePicker.vue
+++ b/src/components/AppNavigation/AppNavigationHeader/AppNavigationHeaderDatePicker.vue
@@ -201,12 +201,17 @@ useHotKey(['p', 'k'], () => navigateTimeRangeBackward())
 		border-radius: 0 !important;
 		text-align: center;
 		border: 1px solid var(--color-primary-element-light-hover) !important;
-		font-weight: bold;
+		font-weight: var(--font-weight-element);
 		background-color: var(--color-primary-element-light) !important;
 		margin: 0 !important;
 
 		padding: 0 !important;
 		width: calc(var(--default-grid-baseline) * 54) !important;
+
+		&:hover {
+			background-color: var(--color-primary-element-light-hover) !important;
+			box-shadow: none;
+		}
 	}
 
 	:deep(.dp__input_not_clearable) {


### PR DESCRIPTION
Fixes: https://github.com/nextcloud/calendar/issues/8888

Summary:
The navigation date picker is rendered as an input, so it inherits the global input hover box-shadow, which overlaps the adjacent navigation buttons. This removes that shadow on hover and applies the same hover background color used by NcButton.

Before:
<img width="335" height="234" alt="image" src="https://github.com/user-attachments/assets/6dfea912-1d8f-4738-95c1-ee27c98b28b6" />

After:
<img width="355" height="163" alt="image" src="https://github.com/user-attachments/assets/af91bd97-8323-4684-bcef-900f3f786cbf" />

