### PR TITLE
fix: correct "widht" typos in PropertySelect comments

### DIFF
--- a/src/components/Editor/Properties/PropertySelect.vue
+++ b/src/components/Editor/Properties/PropertySelect.vue
@@ -87,9 +87,9 @@ export default {
 	flex: auto;
 
 	display: flex;
-	// Makes content take full widht.
+	// Makes content take full width.
 	flex-direction: column;
-	// Centers content if it is smaller then the minimal widht.
+	// Centers content if it is smaller than the minimal width.
 	// Relevant if readonly text is shown instead of a select.
 	justify-content: center;
 }


### PR DESCRIPTION
Two typos in the SCSS block of `PropertySelect.vue`: `widht` -> `width`.

Comment-only change, no rendering or behaviour impact.