### PR TITLE
fix(proposals): handle invalid timezone fallback

### DIFF
--- a/src/services/timezoneOffsetService.ts
+++ b/src/services/timezoneOffsetService.ts
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
+import logger from '@/utils/logger.js'
+
 /**
  * Get the offset in minutes between a date's timezone and the given timezone
  *

--- a/tests/javascript/unit/services/timezoneOffsetService.test.ts
+++ b/tests/javascript/unit/services/timezoneOffsetService.test.ts
@@ -1,0 +1,27 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { describe, expect, it, vi } from 'vitest'
+import { getTimezoneOffset } from '@/services/timezoneOffsetService.ts'
+import logger from '@/utils/logger.js'
+
+vi.mock('@/utils/logger.js', () => ({
+	default: {
+		error: vi.fn(),
+	},
+}))
+
+describe('timezoneOffsetService', () => {
+	it('falls back to UTC for an invalid timezone', () => {
+		const date = new Date('2026-07-11T00:00:00Z')
+
+		const offset = getTimezoneOffset(date, 'Invalid/Timezone')
+
+		expect(offset).toBe(0)
+		expect(logger.error).toHaveBeenCalledWith('Failed to compute timezone offset', {
+			error: expect.any(RangeError),
+		})
+	})
+})


### PR DESCRIPTION
## Summary

- import the Calendar logger used by the timezone-offset fallback
- add a regression test for invalid timezone identifiers
- preserve the intended UTC offset fallback instead of throwing a `ReferenceError`

## Tests

- `npm run test:unit -- tests/javascript/unit/services/timezoneOffsetService.test.ts --reporter=dot`
- `TZ=UTC npm run test:unit -- --reporter=dot` (519 tests passed)
- `npx eslint src/services/timezoneOffsetService.ts tests/javascript/unit/services/timezoneOffsetService.test.ts`

Closes #8928
