### PR TITLE
fix(appointments): avoid nested booking form scrolling

### DIFF
--- a/src/components/Appointments/AppointmentDetails.vue
+++ b/src/components/Appointments/AppointmentDetails.vue
@@ -217,6 +217,10 @@ h3 {
 	margin-top: 0;
 }
 
+.booking__name {
+	overflow-wrap: anywhere;
+}
+
 .booking__date, .booking__time {
 	display: flex;
 	align-items: center;
@@ -231,8 +235,6 @@ h3 {
 	flex-wrap: wrap;
 	width: calc(100vw - 120px);
 	max-width: 720px;
-	max-height: 500px;
-	overflow: auto;
 }
 
 .booking-appointment-wrapper {


### PR DESCRIPTION
### Description

Remove the fixed height and internal overflow from the appointment details card so the guest page remains the single vertical scroll container on mobile. Long unbroken appointment names can wrap within the card.

Closes: https://github.com/nextcloud/calendar/issues/8826

Before:
<img width="304" height="321" alt="image" src="https://github.com/user-attachments/assets/a34c97b7-6502-4005-9dc7-ae19ccf729a5" />
<img width="294" height="373" alt="image" src="https://github.com/user-attachments/assets/a2d125ac-2830-417d-a684-c99c6c89a44c" />


After:
<img width="289" height="408" alt="image" src="https://github.com/user-attachments/assets/bbc3ac29-800e-4449-b925-eadf1340c79f" />
