### PR TITLE
fix(proposals): handle invalid timezone fallback

### DIFF
--- a/src/services/timezoneOffsetService.ts
+++ b/src/services/timezoneOffsetService.ts
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
+import logger from '@/utils/logger.js'
+
 /**
  * Get the offset in minutes between a date's timezone and the given timezone
  *

--- a/tests/javascript/unit/services/timezoneOffsetService.test.ts
+++ b/tests/javascript/unit/services/timezoneOffsetService.test.ts
@@ -1,0 +1,26 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { getTimezoneOffset } from '@/services/timezoneOffsetService'
+import logger from '@/utils/logger.js'
+
+vi.mock('@/utils/logger.js', () => ({
+	default: {
+		error: vi.fn(),
+	},
+}))
+
+describe('services/timezoneOffsetService test suite', () => {
+	afterEach(() => {
+		vi.clearAllMocks()
+	})
+
+	it('falls back to UTC for an invalid timezone', () => {
+		const offset = getTimezoneOffset(new Date('2026-01-01T00:00:00Z'), 'Invalid/Timezone')
+
+		expect(offset).toBe(0)
+		expect(logger.error).toHaveBeenCalledOnce()
+	})
+})


### PR DESCRIPTION
## Summary

- import the shared logger in the timezone offset service
- preserve the intended UTC fallback when an invalid timezone is supplied
- add a regression test for invalid timezone identifiers

## Testing

```text
npm run test:unit -- tests/javascript/unit/services/timezoneOffsetService.test.ts
npx eslint src/services/timezoneOffsetService.ts tests/javascript/unit/services/timezoneOffsetService.test.ts
git diff --check
```

All checks pass.

Closes #8914
