### PR TITLE
ci: watch PHPUnit unit configuration

### DIFF
--- a/.github/changes-filters.yml
+++ b/.github/changes-filters.yml
@@ -12,6 +12,6 @@ backend:
   - 'composer.json'
   - 'composer.lock'
   - 'phpunit.integration.xml'
-  - 'phpunit.unit'
+  - 'phpunit.unit.xml'
   - '.php-cs-fixer.dist.php'
   - 'psalm.xml'


### PR DESCRIPTION
## Summary

- correct the backend change filter from `phpunit.unit` to `phpunit.unit.xml`
- ensure PHPUnit configuration-only changes trigger the PHP CI workflows

## Validation

- verified `phpunit.unit.xml` exists and `phpunit.unit` does not
- `git diff --check`

Closes #8929
